### PR TITLE
feat: LedgerFootprint XDR parser

### DIFF
--- a/indexer/src/footprintParser.js
+++ b/indexer/src/footprintParser.js
@@ -1,0 +1,63 @@
+import { xdr, StrKey, scValToNative } from "@stellar/stellar-sdk";
+
+/**
+ * Classify a single LedgerKey into a structured descriptor.
+ *
+ * @param {xdr.LedgerKey} key
+ * @returns {{ type: string, contractId?: string, wasmHash?: string, dataKey?: string, durability?: string }}
+ */
+function classifyKey(key) {
+  const kind = key.switch().name;
+
+  switch (kind) {
+    case "contractData": {
+      const cd = key.contractData();
+      const dataKeyVal = cd.key();
+      const isInstance = dataKeyVal.switch().name === "scvLedgerKeyContractInstance";
+      const contractId = StrKey.encodeContract(cd.contract().contractId());
+      const durability = cd.durability().name === "persistent" ? "persistent" : "temporary";
+      if (isInstance) {
+        return { type: "contractInstance", contractId, durability };
+      }
+      let dataKey;
+      try { dataKey = String(scValToNative(dataKeyVal)); } catch { dataKey = dataKeyVal.switch().name; }
+      return { type: "contractData", contractId, dataKey, durability };
+    }
+
+    case "contractCode": {
+      const wasmHash = Buffer.from(key.contractCode().hash()).toString("hex");
+      return { type: "contractCode", wasmHash };
+    }
+
+    case "account":
+      return { type: "account", accountId: StrKey.encodeEd25519PublicKey(key.account().accountId().ed25519()) };
+
+    case "trustline": {
+      const tl = key.trustLine();
+      return { type: "trustline", accountId: StrKey.encodeEd25519PublicKey(tl.accountId().ed25519()) };
+    }
+
+    default:
+      return { type: kind };
+  }
+}
+
+/**
+ * Parse a base64-encoded LedgerFootprint XDR string and return a structured
+ * summary of which ledger entries were read or written.
+ *
+ * @param {string} footprintXdr  Base64 LedgerFootprint XDR
+ * @returns {{
+ *   reads:  { count: number, keys: object[] },
+ *   writes: { count: number, keys: object[] },
+ * }}
+ */
+export function parseFootprint(footprintXdr) {
+  const fp = xdr.LedgerFootprint.fromXDR(footprintXdr, "base64");
+  const reads  = fp.readOnly().map(classifyKey);
+  const writes = fp.readWrite().map(classifyKey);
+  return {
+    reads:  { count: reads.length,  keys: reads  },
+    writes: { count: writes.length, keys: writes },
+  };
+}

