### PR TITLE
feat(indexer): implement ScVal→JS converter and ContractAuth decoder

### DIFF
--- a/indexer/src/auth.js
+++ b/indexer/src/auth.js
@@ -1,0 +1,106 @@
+import { xdr, StrKey } from "@stellar/stellar-sdk";
+import { scValToJs } from "./scval.js";
+
+/**
+ * Extract and decode the ContractAuth (SorobanAuthorizationEntry) array
+ * from an InvokeHostFunctionOp XDR base64 string or xdr.Operation object.
+ *
+ * @param {string|xdr.Operation} input - base64 XDR envelope/operation or parsed object
+ * @returns {Array<{signer: string|null, nonce: BigInt|null, rootInvocation: object}>}
+ */
+export function extractContractAuth(input) {
+  let op;
+
+  if (typeof input === "string") {
+    // Accept a full TransactionEnvelope or a bare Operation in base64
+    try {
+      const envelope = xdr.TransactionEnvelope.fromXDR(input, "base64");
+      const tx = envelope.value().tx ? envelope.value().tx() : envelope.value();
+      op = tx.operations()[0].body().invokeHostFunctionOp();
+    } catch {
+      op = xdr.Operation.fromXDR(input, "base64").body().invokeHostFunctionOp();
+    }
+  } else {
+    // Already a parsed InvokeHostFunctionOp
+    op = input;
+  }
+
+  const authEntries = op.auth() ?? [];
+
+  return authEntries.map(decodeAuthEntry);
+}
+
+/**
+ * Decode a single SorobanAuthorizationEntry into a plain object.
+ *
+ * @param {xdr.SorobanAuthorizationEntry} entry
+ * @returns {{ signer: string|null, nonce: BigInt|null, rootInvocation: object }}
+ */
+function decodeAuthEntry(entry) {
+  const credentials = entry.credentials();
+  const credType = credentials.switch().name;
+
+  let signer = null;
+  let nonce = null;
+
+  if (credType === "sorobanCredentialsAddress") {
+    const addrCreds = credentials.address();
+    const addr = addrCreds.address();
+    const addrType = addr.switch().name;
+
+    if (addrType === "scAddressTypeAccount") {
+      signer = StrKey.encodeEd25519PublicKey(addr.accountId().ed25519());
+    } else if (addrType === "scAddressTypeContract") {
+      signer = StrKey.encodeContract(addr.contractId());
+    }
+
+    nonce = BigInt(addrCreds.nonce().toString());
+  }
+  // sorobanCredentialsSourceAccount has no signer/nonce fields
+
+  const rootInvocation = decodeInvocation(entry.rootInvocation());
+
+  return { signer, nonce, rootInvocation };
+}
+
+/**
+ * Recursively decode a SorobanAuthorizedInvocation.
+ *
+ * @param {xdr.SorobanAuthorizedInvocation} invocation
+ * @returns {{ function: object, subInvocations: object[] }}
+ */
+function decodeInvocation(invocation) {
+  const fn = invocation.function();
+  const fnType = fn.switch().name;
+
+  let decodedFn;
+
+  if (fnType === "sorobanAuthorizedFunctionTypeContractFn") {
+    const contractFn = fn.contractFn();
+    const contractAddress = contractFn.contractAddress();
+    const addrType = contractAddress.switch().name;
+
+    let contractId;
+    if (addrType === "scAddressTypeContract") {
+      contractId = StrKey.encodeContract(contractAddress.contractId());
+    } else {
+      contractId = contractAddress.toString();
+    }
+
+    decodedFn = {
+      type: "contractFn",
+      contractId,
+      functionName: contractFn.functionName().toString(),
+      args: (contractFn.args() ?? []).map(scValToJs),
+    };
+  } else if (fnType === "sorobanAuthorizedFunctionTypeCreateContractHostFn") {
+    decodedFn = { type: "createContract" };
+  } else {
+    decodedFn = { type: fnType };
+  }
+
+  return {
+    function: decodedFn,
+    subInvocations: (invocation.subInvocations() ?? []).map(decodeInvocation),
+  };
+}

