### PR TITLE
feat(indexer): GitHub ABI sync cron job (#24)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,9 @@ PORT=3001
 
 # Deployed explorer contract ID (set after `make deploy`)
 EXPLORER_CONTRACT_ID=
+
+# GitHub ABI sync
+GITHUB_TOKEN=
+ABI_REPO=Soroban-Smart-Block-Explorer/verified-abis
+ABI_PATH=contracts
+ABI_SYNC_CRON=*/10 * * * *

--- a/indexer/package-lock.json
+++ b/indexer/package-lock.json
@@ -11,6 +11,7 @@
         "@stellar/stellar-sdk": "12.3.0",
         "dotenv": "16.4.5",
         "express": "4.19.2",
+        "node-cron": "^3.0.3",
         "pg": "8.12.0"
       }
     },
@@ -988,6 +989,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -1545,6 +1558,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -9,8 +9,9 @@
   },
   "dependencies": {
     "@stellar/stellar-sdk": "12.3.0",
+    "dotenv": "16.4.5",
     "express": "4.19.2",
-    "pg": "8.12.0",
-    "dotenv": "16.4.5"
+    "node-cron": "^3.0.3",
+    "pg": "8.12.0"
   }
 }

--- a/indexer/src/githubAbiSync.js
+++ b/indexer/src/githubAbiSync.js
@@ -1,0 +1,97 @@
+/**
+ * githubAbiSync.js
+ *
+ * Periodically fetches verified contract ABI definitions from a public GitHub
+ * repository and upserts them into the local contracts table.
+ *
+ * Expected repo layout:
+ *   <ABI_REPO_OWNER>/<ABI_REPO_NAME>/
+ *     contracts/
+ *       <contract-id>.json   ← one file per contract
+ *
+ * Each JSON file must contain:
+ *   { "id": "C...", "name": "...", "description": "...", "functions": [...] }
+ */
+
+import cron from "node-cron";
+import { db } from "./db.js";
+
+const GITHUB_API   = "https://api.github.com";
+const ABI_REPO     = process.env.ABI_REPO     || "Soroban-Smart-Block-Explorer/verified-abis";
+const ABI_PATH     = process.env.ABI_PATH     || "contracts";
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN || "";
+// Default: run every 10 minutes
+const SYNC_CRON    = process.env.ABI_SYNC_CRON || "*/10 * * * *";
+
+function githubHeaders() {
+  const h = { Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" };
+  if (GITHUB_TOKEN) h.Authorization = `Bearer ${GITHUB_TOKEN}`;
+  return h;
+}
+
+async function ghFetch(url) {
+  const res = await fetch(url, { headers: githubHeaders() });
+
+  if (res.status === 403 || res.status === 429) {
+    const reset = res.headers.get("x-ratelimit-reset");
+    const waitMs = reset ? (Number(reset) * 1000 - Date.now()) : 60_000;
+    console.warn(`[abi-sync] GitHub rate-limited. Retrying after ${Math.ceil(waitMs / 1000)}s`);
+    await new Promise(r => setTimeout(r, Math.max(waitMs, 0)));
+    return ghFetch(url);
+  }
+
+  if (!res.ok) throw new Error(`GitHub API ${res.status}: ${url}`);
+  return res.json();
+}
+
+async function syncAbis() {
+  const [owner, repo] = ABI_REPO.split("/");
+  const dirUrl = `${GITHUB_API}/repos/${owner}/${repo}/contents/${ABI_PATH}`;
+
+  let entries;
+  try {
+    entries = await ghFetch(dirUrl);
+  } catch (err) {
+    console.error("[abi-sync] Failed to list ABI directory:", err.message);
+    return;
+  }
+
+  const jsonFiles = entries.filter(e => e.type === "file" && e.name.endsWith(".json"));
+
+  let added = 0, updated = 0, errors = 0;
+
+  for (const file of jsonFiles) {
+    try {
+      const raw = await ghFetch(file.download_url);
+      const meta = typeof raw === "string" ? JSON.parse(raw) : raw;
+
+      if (!meta.id || !meta.name) {
+        console.warn(`[abi-sync] Skipping ${file.name}: missing id or name`);
+        continue;
+      }
+
+      const existing = await db.getContractMeta(meta.id);
+      await db.upsertContractMeta({
+        id:           meta.id,
+        name:         meta.name,
+        description:  meta.description ?? null,
+        functions:    meta.functions   ?? [],
+        registered_by: "github-sync",
+      });
+
+      existing ? updated++ : added++;
+    } catch (err) {
+      console.error(`[abi-sync] Error processing ${file.name}:`, err.message);
+      errors++;
+    }
+  }
+
+  console.log(`[abi-sync] Sync complete — added: ${added}, updated: ${updated}, errors: ${errors}`);
+}
+
+export function startAbiSync() {
+  console.log(`[abi-sync] Scheduling ABI sync (${SYNC_CRON}) from ${ABI_REPO}/${ABI_PATH}`);
+  // Run once immediately on startup, then on schedule
+  syncAbis();
+  cron.schedule(SYNC_CRON, syncAbis);
+}

--- a/indexer/src/index.js
+++ b/indexer/src/index.js
@@ -3,6 +3,7 @@ import { SorobanRpc, xdr, StrKey } from "@stellar/stellar-sdk";
 import { startApi } from "./api.js";
 import { db } from "./db.js";
 import { decode } from "./decoder.js";
+import { startAbiSync } from "./githubAbiSync.js";
 
 const RPC_URL    = process.env.SOROBAN_RPC_URL    || "https://soroban-testnet.stellar.org";
 const START_LEDGER = Number(process.env.START_LEDGER || 0);
@@ -30,6 +31,7 @@ async function indexLedger(ledger) {
 async function run() {
   await db.init();
   startApi();
+  startAbiSync();
 
   let cursor = START_LEDGER || (await rpc.getLatestLedger()).sequence - 100;
 


### PR DESCRIPTION
## Summary

Closes #24

Adds a background worker that periodically pulls verified contract ABI definitions from a public GitHub repository and upserts them into the local `contracts` table.

## Changes

- **`indexer/src/githubAbiSync.js`** — new module:
  - Lists JSON files under `ABI_PATH` in the configured `ABI_REPO`
  - Fetches each file and upserts via `db.upsertContractMeta()`
  - Rate-limit handling: detects HTTP 403/429, reads `x-ratelimit-reset` header, waits before retrying
  - Logs count of added / updated / errored records per cycle
  - Runs once immediately on startup, then on cron schedule
- **`indexer/src/index.js`** — calls `startAbiSync()` inside `run()`
- **`indexer/package.json`** — adds `node-cron@3.0.3`
- **`.env.example`** — documents `GITHUB_TOKEN`, `ABI_REPO`, `ABI_PATH`, `ABI_SYNC_CRON`

## Configuration

| Variable | Default | Description |
|---|---|---|
| `ABI_REPO` | `Soroban-Smart-Block-Explorer/verified-abis` | `owner/repo` of the ABI source |
| `ABI_PATH` | `contracts` | Directory inside the repo |
| `GITHUB_TOKEN` | _(empty)_ | Optional PAT for higher rate limits |
| `ABI_SYNC_CRON` | `*/10 * * * *` | Cron expression for sync frequency |

## Acceptance Criteria

- [x] Background worker completes a sync cycle
- [x] Logs newly discovered and updated contract counts
- [x] No duplicate rows (upsert on primary key)
- [x] Rate-limit management for GitHub API