### PR TITLE
feat(indexer): ABI template rendering engine (#25)

### DIFF
--- a/indexer/src/decoder.js
+++ b/indexer/src/decoder.js
@@ -1,9 +1,10 @@
 import { xdr, scValToNative, StrKey } from "@stellar/stellar-sdk";
 import { db } from "./db.js";
+import { renderTemplate } from "./templateRenderer.js";
 
 /**
  * Decode a raw Soroban RPC event into a human-readable record.
- * Falls back to a generic description when no ABI is registered.
+ * Uses the ABI template when available; falls back to a generic description.
  */
 export async function decode(ev) {
   const contractId = ev.contractId;
@@ -15,13 +16,13 @@ export async function decode(ev) {
     ? String(topics[0])
     : "unknown";
 
-  // Look up registered ABI for richer description
-  const meta = await db.getContractMeta(contractId).catch(() => null);
+  const meta  = await db.getContractMeta(contractId).catch(() => null);
   const fnAbi = meta?.functions?.find(f => f.name === fnName);
 
-  const description = fnAbi
-    ? buildDescription(fnName, topics.slice(1), data, meta.name)
-    : genericDescription(fnName, topics.slice(1), data, contractId);
+  const description = fnAbi?.template
+    ? renderTemplate(fnAbi.template, fnAbi.params ?? [], topics.slice(1),
+        { contractName: meta.name, fnName })
+    : genericDescription(fnName, topics.slice(1), contractId);
 
   return {
     contract_id: contractId,
@@ -34,35 +35,6 @@ export async function decode(ev) {
   };
 }
 
-function buildDescription(fn, args, data, contractName) {
-  switch (fn) {
-    case "swap": {
-      const [from, amtIn, tokenIn, amtOut, tokenOut] = args;
-      return `Address ${fmt(from)} swapped ${amtIn} ${tokenIn} → ${amtOut} ${tokenOut} on ${contractName}`;
-    }
-    case "transfer": {
-      const [from, to, amount, token] = args;
-      return `Address ${fmt(from)} transferred ${amount} ${token ?? ""} to ${fmt(to)} on ${contractName}`;
-    }
-    case "mint": {
-      const [to, amount, token] = args;
-      return `${amount} ${token ?? ""} minted to ${fmt(to)} on ${contractName}`;
-    }
-    case "burn": {
-      const [from, amount, token] = args;
-      return `${amount} ${token ?? ""} burned from ${fmt(from)} on ${contractName}`;
-    }
-    default:
-      return genericDescription(fn, args, data, contractName);
-  }
-}
-
-function genericDescription(fn, args, data, contractId) {
-  const argStr = args.map(String).join(", ");
-  return `${fn}(${argStr}) called on ${contractId}`;
-}
-
-function fmt(addr) {
-  if (typeof addr !== "string" || addr.length < 10) return String(addr);
-  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+function genericDescription(fn, args, contractId) {
+  return `${fn}(${args.map(String).join(", ")}) called on ${contractId}`;
 }

--- a/indexer/src/templateRenderer.js
+++ b/indexer/src/templateRenderer.js
@@ -1,0 +1,68 @@
+/**
+ * templateRenderer.js
+ *
+ * Renders a human-readable string from an ABI function definition and its
+ * decoded arguments.
+ *
+ * ABI function shape (stored in contracts.functions JSONB):
+ *   {
+ *     "name": "swap",
+ *     "template": "Swapped {amt_in} {token_in} → {amt_out} {token_out} on {_contract}",
+ *     "params": [
+ *       { "name": "amt_in",   "type": "u128" },
+ *       { "name": "token_in", "type": "Address" },
+ *       { "name": "amt_out",  "type": "u128" },
+ *       { "name": "token_out","type": "Address" }
+ *     ]
+ *   }
+ *
+ * Special tokens:
+ *   {_contract}  — replaced with the contract name
+ *   {_fn}        — replaced with the function name
+ *
+ * Arguments are matched positionally to params[].name, then substituted into
+ * the template. Unknown tokens are left as-is.
+ */
+
+/**
+ * Shorten a Stellar address for display: "GABCD…WXYZ"
+ */
+function fmtAddr(v) {
+  const s = String(v);
+  return s.length > 10 ? `${s.slice(0, 6)}…${s.slice(-4)}` : s;
+}
+
+/**
+ * Format a single argument value for display.
+ * Stellar addresses (G/C prefix, 56 chars) get shortened.
+ */
+function fmtValue(v) {
+  const s = String(v);
+  if ((s.startsWith("G") || s.startsWith("C")) && s.length === 56) return fmtAddr(s);
+  return s;
+}
+
+/**
+ * Render a template string by substituting named {tokens} with argument values.
+ *
+ * @param {string}   template   - e.g. "Swapped {amt} {token} on {_contract}"
+ * @param {object[]} params     - ABI param definitions: [{ name, type }, ...]
+ * @param {any[]}    args       - decoded argument values, positionally aligned to params
+ * @param {object}   [ctx]      - extra context: { contractName, fnName }
+ * @returns {string}
+ */
+export function renderTemplate(template, params = [], args = [], ctx = {}) {
+  // Build a lookup map: param name → formatted value
+  const vars = {};
+  params.forEach((p, i) => {
+    if (i < args.length) vars[p.name] = fmtValue(args[i]);
+  });
+
+  // Special context tokens
+  if (ctx.contractName) vars._contract = ctx.contractName;
+  if (ctx.fnName)       vars._fn       = ctx.fnName;
+
+  return template.replace(/\{(\w+)\}/g, (match, key) =>
+    key in vars ? vars[key] : match
+  );
+}

--- a/indexer/test/templateRenderer.test.js
+++ b/indexer/test/templateRenderer.test.js
@@ -1,0 +1,80 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { renderTemplate } from "../src/templateRenderer.js";
+
+const SWAP_PARAMS = [
+  { name: "amt_in",    type: "u128" },
+  { name: "token_in",  type: "Address" },
+  { name: "amt_out",   type: "u128" },
+  { name: "token_out", type: "Address" },
+];
+
+describe("renderTemplate", () => {
+  it("substitutes all named params", () => {
+    const result = renderTemplate(
+      "Swapped {amt_in} {token_in} → {amt_out} {token_out} on {_contract}",
+      SWAP_PARAMS,
+      [100, "USDC", 98, "XLM"],
+      { contractName: "StellarSwap" }
+    );
+    assert.equal(result, "Swapped 100 USDC → 98 XLM on StellarSwap");
+  });
+
+  it("shortens Stellar addresses", () => {
+    const addr = "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ234567890ABCDEFG"; // 56 chars
+    const result = renderTemplate(
+      "Transfer from {from}",
+      [{ name: "from", type: "Address" }],
+      [addr]
+    );
+    assert.equal(result, `Transfer from GABC12…DEFG`);
+  });
+
+  it("leaves unknown tokens unchanged", () => {
+    const result = renderTemplate(
+      "Hello {unknown} world",
+      [],
+      []
+    );
+    assert.equal(result, "Hello {unknown} world");
+  });
+
+  it("handles missing trailing args gracefully", () => {
+    const result = renderTemplate(
+      "{a} and {b}",
+      [{ name: "a", type: "u128" }, { name: "b", type: "u128" }],
+      [42]   // b is missing
+    );
+    assert.equal(result, "42 and {b}");
+  });
+
+  it("substitutes {_fn} context token", () => {
+    const result = renderTemplate(
+      "{_fn} called on {_contract}",
+      [],
+      [],
+      { fnName: "mint", contractName: "TokenX" }
+    );
+    assert.equal(result, "mint called on TokenX");
+  });
+
+  it("works with empty params and args", () => {
+    const result = renderTemplate("Static string", [], []);
+    assert.equal(result, "Static string");
+  });
+
+  it("formats transfer template correctly", () => {
+    const result = renderTemplate(
+      "Address {from} transferred {amount} {token} to {to} on {_contract}",
+      [
+        { name: "from",   type: "Address" },
+        { name: "to",     type: "Address" },
+        { name: "amount", type: "u128" },
+        { name: "token",  type: "String" },
+      ],
+      ["GABC…", "GXYZ…", 500, "USDC"],
+      { contractName: "MyDEX" }
+    );
+    assert.equal(result, "Address GABC… transferred 500 USDC to GXYZ… on MyDEX");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #25

Implements a template rendering engine that maps arbitrary ABI function arguments into human-readable sentences using a `{param}` token syntax.

## Changes

### `indexer/src/templateRenderer.js` (new)
- `renderTemplate(template, params, args, ctx)` — substitutes `{paramName}` tokens positionally from the ABI `params` array
- Special tokens: `{_contract}` and `{_fn}` for context values
- Stellar addresses (G/C prefix, 56 chars) are automatically shortened to `GABC12…WXYZ`
- Unknown tokens are left unchanged (safe fallback)

### `indexer/src/decoder.js` (updated)
- Removed hardcoded `buildDescription()` switch/case for swap/transfer/mint/burn
- Now calls `renderTemplate(fnAbi.template, fnAbi.params, args, ctx)` when the ABI entry has a `template` field
- Falls back to `genericDescription()` when no template is present

### `indexer/test/templateRenderer.test.js` (new)
7 tests covering:
- Full param substitution
- Stellar address shortening
- Unknown token passthrough
- Missing trailing args
- `{_fn}` / `{_contract}` context tokens
- Static strings
- Transfer template end-to-end

## ABI Example

```json
{
  "name": "swap",
  "template": "Swapped {amt_in} {token_in} → {amt_out} {token_out} on {_contract}",
  "params": [
    { "name": "amt_in",    "type": "u128" },
    { "name": "token_in",  "type": "Address" },
    { "name": "amt_out",   "type": "u128" },
    { "name": "token_out", "type": "Address" }
  ]
}
```

Produces: `Swapped 100 USDC → 98.7 XLM on StellarSwap`

## Acceptance Criteria

- [x] Engine accepts a template string and maps variables dynamically
- [x] Transforms structural function inputs into grammatical strings
- [x] All 7 tests pass