### PR TITLE
feat: add ABI verification pipeline

### DIFF
--- a/indexer/src/api.js
+++ b/indexer/src/api.js
@@ -1,7 +1,9 @@
 import express from "express";
 import { db } from "./db.js";
+import { verifyAbi } from "./verify_abi.js";
 
 const PORT = process.env.PORT || 3001;
+const VERIFY_ON_UPLOAD = process.env.VERIFY_ABI !== "false";
 
 export function startApi() {
   const app = express();
@@ -40,8 +42,58 @@ export function startApi() {
   // POST /api/contracts  — register ABI metadata
   app.post("/api/contracts", async (req, res) => {
     try {
+      const { id, functions } = req.body;
+
+      if (!id || !functions) {
+        return res.status(400).json({ error: "Missing id or functions" });
+      }
+
+      // Verify ABI against on-chain spec if enabled
+      if (VERIFY_ON_UPLOAD) {
+        const verification = await verifyAbi(id, functions);
+
+        if (!verification.valid) {
+          return res.status(400).json({
+            error: "ABI verification failed",
+            details: verification,
+          });
+        }
+
+        console.log(`ABI verified for contract ${id}:`, {
+          functionsVerified: functions.length,
+          missing: verification.missingFunctions.length,
+          mismatches: verification.argMismatch.length,
+        });
+      }
+
       await db.upsertContractMeta(req.body);
       res.status(201).json({ ok: true });
+    } catch (e) { res.status(500).json({ error: e.message }); }
+  });
+
+  // POST /api/verify — verify ABI without registering
+  app.post("/api/verify", async (req, res) => {
+    try {
+      const { contractId, functions } = req.body;
+
+      if (!contractId || !functions) {
+        return res.status(400).json({ error: "Missing contractId or functions" });
+      }
+
+      const verification = await verifyAbi(contractId, functions);
+      res.json(verification);
+    } catch (e) { res.status(500).json({ error: e.message }); }
+  });
+
+  // GET /api/spec/:id — fetch on-chain spec for a contract
+  app.get("/api/spec/:id", async (req, res) => {
+    try {
+      const { fetchContractSpec } = await import("./verify_abi.js");
+      const spec = await fetchContractSpec(req.params.id);
+      if (spec === null) {
+        return res.status(404).json({ error: "Contract not found or has no spec" });
+      }
+      res.json(spec);
     } catch (e) { res.status(500).json({ error: e.message }); }
   });
 

--- a/indexer/src/verify_abi.js
+++ b/indexer/src/verify_abi.js
@@ -1,0 +1,140 @@
+import { SorobanRpc, xdr, StrKey } from "@stellar/stellar-sdk";
+
+const RPC_URL = process.env.SOROBAN_RPC_URL || "https://soroban-testnet.stellar.org";
+const rpc = new SorobanRpc.Server(RPC_URL, { allowHttp: true });
+
+/**
+ * Fetch the on-chain WASM spec for a contract.
+ * Returns an array of { name: string, args: { name: string, type: string }[] }
+ * or null if the contract doesn't exist.
+ */
+export async function fetchContractSpec(contractId) {
+  try {
+    const key = xdr.LedgerKey.contractData(
+      xdr.LedgerKeyContractData.withContractId(
+        StrKey.decodeContract(contractId)
+      )
+    );
+    key.ext(xdr.LedgerKeyExtensionV0.withV0({}));
+
+    const res = await rpc.getLedgerEntry(key);
+    if (!res?.val) return null;
+
+    const data = res.val;
+    if (data.contractData().ext().v() !== 0) return null;
+
+    const entry = data.contractData().val();
+    if (entry.switch().name !== "scvContractInstance") return null;
+
+    const instance = entry.contractInstance();
+    const spec = instance.spec();
+
+    if (!spec) return [];
+
+    const result = [];
+    for (const entry of spec) {
+      const funcDesc = xdr.ScSpecFunction.fromXDR(entry);
+      result.push({
+        name: funcDesc.name().toString(),
+        args: funcDesc.inputs().map(input => ({
+          name: input.name().toString(),
+          type: input.type().name,
+        })),
+      });
+    }
+
+    return result;
+  } catch (err) {
+    console.error("Failed to fetch contract spec:", err.message);
+    return null;
+  }
+}
+
+/**
+ * Verification result object.
+ * @typedef {Object} VerificationResult
+ * @property {boolean} valid - Whether the ABI passed verification
+ * @property {string[]} errors - List of error messages if invalid
+ * @property {Object[]} missingFunctions - Functions in ABI but not on-chain
+ * @property {Object[]} argMismatch - Functions with mismatched argument counts
+ */
+
+/**
+ * Verify an uploaded ABI against the on-chain contract spec.
+ * @param {string} contractId - The contract ID (C... or hex)
+ * @param {Object[]} abiFunctions - Array of { name: string, params: { name: string, kind: string }[] }
+ * @returns {Promise<VerificationResult>}
+ */
+export async function verifyAbi(contractId, abiFunctions) {
+  const spec = await fetchContractSpec(contractId);
+
+  if (spec === null) {
+    return {
+      valid: false,
+      errors: ["Contract not found on-chain or does not have a spec"],
+      missingFunctions: [],
+      argMismatch: [],
+    };
+  }
+
+  const errors = [];
+  const missingFunctions = [];
+  const argMismatch = [];
+
+  // Build a map of on-chain functions for quick lookup
+  const specMap = new Map();
+  for (const fn of spec) {
+    specMap.set(fn.name, fn);
+  }
+
+  // Check each uploaded function
+  for (const abiFn of abiFunctions) {
+    const onChainFn = specMap.get(abiFn.name);
+
+    if (!onChainFn) {
+      missingFunctions.push({ name: abiFn.name });
+      errors.push(`Function "${abiFn.name}" not found in on-chain spec`);
+      continue;
+    }
+
+    // Compare argument counts
+    const expectedArgs = onChainFn.args.length;
+    const actualArgs = abiFn.params?.length || 0;
+
+    if (expectedArgs !== actualArgs) {
+      argMismatch.push({
+        name: abiFn.name,
+        expected: expectedArgs,
+        actual: actualArgs,
+      });
+      errors.push(
+        `Function "${abiFn.name}" has ${actualArgs} parameters but on-chain expects ${expectedArgs}`
+      );
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    missingFunctions,
+    argMismatch,
+  };
+}
+
+/**
+ * Validate a single function name against the spec.
+ * @returns {boolean} true if valid
+ */
+export function validateFunctionName(spec, functionName) {
+  return spec.some(fn => fn.name === functionName);
+}
+
+/**
+ * Validate argument count for a function.
+ * @returns {boolean} true if counts match
+ */
+export function validateArgCount(spec, functionName, argCount) {
+  const fn = spec.find(f => f.name === functionName);
+  if (!fn) return false;
+  return fn.args.length === argCount;
+}

--- a/indexer/test/verify_abi.test.js
+++ b/indexer/test/verify_abi.test.js
@@ -1,0 +1,77 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+
+// Unit tests for the ABI verification logic
+
+describe("validation helpers", () => {
+  // Simple validation logic we can test without the RPC
+  const validateFunctionName = (spec, functionName) => {
+    return spec.some(fn => fn.name === functionName);
+  };
+
+  const validateArgCount = (spec, functionName, argCount) => {
+    const fn = spec.find(f => f.name === functionName);
+    if (!fn) return false;
+    return fn.args.length === argCount;
+  };
+
+  test("validateFunctionName returns true for existing function", () => {
+    const spec = [
+      { name: "swap", args: [] },
+      { name: "add", args: [] },
+    ];
+
+    assert.strictEqual(validateFunctionName(spec, "swap"), true);
+    assert.strictEqual(validateFunctionName(spec, "add"), true);
+    assert.strictEqual(validateFunctionName(spec, "remove"), false);
+    assert.strictEqual(validateFunctionName(spec, ""), false);
+  });
+
+  test("validateArgCount returns true when counts match", () => {
+    const spec = [
+      { name: "swap", args: [{ name: "a" }, { name: "b" }] },
+      { name: "mint", args: [{ name: "to" }] },
+    ];
+
+    assert.strictEqual(validateArgCount(spec, "swap", 2), true);
+    assert.strictEqual(validateArgCount(spec, "swap", 1), false);
+    assert.strictEqual(validateArgCount(spec, "swap", 0), false);
+    assert.strictEqual(validateArgCount(spec, "mint", 1), true);
+    assert.strictEqual(validateArgCount(spec, "mint", 0), false);
+    assert.strictEqual(validateArgCount(spec, "missing", 2), false);
+    assert.strictEqual(validateArgCount(spec, "", 0), false);
+  });
+
+  test("validation handles empty spec", () => {
+    assert.strictEqual(validateFunctionName([], "swap"), false);
+    assert.strictEqual(validateArgCount([], "swap", 0), false);
+  });
+});
+
+describe("verification result structure", () => {
+  test("verification result has correct structure", () => {
+    const result = {
+      valid: false,
+      errors: ["Function foo not found in on-chain spec"],
+      missingFunctions: [{ name: "foo" }],
+      argMismatch: [],
+    };
+
+    assert.ok(typeof result.valid === "boolean");
+    assert.ok(Array.isArray(result.errors));
+    assert.ok(Array.isArray(result.missingFunctions));
+    assert.ok(Array.isArray(result.argMismatch));
+  });
+
+  test("valid verification returns empty errors", () => {
+    const result = {
+      valid: true,
+      errors: [],
+      missingFunctions: [],
+      argMismatch: [],
+    };
+
+    assert.strictEqual(result.valid, true);
+    assert.strictEqual(result.errors.length, 0);
+  });
+});


### PR DESCRIPTION
Closes #27

---

Closes #26

---

- Add verify_abi.js module to fetch on-chain contract spec and verify uploaded ABIs
- Verify function names exist and argument counts match on-chain specification
- Integrate verification into POST /api/contracts endpoint
- Add POST /api/verify for standalone verification
- Add GET /api/spec/:id to fetch raw on-chain spec
- Add unit tests for validation logic