### PR TITLE
feat(indexer): extract ContractSpec metadata from WASM bytecode (#23)

### DIFF
--- a/indexer/src/wasmContractSpec.js
+++ b/indexer/src/wasmContractSpec.js
@@ -1,0 +1,193 @@
+/**
+ * wasmContractSpec.js
+ *
+ * Parses a Soroban WASM binary and extracts the embedded ContractSpec
+ * from the custom section named "contractspecv0".
+ *
+ * Returns a clean, human-readable list of functions and types.
+ */
+
+import { xdr } from "@stellar/stellar-sdk";
+import jsXdr from "@stellar/js-xdr";
+const { XdrReader } = jsXdr;
+
+const WASM_MAGIC = 0x0061736d; // "\0asm" big-endian u32
+
+// ── LEB128 decoder ───────────────────────────────────────────────────────────
+
+function readLEB128(buf, offset) {
+  let result = 0, shift = 0, byte;
+  do {
+    byte = buf[offset++];
+    result |= (byte & 0x7f) << shift;
+    shift += 7;
+  } while (byte & 0x80);
+  return { value: result, offset };
+}
+
+// ── WASM section scanner ─────────────────────────────────────────────────────
+
+/**
+ * Find and return the raw bytes of the "contractspecv0" custom section.
+ * @param {Buffer|Uint8Array} wasm
+ * @returns {Buffer}  raw section payload (after the name)
+ * @throws if magic is wrong or section not found
+ */
+export function extractContractSpecSection(wasm) {
+  const buf = Buffer.isBuffer(wasm) ? wasm : Buffer.from(wasm);
+
+  if (buf.readUInt32BE(0) !== WASM_MAGIC) {
+    throw new Error("Not a valid WASM binary (bad magic)");
+  }
+
+  let pos = 8; // skip magic (4) + version (4)
+
+  while (pos < buf.length) {
+    const sectionId = buf[pos++];
+    const { value: sectionSize, offset: afterSize } = readLEB128(buf, pos);
+    pos = afterSize;
+    const sectionEnd = pos + sectionSize;
+
+    if (sectionId === 0) {
+      // Custom section: read name
+      const { value: nameLen, offset: afterNameLen } = readLEB128(buf, pos);
+      const name = buf.slice(afterNameLen, afterNameLen + nameLen).toString("utf8");
+      if (name === "contractspecv0") {
+        return buf.slice(afterNameLen + nameLen, sectionEnd);
+      }
+    }
+
+    pos = sectionEnd;
+  }
+
+  throw new Error('WASM does not contain a "contractspecv0" custom section');
+}
+
+// ── XDR entry decoder ────────────────────────────────────────────────────────
+
+/**
+ * Convert a ScSpecTypeDef to a readable type string.
+ */
+function typeStr(typeDef) {
+  const name = typeDef.switch().name;
+  const MAP = {
+    scSpecTypeVal:       "Val",
+    scSpecTypeBool:      "bool",
+    scSpecTypeVoid:      "void",
+    scSpecTypeError:     "Error",
+    scSpecTypeU32:       "u32",
+    scSpecTypeI32:       "i32",
+    scSpecTypeU64:       "u64",
+    scSpecTypeI64:       "i64",
+    scSpecTypeTimepoint: "Timepoint",
+    scSpecTypeDuration:  "Duration",
+    scSpecTypeU128:      "u128",
+    scSpecTypeI128:      "i128",
+    scSpecTypeU256:      "u256",
+    scSpecTypeI256:      "i256",
+    scSpecTypeBytes:     "Bytes",
+    scSpecTypeString:    "String",
+    scSpecTypeSymbol:    "Symbol",
+    scSpecTypeAddress:   "Address",
+  };
+  if (MAP[name]) return MAP[name];
+  if (name === "scSpecTypeUdt")    return typeDef.udt().name().toString();
+  if (name === "scSpecTypeOption") return `Option<${typeStr(typeDef.option().valueType())}>`;
+  if (name === "scSpecTypeVec")    return `Vec<${typeStr(typeDef.vec().elementType())}>`;
+  if (name === "scSpecTypeMap")    return `Map<${typeStr(typeDef.map().keyType())},${typeStr(typeDef.map().valueType())}>`;
+  if (name === "scSpecTypeTuple")  return `(${typeDef.tuple().valueTypes().map(typeStr).join(",")})`;
+  if (name === "scSpecTypeBytesN") return `BytesN<${typeDef.bytesN().n()}>`;
+  if (name === "scSpecTypeResult") return `Result<${typeStr(typeDef.result().okType())},${typeStr(typeDef.result().errorType())}>`;
+  return name;
+}
+
+function decodeEntry(entry) {
+  const kind = entry.switch().name;
+
+  if (kind === "scSpecEntryFunctionV0") {
+    const fn = entry.functionV0();
+    return {
+      kind: "function",
+      name: fn.name().toString(),
+      doc:  fn.doc().toString() || undefined,
+      inputs:  fn.inputs().map(i => ({ name: i.name().toString(), type: typeStr(i.type()) })),
+      outputs: fn.outputs().map(typeStr),
+    };
+  }
+
+  if (kind === "scSpecEntryUdtStructV0") {
+    const s = entry.udtStructV0();
+    return {
+      kind:   "struct",
+      name:   s.name().toString(),
+      doc:    s.doc().toString() || undefined,
+      fields: s.fields().map(f => ({ name: f.name().toString(), type: typeStr(f.type()) })),
+    };
+  }
+
+  if (kind === "scSpecEntryUdtUnionV0") {
+    const u = entry.udtUnionV0();
+    return {
+      kind:  "union",
+      name:  u.name().toString(),
+      doc:   u.doc().toString() || undefined,
+      cases: u.cases().map(c => {
+        const ck = c.switch().name;
+        if (ck === "scSpecUdtUnionCaseVoidV0")  return { name: c.voidCase().name().toString() };
+        if (ck === "scSpecUdtUnionCaseTupleV0") {
+          const t = c.tupleCase();
+          return { name: t.name().toString(), types: t.type().map(typeStr) };
+        }
+        return { name: String(c) };
+      }),
+    };
+  }
+
+  if (kind === "scSpecEntryUdtEnumV0") {
+    const e = entry.udtEnumV0();
+    return {
+      kind:  "enum",
+      name:  e.name().toString(),
+      doc:   e.doc().toString() || undefined,
+      cases: e.cases().map(c => ({ name: c.name().toString(), value: c.value() })),
+    };
+  }
+
+  if (kind === "scSpecEntryUdtErrorEnumV0") {
+    const e = entry.udtErrorEnumV0();
+    return {
+      kind:  "error_enum",
+      name:  e.name().toString(),
+      doc:   e.doc().toString() || undefined,
+      cases: e.cases().map(c => ({ name: c.name().toString(), value: c.value() })),
+    };
+  }
+
+  return { kind };
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Parse a Soroban WASM binary and return its ContractSpec entries.
+ *
+ * The contractspecv0 section is a concatenation of XDR-encoded ScSpecEntry
+ * values. We read them sequentially until the buffer is exhausted.
+ *
+ * @param {Buffer|Uint8Array} wasm
+ * @returns {{ functions: object[], types: object[] }}
+ */
+export function parseContractSpec(wasm) {
+  const data = extractContractSpecSection(wasm);
+  const entries = [];
+  const reader = new XdrReader(data);
+
+  while (!reader.eof) {
+    entries.push(decodeEntry(xdr.ScSpecEntry.read(reader)));
+  }
+
+  return {
+    functions: entries.filter(e => e.kind === "function"),
+    types:     entries.filter(e => e.kind !== "function"),
+  };
+}

--- a/indexer/test/wasmContractSpec.test.js
+++ b/indexer/test/wasmContractSpec.test.js
@@ -1,0 +1,132 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { xdr } from "@stellar/stellar-sdk";
+import { extractContractSpecSection, parseContractSpec } from "../src/wasmContractSpec.js";
+
+// ── WASM builder helpers ──────────────────────────────────────────────────────
+
+function leb128(n) {
+  const bytes = [];
+  do {
+    let b = n & 0x7f;
+    n >>>= 7;
+    if (n) b |= 0x80;
+    bytes.push(b);
+  } while (n);
+  return Buffer.from(bytes);
+}
+
+function makeWasm(sectionName, payload) {
+  const magic   = Buffer.from([0x00, 0x61, 0x73, 0x6d]);
+  const version = Buffer.from([0x01, 0x00, 0x00, 0x00]);
+  const nameBytes = Buffer.from(sectionName);
+  const body = Buffer.concat([leb128(nameBytes.length), nameBytes, payload]);
+  return Buffer.concat([magic, version, Buffer.from([0x00]), leb128(body.length), body]);
+}
+
+// ── XDR spec entry builders ───────────────────────────────────────────────────
+
+function makeFnEntry(name, inputs = [], outputs = []) {
+  return xdr.ScSpecEntry.scSpecEntryFunctionV0(
+    new xdr.ScSpecFunctionV0({ doc: "", name, inputs, outputs })
+  ).toXDR();
+}
+
+function makeInput(name, type) {
+  return new xdr.ScSpecFunctionInputV0({ doc: "", name, type });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("extractContractSpecSection", () => {
+  it("extracts the contractspecv0 payload", () => {
+    const payload = Buffer.from([0xca, 0xfe]);
+    const wasm = makeWasm("contractspecv0", payload);
+    assert.deepEqual(extractContractSpecSection(wasm), payload);
+  });
+
+  it("throws on bad WASM magic", () => {
+    assert.throws(() => extractContractSpecSection(Buffer.from([0x00, 0x00, 0x00, 0x00])),
+      /bad magic/);
+  });
+
+  it("throws when section is absent", () => {
+    const wasm = makeWasm("other_section", Buffer.from([0x01]));
+    assert.throws(() => extractContractSpecSection(wasm), /contractspecv0/);
+  });
+});
+
+describe("parseContractSpec", () => {
+  it("parses a single function with inputs and output", () => {
+    const xdrBuf = makeFnEntry(
+      "swap",
+      [makeInput("amt", xdr.ScSpecTypeDef.scSpecTypeU128()),
+       makeInput("to",  xdr.ScSpecTypeDef.scSpecTypeAddress())],
+      [xdr.ScSpecTypeDef.scSpecTypeBool()]
+    );
+    const wasm = makeWasm("contractspecv0", xdrBuf);
+    const { functions, types } = parseContractSpec(wasm);
+
+    assert.equal(functions.length, 1);
+    assert.equal(types.length, 0);
+
+    const fn = functions[0];
+    assert.equal(fn.name, "swap");
+    assert.deepEqual(fn.inputs, [{ name: "amt", type: "u128" }, { name: "to", type: "Address" }]);
+    assert.deepEqual(fn.outputs, ["bool"]);
+  });
+
+  it("parses multiple entries", () => {
+    const buf = Buffer.concat([
+      makeFnEntry("init",     [], []),
+      makeFnEntry("transfer", [makeInput("amount", xdr.ScSpecTypeDef.scSpecTypeU64())], []),
+    ]);
+    const { functions } = parseContractSpec(makeWasm("contractspecv0", buf));
+    assert.equal(functions.length, 2);
+    assert.equal(functions[0].name, "init");
+    assert.equal(functions[1].name, "transfer");
+    assert.equal(functions[1].inputs[0].type, "u64");
+  });
+
+  it("parses a struct type", () => {
+    const entry = xdr.ScSpecEntry.scSpecEntryUdtStructV0(
+      new xdr.ScSpecUdtStructV0({
+        doc: "",
+        lib: "",
+        name: "SwapParams",
+        fields: [
+          new xdr.ScSpecUdtStructFieldV0({ doc: "", name: "amount", type: xdr.ScSpecTypeDef.scSpecTypeU128() }),
+        ],
+      })
+    ).toXDR();
+    const { types } = parseContractSpec(makeWasm("contractspecv0", entry));
+    assert.equal(types.length, 1);
+    assert.equal(types[0].kind, "struct");
+    assert.equal(types[0].name, "SwapParams");
+    assert.deepEqual(types[0].fields, [{ name: "amount", type: "u128" }]);
+  });
+
+  it("renders Option<u32> type correctly", () => {
+    const xdrBuf = makeFnEntry(
+      "maybe",
+      [makeInput("x", xdr.ScSpecTypeDef.scSpecTypeOption(
+        new xdr.ScSpecTypeOption({ valueType: xdr.ScSpecTypeDef.scSpecTypeU32() })
+      ))],
+      []
+    );
+    const { functions } = parseContractSpec(makeWasm("contractspecv0", xdrBuf));
+    assert.equal(functions[0].inputs[0].type, "Option<u32>");
+  });
+
+  it("renders Vec<Address> type correctly", () => {
+    const xdrBuf = makeFnEntry(
+      "batch",
+      [makeInput("addrs", xdr.ScSpecTypeDef.scSpecTypeVec(
+        new xdr.ScSpecTypeVec({ elementType: xdr.ScSpecTypeDef.scSpecTypeAddress() })
+      ))],
+      []
+    );
+    const { functions } = parseContractSpec(makeWasm("contractspecv0", xdrBuf));
+    assert.equal(functions[0].inputs[0].type, "Vec<Address>");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #23

Builds a utility that parses a Soroban contract's WASM binary and extracts the embedded `ContractSpec` from the `contractspecv0` custom section, returning a clean human-readable list of functions and types.

## Changes

### `indexer/src/wasmContractSpec.js` (new)

**`extractContractSpecSection(wasm)`**
- Validates WASM magic bytes
- Walks WASM sections using LEB128 decoding
- Returns the raw payload bytes of the `contractspecv0` custom section

**`parseContractSpec(wasm)`**
- Uses `XdrReader` to sequentially decode concatenated `ScSpecEntry` XDR values (the section is a flat concatenation, not length-prefixed)
- Returns `{ functions, types }`

**`typeStr(typeDef)`**
- Renders `ScSpecTypeDef` to human-readable strings
- Handles all primitives plus generics: `Option<T>`, `Vec<T>`, `Map<K,V>`, `Result<O,E>`, `BytesN<N>`, `(T1,T2,...)`
- UDT names rendered by their declared name

**Entry kinds decoded:** `function`, `struct`, `union`, `enum`, `error_enum`

### `indexer/test/wasmContractSpec.test.js` (new)
8 tests covering:
- Section extraction from a synthetic WASM binary
- Bad magic / missing section error paths
- Single and multiple entry parsing
- Struct type decoding
- `Option<u32>` and `Vec<Address>` generic type rendering

## Example output

```js
parseContractSpec(wasmBytes)
// {
//   functions: [
//     { kind: 'function', name: 'swap',
//       inputs: [{ name: 'amt', type: 'u128' }, { name: 'to', type: 'Address' }],
//       outputs: ['bool'] }
//   ],
//   types: [
//     { kind: 'struct', name: 'SwapParams',
//       fields: [{ name: 'amount', type: 'u128' }] }
//   ]
// }
```

## Acceptance Criteria

- [x] Receives a raw WASM byte array
- [x] Extracts the `contractspecv0` custom section
- [x] Returns a clean, human-readable list of functions and types
- [x] All 8 tests pass