### PR TITLE
feat: track wrapping/unwrapping of native XLM (#21)

### DIFF
--- a/frontend/src/components/EventTable.tsx
+++ b/frontend/src/components/EventTable.tsx
@@ -5,6 +5,26 @@ interface Props {
   events: DecodedEvent[];
 }
 
+function FunctionBadge({ fn }: { fn: string }) {
+  if (fn === "wrap_native") {
+    return (
+      <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+        <span className="badge wrap">Wrap Native Asset</span>
+        <span style={{ fontSize: 11, color: "var(--muted)" }}>Classic XLM → Soroban</span>
+      </span>
+    );
+  }
+  if (fn === "unwrap_native") {
+    return (
+      <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+        <span className="badge unwrap">Unwrap Native Asset</span>
+        <span style={{ fontSize: 11, color: "var(--muted)" }}>Soroban → Classic XLM</span>
+      </span>
+    );
+  }
+  return <span className="badge">{fn}</span>;
+}
+
 export default function EventTable({ events }: Props) {
   if (!events.length) return <p style={{ color: "var(--muted)" }}>No events found.</p>;
 
@@ -27,7 +47,7 @@ export default function EventTable({ events }: Props) {
               </td>
               <td style={td}>{ev.ledger.toLocaleString()}</td>
               <td style={td}>
-                <span className="badge">{ev.function}</span>
+                <FunctionBadge fn={ev.function} />
               </td>
               <td style={{ ...td, maxWidth: 480, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                 {ev.description}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -56,3 +56,5 @@ button:hover { opacity: 0.85; }
 }
 .badge.green { background: #1a3a22; color: var(--green); }
 .badge.yellow { background: #3a2e0a; color: var(--yellow); }
+.badge.wrap { background: #0d2a3a; color: #58c4f5; }
+.badge.unwrap { background: #2a1a0d; color: #e8a44a; }

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -42,7 +42,7 @@ function Row({ label, value, highlight, badge, mono }: {
     <div style={{ display: "flex", gap: 16, alignItems: "flex-start" }}>
       <span style={{ color: "var(--muted)", minWidth: 100 }}>{label}</span>
       {badge
-        ? <span className="badge green">{value}</span>
+        ? <FunctionBadge fn={String(value)} />
         : <span style={{
             fontWeight: highlight ? 600 : 400,
             fontFamily: mono ? "monospace" : undefined,
@@ -52,4 +52,24 @@ function Row({ label, value, highlight, badge, mono }: {
       }
     </div>
   );
+}
+
+function FunctionBadge({ fn }: { fn: string }) {
+  if (fn === "wrap_native") {
+    return (
+      <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+        <span className="badge wrap">Wrap Native Asset</span>
+        <span style={{ fontSize: 12, color: "var(--muted)" }}>Classic XLM → Soroban</span>
+      </span>
+    );
+  }
+  if (fn === "unwrap_native") {
+    return (
+      <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+        <span className="badge unwrap">Unwrap Native Asset</span>
+        <span style={{ fontSize: 12, color: "var(--muted)" }}>Soroban → Classic XLM</span>
+      </span>
+    );
+  }
+  return <span className="badge green">{fn}</span>;
 }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { api } from "../api";
 import EventTable from "../components/EventTable";
 
-const FUNCTIONS = ["", "swap", "transfer", "mint", "burn", "stake", "unstake"];
+const FUNCTIONS = ["", "swap", "transfer", "mint", "burn", "stake", "unstake", "wrap_native", "unwrap_native"];
 
 export default function Home() {
   const [fnFilter, setFnFilter] = useState("");

--- a/indexer/src/decoder.js
+++ b/indexer/src/decoder.js
@@ -1,6 +1,12 @@
 import { xdr, scValToNative, StrKey } from "@stellar/stellar-sdk";
 import { db } from "./db.js";
 
+// Native XLM Stellar Asset Contract IDs (testnet + mainnet)
+const NATIVE_SAC_IDS = new Set([
+  "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC", // testnet
+  "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA", // mainnet
+]);
+
 /**
  * Decode a raw Soroban RPC event into a human-readable record.
  * Falls back to a generic description when no ABI is registered.
@@ -14,6 +20,22 @@ export async function decode(ev) {
   const fnName = typeof topics[0] === "symbol" || typeof topics[0] === "string"
     ? String(topics[0])
     : "unknown";
+
+  // Detect native XLM wrap/unwrap on the SAC contract
+  if (NATIVE_SAC_IDS.has(contractId)) {
+    const wrapUnwrap = nativeXlmDescription(fnName, topics.slice(1), data);
+    if (wrapUnwrap) {
+      return {
+        contract_id: contractId,
+        function:    wrapUnwrap.function,
+        ledger:      ev.ledger,
+        tx_hash:     ev.txHash,
+        description: wrapUnwrap.description,
+        raw_topics:  topics.map(String),
+        raw_data:    JSON.stringify(data),
+      };
+    }
+  }
 
   // Look up registered ABI for richer description
   const meta = await db.getContractMeta(contractId).catch(() => null);
@@ -32,6 +54,31 @@ export async function decode(ev) {
     raw_topics:  topics.map(String),
     raw_data:    JSON.stringify(data),
   };
+}
+
+/**
+ * Returns wrap/unwrap label and description for native XLM SAC events.
+ * mint on native SAC = Classic XLM → Soroban (wrap)
+ * burn on native SAC = Soroban → Classic XLM (unwrap)
+ */
+function nativeXlmDescription(fnName, args, data) {
+  if (fnName === "mint") {
+    const [to, amount] = args;
+    const amt = amount ?? data;
+    return {
+      function: "wrap_native",
+      description: `Wrapped ${fmtXlm(amt)} XLM (Classic → Soroban) to ${fmt(to)}`,
+    };
+  }
+  if (fnName === "burn") {
+    const [from, amount] = args;
+    const amt = amount ?? data;
+    return {
+      function: "unwrap_native",
+      description: `Unwrapped ${fmtXlm(amt)} XLM (Soroban → Classic) from ${fmt(from)}`,
+    };
+  }
+  return null;
 }
 
 function buildDescription(fn, args, data, contractName) {
@@ -65,4 +112,11 @@ function genericDescription(fn, args, data, contractId) {
 function fmt(addr) {
   if (typeof addr !== "string" || addr.length < 10) return String(addr);
   return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+function fmtXlm(amount) {
+  if (amount == null) return "?";
+  // SAC amounts are in stroops (1 XLM = 10_000_000 stroops)
+  const n = Number(amount);
+  return isNaN(n) ? String(amount) : (n / 1e7).toLocaleString(undefined, { maximumFractionDigits: 7 });
 }


### PR DESCRIPTION
- Detect mint/burn events on native XLM SAC contracts (testnet + mainnet)
- Map mint -> wrap_native, burn -> unwrap_native with stroop-formatted amounts
- Add .badge.wrap and .badge.unwrap CSS styles
- Add FunctionBadge component showing 'Classic XLM → Soroban' / 'Soroban → Classic XLM' flow
- Add wrap_native/unwrap_native to function filter dropdown

closes #21 