### PR TITLE
feat: DiagnosticEvent parser for failed Soroban transactions

### DIFF
--- a/indexer/src/diagnosticParser.js
+++ b/indexer/src/diagnosticParser.js
@@ -1,0 +1,145 @@
+import { xdr, StrKey, scValToNative } from "@stellar/stellar-sdk";
+
+/**
+ * Extract a human-readable error label from an ScError XDR value.
+ * Soroban encodes contract panics as scErrorTypeWasm and custom errors
+ * as scErrorTypeContract with a numeric code.
+ *
+ * @param {xdr.ScError} err
+ * @returns {string}
+ */
+function scErrorToLabel(err) {
+  const kind = err.switch().name; // e.g. "sceContract", "sceWasmVm", "sceValue"
+  switch (kind) {
+    case "sceContract": {
+      // Custom contract error — numeric code defined by the contract author
+      // XDR arm is `contractCode` (Uint32), not `code`
+      const code = err.contractCode();
+      return `ContractError(${code})`;
+    }
+    case "sceWasmVm":
+      return "WasmVmError";
+    case "sceValue":
+      return "ValueError";
+    case "sceAuth":
+      return "AuthError";
+    case "sceArith":
+      return "ArithmeticError";
+    default:
+      return kind ?? "UnknownError";
+  }
+}
+
+/**
+ * Attempt to extract a symbolic error name from an ScVal.
+ * Contracts often emit the error symbol as a scvSymbol or scvString topic,
+ * or as an scvError data value.
+ *
+ * @param {xdr.ScVal} val
+ * @returns {string|null}
+ */
+function extractErrorFromScVal(val) {
+  if (!val) return null;
+  const type = val.switch().name;
+  if (type === "scvSymbol") return val.sym().toString();
+  if (type === "scvString") return val.str().toString();
+  if (type === "scvError") return scErrorToLabel(val.error());
+  return null;
+}
+
+/**
+ * Parse DiagnosticEvents from a failed Soroban transaction's result XDR.
+ *
+ * Soroban RPC returns `diagnosticEventsXdr` as an array of base64-encoded
+ * `DiagnosticEvent` XDR strings when `ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=1`
+ * is set on the RPC node, or when fetched via `getTransaction` with
+ * `diagnosticEventsXdr` in the response.
+ *
+ * @param {string[]} diagnosticEventsXdr  Array of base64 DiagnosticEvent XDR strings
+ * @returns {{ contractId: string|null, error: string, topics: string[], data: any }[]}
+ */
+export function parseDiagnosticEvents(diagnosticEventsXdr) {
+  if (!Array.isArray(diagnosticEventsXdr) || diagnosticEventsXdr.length === 0) return [];
+
+  const results = [];
+
+  for (const b64 of diagnosticEventsXdr) {
+    try {
+      const diagEvent = xdr.DiagnosticEvent.fromXDR(b64, "base64");
+      const ev = diagEvent.event();
+      const v0 = ev.body().v0();
+      const topics = v0.topics();
+      const dataVal = v0.data();
+
+      const rawId = ev.contractId();
+      const contractId = rawId ? StrKey.encodeContract(rawId) : null;
+
+      // Generic topic markers that are not error labels
+      const SKIP = new Set(["fn_call", "fn_return", "log", "error", "diagnostic"]);
+
+      // 1. Check data first for scvError (most reliable source)
+      let error = null;
+      if (dataVal?.switch?.().name === "scvError") {
+        error = extractErrorFromScVal(dataVal);
+      }
+
+      // 2. Walk topics for a named error symbol (skip generic markers)
+      if (!error) {
+        for (const t of topics) {
+          const kind = t?.switch?.().name;
+          // Always extract scvError from topics
+          if (kind === "scvError") { error = extractErrorFromScVal(t); break; }
+          // Accept scvSymbol/scvString only if not a generic marker
+          if (kind === "scvSymbol" || kind === "scvString") {
+            const label = extractErrorFromScVal(t);
+            if (label && !SKIP.has(label)) { error = label; break; }
+          }
+        }
+      }
+
+      // 3. Fall back to data string/symbol
+      if (!error) error = extractErrorFromScVal(dataVal);
+
+      // Last resort: check if data is a native error object
+      if (!error) {
+        try {
+          const native = scValToNative(dataVal);
+          if (native && typeof native === "object" && "error" in native) {
+            error = String(native.error);
+          }
+        } catch { /* ignore */ }
+      }
+
+      if (!error) continue; // not an error event — skip
+
+      results.push({
+        contractId,
+        error,
+        topics: topics.map(t => {
+          try { return String(scValToNative(t)); } catch { return "?"; }
+        }),
+        data: (() => {
+          try {
+            const n = scValToNative(dataVal);
+            return typeof n === "bigint" ? n.toString() : n;
+          } catch { return null; }
+        })(),
+      });
+    } catch { /* malformed XDR — skip */ }
+  }
+
+  return results;
+}
+
+/**
+ * Convenience wrapper: given a `getTransaction` RPC response for a failed tx,
+ * return the first error label found in its diagnostic events, or null.
+ *
+ * @param {object} txResult  Response from SorobanRpc.getTransaction()
+ * @returns {string|null}
+ */
+export function extractFailureReason(txResult) {
+  if (txResult?.status !== "FAILED") return null;
+  const events = parseDiagnosticEvents(txResult.diagnosticEventsXdr ?? []);
+  return events[0]?.error ?? null;
+}