--- a/indexer/src/scval.js
+++ b/indexer/src/scval.js
@@ -1,0 +1,118 @@
+import { xdr, StrKey } from "@stellar/stellar-sdk";
+
+/**
+ * Convert any ScVal XDR object to a native JavaScript value.
+ * Uses BigInt for i64/u64/i128/u128 to prevent precision loss.
+ *
+ * @param {xdr.ScVal} val
+ * @returns {*} native JS primitive, object, or array
+ */
+export function scValToJs(val) {
+  if (!val) return null;
+
+  const type = val.switch().name;
+
+  switch (type) {
+    case "scvBool":
+      return val.b();
+
+    case "scvVoid":
+      return null;
+
+    case "scvError":
+      return { error: val.error().toString() };
+
+    case "scvU32":
+      return val.u32();
+
+    case "scvI32":
+      return val.i32();
+
+    case "scvU64":
+      return BigInt(val.u64().toString());
+
+    case "scvI64":
+      return BigInt(val.i64().toString());
+
+    case "scvTimepoint":
+      return BigInt(val.timepoint().toString());
+
+    case "scvDuration":
+      return BigInt(val.duration().toString());
+
+    case "scvU128": {
+      const u = val.u128();
+      return (BigInt(u.hi().toString()) << 64n) | BigInt(u.lo().toString());
+    }
+
+    case "scvI128": {
+      const i = val.i128();
+      return (BigInt(i.hi().toString()) << 64n) | BigInt(i.lo().toString());
+    }
+
+    case "scvU256": {
+      const u = val.u256();
+      return (
+        (BigInt(u.hiHi().toString()) << 192n) |
+        (BigInt(u.hiLo().toString()) << 128n) |
+        (BigInt(u.loHi().toString()) << 64n) |
+        BigInt(u.loLo().toString())
+      );
+    }
+
+    case "scvI256": {
+      const i = val.i256();
+      return (
+        (BigInt(i.hiHi().toString()) << 192n) |
+        (BigInt(i.hiLo().toString()) << 128n) |
+        (BigInt(i.loHi().toString()) << 64n) |
+        BigInt(i.loLo().toString())
+      );
+    }
+
+    case "scvBytes":
+      return Buffer.from(val.bytes()).toString("hex");
+
+    case "scvString":
+      return val.str().toString();
+
+    case "scvSymbol":
+      return val.sym().toString();
+
+    case "scvVec":
+      return (val.vec() ?? []).map(scValToJs);
+
+    case "scvMap": {
+      const obj = {};
+      for (const entry of val.map() ?? []) {
+        const k = scValToJs(entry.key());
+        obj[String(k)] = scValToJs(entry.val());
+      }
+      return obj;
+    }
+
+    case "scvAddress": {
+      const addr = val.address();
+      const addrType = addr.switch().name;
+      if (addrType === "scAddressTypeAccount") {
+        return StrKey.encodeEd25519PublicKey(addr.accountId().ed25519());
+      }
+      if (addrType === "scAddressTypeContract") {
+        return StrKey.encodeContract(addr.contractId());
+      }
+      return addr.toString();
+    }
+
+    case "scvLedgerKeyContractInstance":
+      return { type: "ledgerKeyContractInstance" };
+
+    case "scvLedgerKeyNonce":
+      return { type: "ledgerKeyNonce", nonce: BigInt(val.nonceKey().nonce().toString()) };
+
+    case "scvContractInstance":
+      return { type: "contractInstance" };
+
+    default:
+      return String(val);
+  }
+}


### PR DESCRIPTION
Closes #3 — Parse ScVal Types to Native JavaScript Types Closes #4 — Extract and Decode ContractAuth Arrays

---

## Issue #3 — ScVal to Native JS Type Converter (indexer/src/scval.js)

### Problem
The existing decoder.js called scValToNative() from @stellar/stellar-sdk directly, which works for simple cases but loses precision on large integers (i64/u64/i128/u128/ i256/u256) because JavaScript's Number type only has 53 bits of safe integer precision. There was also no centralised, well-typed utility that the rest of the codebase could import for consistent ScVal handling.

### Solution
Created indexer/src/scval.js exporting a single function scValToJs(val).

How it works:
- Switches on val.switch().name to handle every ScVal variant explicitly.
- Primitive types (bool, void, u32, i32, string, symbol, bytes) map directly to their JS equivalents.
- Large integer types (u64, i64, timepoint, duration, u128, i128, u256, i256) are returned as native BigInt values, reconstructed from their hi/lo word pairs using bitwise shift operations, preventing any precision loss.
- scvVec recursively maps each element through scValToJs, producing a plain JS array.
- scvMap iterates the key/value pairs and builds a plain JS object, with keys coerced to strings.
- scvAddress decodes both scAddressTypeAccount (Ed25519 public key → G... address via StrKey.encodeEd25519PublicKey) and scAddressTypeContract (contract hash → C... address via StrKey.encodeContract).
- Ledger key and contract instance variants return descriptive sentinel objects rather than throwing.
- Unknown/unhandled variants fall back to String(val) so the function never throws a runtime error, satisfying the acceptance criterion.

---

## Issue #4 — ContractAuth Array Extractor/Decoder (indexer/src/auth.js)

### Problem
When a Soroban transaction is submitted, the InvokeHostFunctionOp XDR contains an auth[] vector of SorobanAuthorizationEntry objects. These entries record exactly which addresses authorised the invocation, the replay-prevention nonce each signer used, and the full tree of contract function calls being authorised. None of this was surfaced by the indexer, making it impossible to display authorisation information in the explorer.

### Solution
Created indexer/src/auth.js exporting extractContractAuth(input).

How it works:
- Input flexibility: accepts either a base64 XDR string (TransactionEnvelope or bare Operation) or an already-parsed InvokeHostFunctionOp object. The function tries to parse as a full envelope first, then falls back to a bare operation, so callers do not need to pre-parse.
- Auth entry decoding (decodeAuthEntry): inspects the credentials discriminant.
  - sorobanCredentialsAddress: extracts the signer address (account → G... string, contract → C... string) and the nonce as a BigInt.
  - sorobanCredentialsSourceAccount: signer and nonce remain null (source account authorisation carries no explicit address/nonce fields).
- Invocation tree decoding (decodeInvocation, recursive): decodes the rootInvocation and all nested subInvocations into plain objects containing:
  - type: 'contractFn' | 'createContract' | raw discriminant name
  - contractId: C... encoded contract address
  - functionName: string name of the authorised function
  - args: array of native JS values produced by scValToJs (reuses issue #3 utility)
  - subInvocations: recursively decoded child invocations
- Return shape per entry: { signer, nonce, rootInvocation } — directly satisfying the acceptance criteria of exposing the signer address, the nonce, and the root function call authorised.