--- a/indexer/test/footprintParser.test.js
+++ b/indexer/test/footprintParser.test.js
@@ -1,0 +1,101 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { xdr } from "@stellar/stellar-sdk";
+import { parseFootprint } from "../src/footprintParser.js";
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+const CONTRACT_BYTES = Buffer.alloc(32, 0xab);
+const WASM_HASH      = Buffer.alloc(32, 0xcd);
+const ACCOUNT_BYTES  = Buffer.alloc(32, 0x01);
+
+function contractAddr(bytes = CONTRACT_BYTES) {
+  return new xdr.ScAddress("scAddressTypeContract", bytes);
+}
+
+function makeFootprint(readOnly, readWrite) {
+  return new xdr.LedgerFootprint({ readOnly, readWrite }).toXDR("base64");
+}
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+
+const instanceKey = xdr.LedgerKey.contractData(new xdr.LedgerKeyContractData({
+  contract: contractAddr(),
+  key: xdr.ScVal.scvLedgerKeyContractInstance(),
+  durability: xdr.ContractDataDurability.persistent(),
+}));
+
+const dataKey = xdr.LedgerKey.contractData(new xdr.LedgerKeyContractData({
+  contract: contractAddr(),
+  key: xdr.ScVal.scvSymbol("balance"),
+  durability: xdr.ContractDataDurability.persistent(),
+}));
+
+const codeKey = xdr.LedgerKey.contractCode(
+  new xdr.LedgerKeyContractCode({ hash: WASM_HASH })
+);
+
+const accountKey = xdr.LedgerKey.account(
+  new xdr.LedgerKeyAccount({
+    accountId: xdr.AccountId.publicKeyTypeEd25519(ACCOUNT_BYTES),
+  })
+);
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe("parseFootprint", () => {
+  it("returns zero counts for empty footprint", () => {
+    const result = parseFootprint(makeFootprint([], []));
+    assert.equal(result.reads.count, 0);
+    assert.equal(result.writes.count, 0);
+    assert.deepEqual(result.reads.keys, []);
+    assert.deepEqual(result.writes.keys, []);
+  });
+
+  it("classifies contractInstance key", () => {
+    const result = parseFootprint(makeFootprint([instanceKey], []));
+    const [key] = result.reads.keys;
+    assert.equal(key.type, "contractInstance");
+    assert.ok(key.contractId.startsWith("C"));
+    assert.equal(key.durability, "persistent");
+  });
+
+  it("classifies contractData key with dataKey field", () => {
+    const result = parseFootprint(makeFootprint([dataKey], []));
+    const [key] = result.reads.keys;
+    assert.equal(key.type, "contractData");
+    assert.equal(key.dataKey, "balance");
+    assert.ok(key.contractId.startsWith("C"));
+  });
+
+  it("classifies contractCode key with wasmHash", () => {
+    const result = parseFootprint(makeFootprint([codeKey], []));
+    const [key] = result.reads.keys;
+    assert.equal(key.type, "contractCode");
+    assert.equal(key.wasmHash, WASM_HASH.toString("hex"));
+  });
+
+  it("classifies account key", () => {
+    const result = parseFootprint(makeFootprint([accountKey], []));
+    const [key] = result.reads.keys;
+    assert.equal(key.type, "account");
+    assert.ok(key.accountId.startsWith("G"));
+  });
+
+  it("separates reads and writes correctly", () => {
+    const fp = makeFootprint([instanceKey, codeKey], [dataKey]);
+    const result = parseFootprint(fp);
+    assert.equal(result.reads.count, 2);
+    assert.equal(result.writes.count, 1);
+    assert.equal(result.reads.keys[0].type, "contractInstance");
+    assert.equal(result.reads.keys[1].type, "contractCode");
+    assert.equal(result.writes.keys[0].type, "contractData");
+  });
+
+  it("returns correct counts in result shape", () => {
+    const fp = makeFootprint([instanceKey, codeKey, accountKey], [dataKey]);
+    const result = parseFootprint(fp);
+    assert.equal(result.reads.count, result.reads.keys.length);
+    assert.equal(result.writes.count, result.writes.keys.length);
+  });
+});


### PR DESCRIPTION
Closes #5

---

## Summary

Adds `indexer/src/footprintParser.js` to decode the `LedgerFootprint` XDR of a Soroban transaction, showing which ledger entries were read or written.

## Changes

- **`indexer/src/footprintParser.js`**
  - `parseFootprint(footprintXdr)` — parses base64 `LedgerFootprint` XDR and returns:
    ```json
    {
      "reads":  { "count": 2, "keys": [...] },
      "writes": { "count": 1, "keys": [...] }
    }
    ```
  - Each key is classified as one of: `contractInstance`, `contractData`, `contractCode`, `account`, `trustline`, or the raw XDR arm name as fallback
  - `contractInstance` vs `contractData` distinguished by `scvLedgerKeyContractInstance` key type
  - `contractCode` includes `wasmHash` (hex)
  - `contractData` includes `contractId`, `dataKey`, and `durability`

- **`indexer/test/footprintParser.test.js`** — 7 tests covering all key types, read/write separation, counts, and empty footprint

## Testing

```
node --test test/footprintParser.test.js
# 7 pass, 0 fail
```