--- a/indexer/test/diagnosticParser.test.js
+++ b/indexer/test/diagnosticParser.test.js
@@ -1,0 +1,137 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { xdr } from "@stellar/stellar-sdk";
+import { parseDiagnosticEvents, extractFailureReason } from "../src/diagnosticParser.js";
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function makeDiagXdr(contractIdByte, topics, data) {
+  return new xdr.DiagnosticEvent({
+    inSuccessfulContractCall: false,
+    event: new xdr.ContractEvent({
+      ext: new xdr.ExtensionPoint(0),
+      contractId: Buffer.alloc(32, contractIdByte),
+      type: xdr.ContractEventType.diagnostic(),
+      body: new xdr.ContractEventBody(
+        0,
+        new xdr.ContractEventV0({ topics, data })
+      ),
+    }),
+  }).toXDR("base64");
+}
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+
+// Custom contract error: sceContract with code 7
+const CONTRACT_ERROR_XDR = makeDiagXdr(
+  0xab,
+  [xdr.ScVal.scvSymbol("error")],
+  xdr.ScVal.scvError(xdr.ScError.sceContract(7))
+);
+
+// Wasm VM trap: sceWasmVm
+const WASM_ERROR_XDR = makeDiagXdr(
+  0xcd,
+  [xdr.ScVal.scvSymbol("error")],
+  xdr.ScVal.scvError(xdr.ScError.sceWasmVm(xdr.ScErrorCode.scecInvalidInput()))
+);
+
+// Symbol error in topic (e.g. contract panics with a named symbol)
+const SYMBOL_TOPIC_XDR = makeDiagXdr(
+  0xef,
+  [xdr.ScVal.scvSymbol("fn_call"), xdr.ScVal.scvSymbol("InsufficientBalance")],
+  xdr.ScVal.scvVoid()
+);
+
+// String error in data
+const STRING_DATA_XDR = makeDiagXdr(
+  0x12,
+  [xdr.ScVal.scvSymbol("log")],
+  xdr.ScVal.scvString("overflow detected")
+);
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe("parseDiagnosticEvents", () => {
+  it("returns [] for empty input", () => {
+    assert.deepEqual(parseDiagnosticEvents([]), []);
+    assert.deepEqual(parseDiagnosticEvents(null), []);
+  });
+
+  it("extracts ContractError code from sceContract data", () => {
+    const [result] = parseDiagnosticEvents([CONTRACT_ERROR_XDR]);
+    assert.equal(result.error, "ContractError(7)");
+    assert.ok(result.contractId, "contractId should be present");
+    assert.ok(result.contractId.startsWith("C"), "contractId should be a Stellar contract address");
+  });
+
+  it("extracts WasmVmError from sceWasmVm data", () => {
+    const [result] = parseDiagnosticEvents([WASM_ERROR_XDR]);
+    assert.equal(result.error, "WasmVmError");
+  });
+
+  it("extracts named error symbol from topics (e.g. InsufficientBalance)", () => {
+    const [result] = parseDiagnosticEvents([SYMBOL_TOPIC_XDR]);
+    assert.equal(result.error, "InsufficientBalance");
+  });
+
+  it("extracts string error from data", () => {
+    const [result] = parseDiagnosticEvents([STRING_DATA_XDR]);
+    assert.equal(result.error, "overflow detected");
+  });
+
+  it("parses multiple events and returns all errors", () => {
+    const results = parseDiagnosticEvents([CONTRACT_ERROR_XDR, WASM_ERROR_XDR, SYMBOL_TOPIC_XDR]);
+    assert.equal(results.length, 3);
+    assert.equal(results[0].error, "ContractError(7)");
+    assert.equal(results[1].error, "WasmVmError");
+    assert.equal(results[2].error, "InsufficientBalance");
+  });
+
+  it("skips malformed XDR without throwing", () => {
+    const results = parseDiagnosticEvents(["not-valid-xdr", CONTRACT_ERROR_XDR]);
+    assert.equal(results.length, 1);
+    assert.equal(results[0].error, "ContractError(7)");
+  });
+
+  it("includes topics array in result", () => {
+    const [result] = parseDiagnosticEvents([CONTRACT_ERROR_XDR]);
+    assert.ok(Array.isArray(result.topics));
+    assert.ok(result.topics.includes("error"));
+  });
+});
+
+describe("extractFailureReason", () => {
+  it("returns null for non-FAILED status", () => {
+    assert.equal(extractFailureReason({ status: "SUCCESS" }), null);
+    assert.equal(extractFailureReason(null), null);
+  });
+
+  it("returns null when no diagnostic events present", () => {
+    assert.equal(extractFailureReason({ status: "FAILED", diagnosticEventsXdr: [] }), null);
+  });
+
+  it("returns first error from diagnosticEventsXdr on FAILED tx", () => {
+    const reason = extractFailureReason({
+      status: "FAILED",
+      diagnosticEventsXdr: [SYMBOL_TOPIC_XDR],
+    });
+    assert.equal(reason, "InsufficientBalance");
+  });
+
+  it("returns ContractError code for sceContract failure", () => {
+    const reason = extractFailureReason({
+      status: "FAILED",
+      diagnosticEventsXdr: [CONTRACT_ERROR_XDR],
+    });
+    assert.equal(reason, "ContractError(7)");
+  });
+
+  it("returns WasmVmError for wasm trap", () => {
+    const reason = extractFailureReason({
+      status: "FAILED",
+      diagnosticEventsXdr: [WASM_ERROR_XDR],
+    });
+    assert.equal(reason, "WasmVmError");
+  });
+});


### PR DESCRIPTION
Closes #6

---

## Summary

Adds `indexer/src/diagnosticParser.js` to extract human-readable error labels from `DiagnosticEvent` XDR when a Soroban transaction fails.

## Changes

- **`indexer/src/diagnosticParser.js`** — two exports:
  - `parseDiagnosticEvents(xdrArray)` — parses the `diagnosticEventsXdr` array from a `getTransaction` response; returns `{ contractId, error, topics, data }[]`
  - `extractFailureReason(txResult)` — convenience wrapper returning the first error string from a `FAILED` tx result, or `null`

- **`indexer/test/diagnosticParser.test.js`** — 13 tests covering:
  - `sceContract` custom error codes → `ContractError(7)`
  - `sceWasmVm` traps → `WasmVmError`
  - Named error symbols in topics → `InsufficientBalance`
  - String errors in data
  - Multi-event parsing, malformed XDR resilience, `extractFailureReason` edge cases

## Testing

```
node --test test/diagnosticParser.test.js
# 13 pass, 0 fail
```