### PR TITLE
feat: SEP-49 migration tracker and multi-file source viewer

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -33,11 +33,25 @@ export interface DecodedEvent {
   storage_tiers?: StorageTiers;
 }
 
+export interface SourceFile {
+  path: string;
+  content: string;
+}
+
+export interface MigrationStatus {
+  pending: boolean;
+  upgradedAtLedger: number | null;
+  migratedAtLedger: number | null;
+}
+
 export interface ContractMeta {
   id: string;
   name: string;
   description: string;
   functions: { name: string; description: string }[];
+  source?: string;
+  source_file?: string;
+  source_files?: SourceFile[];
 }
 
 // Issue #38: paginated contract transaction response
@@ -75,7 +89,8 @@ export const api = {
     return get<DecodedEvent[]>(`/events?${q}`);
   },
   event:    (seq: number)     => get<DecodedEvent>(`/events/${seq}`),
-  contract: (id: string)      => get<ContractMeta>(`/contracts/${id}`),
+  contract:        (id: string) => get<ContractMeta>(`/contracts/${id}`),
+  migrationStatus: (id: string) => get<MigrationStatus>(`/contracts/${id}/migration-status`),
   wallet:   (address: string) => get<DecodedEvent[]>(`/wallet/${address}`),
 
   downloadAbi: async (id: string) => {

--- a/frontend/src/components/MigrationBanner.tsx
+++ b/frontend/src/components/MigrationBanner.tsx
@@ -1,0 +1,30 @@
+interface Props {
+  upgradedAtLedger: number;
+}
+
+export default function MigrationBanner({ upgradedAtLedger }: Props) {
+  return (
+    <div style={{
+      border: "1px solid var(--yellow)",
+      borderRadius: 8,
+      background: "#3a2e0a",
+      padding: "16px 20px",
+      display: "flex",
+      alignItems: "flex-start",
+      gap: 14,
+    }}>
+      <span style={{ fontSize: 22, lineHeight: 1, marginTop: 1 }}>⚠</span>
+      <div>
+        <div style={{ color: "var(--yellow)", fontWeight: 700, fontSize: 14, marginBottom: 6 }}>
+          Migration Pending — External State Interactions Suspended
+        </div>
+        <div style={{ color: "var(--muted)", fontSize: 12, lineHeight: 1.6 }}>
+          This contract was upgraded at ledger&nbsp;
+          <strong style={{ color: "var(--text)" }}>{upgradedAtLedger}</strong> but has not yet
+          executed its post-upgrade&nbsp;<code>migrate()</code>&nbsp;step. Per SEP-49, external
+          state interactions remain suspended until the mandatory migration call completes.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SourceFileTree.tsx
+++ b/frontend/src/components/SourceFileTree.tsx
@@ -1,0 +1,189 @@
+import { useState } from "react";
+import RustCodeViewer from "./RustCodeViewer";
+
+export interface SourceFile {
+  path: string;
+  content: string;
+}
+
+interface TreeNode {
+  name: string;
+  fullPath: string;
+  isDir: boolean;
+  children: TreeNode[];
+  content?: string;
+}
+
+function buildTree(files: SourceFile[]): TreeNode {
+  const root: TreeNode = { name: "", fullPath: "", isDir: true, children: [] };
+
+  for (const file of files) {
+    const parts = file.path.replace(/^\//, "").split("/");
+    let node = root;
+
+    for (let i = 0; i < parts.length; i++) {
+      const name = parts[i];
+      const isLast = i === parts.length - 1;
+
+      if (isLast) {
+        node.children.push({ name, fullPath: file.path, isDir: false, children: [], content: file.content });
+      } else {
+        let dir = node.children.find(c => c.name === name && c.isDir);
+        if (!dir) {
+          dir = { name, fullPath: parts.slice(0, i + 1).join("/"), isDir: true, children: [] };
+          node.children.push(dir);
+        }
+        node = dir;
+      }
+    }
+  }
+
+  return root;
+}
+
+function sortNodes(nodes: TreeNode[]): TreeNode[] {
+  return [...nodes].sort((a, b) => {
+    if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+interface NodeRowProps {
+  node: TreeNode;
+  depth: number;
+  selected: string;
+  onSelect: (file: SourceFile) => void;
+  expanded: Set<string>;
+  onToggle: (path: string) => void;
+}
+
+function NodeRow({ node, depth, selected, onSelect, expanded, onToggle }: NodeRowProps) {
+  const isExpanded = expanded.has(node.fullPath);
+  const isSelected = selected === node.fullPath;
+
+  const handleClick = () => {
+    if (node.isDir) {
+      onToggle(node.fullPath);
+    } else {
+      onSelect({ path: node.fullPath, content: node.content ?? "" });
+    }
+  };
+
+  return (
+    <>
+      <div
+        onClick={handleClick}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          padding: "4px 8px",
+          paddingLeft: 8 + depth * 16,
+          cursor: "pointer",
+          background: isSelected ? "rgba(88,166,255,0.12)" : "transparent",
+          borderRadius: 4,
+          color: isSelected ? "var(--accent)" : "var(--text)",
+          fontSize: 13,
+          userSelect: "none",
+        }}
+      >
+        <span style={{ color: "var(--muted)", fontSize: 11, width: 12, textAlign: "center", flexShrink: 0 }}>
+          {node.isDir ? (isExpanded ? "▾" : "▸") : ""}
+        </span>
+        <span style={{ color: node.isDir ? "var(--yellow)" : "var(--muted)", fontSize: 13 }}>
+          {node.isDir ? "📁" : fileIcon(node.name)}
+        </span>
+        <span>{node.name}</span>
+      </div>
+      {node.isDir && isExpanded &&
+        sortNodes(node.children).map(child => (
+          <NodeRow
+            key={child.fullPath}
+            node={child}
+            depth={depth + 1}
+            selected={selected}
+            onSelect={onSelect}
+            expanded={expanded}
+            onToggle={onToggle}
+          />
+        ))
+      }
+    </>
+  );
+}
+
+function fileIcon(name: string): string {
+  if (name === "Cargo.toml" || name === "Cargo.lock") return "📦";
+  if (name.endsWith(".rs")) return "🦀";
+  if (name.endsWith(".toml")) return "⚙";
+  if (name.endsWith(".md")) return "📝";
+  return "📄";
+}
+
+interface Props {
+  files: SourceFile[];
+}
+
+export default function SourceFileTree({ files }: Props) {
+  const tree = buildTree(files);
+
+  const initialDirs = new Set<string>();
+  (function collectDirs(node: TreeNode) {
+    if (node.isDir && node.fullPath) initialDirs.add(node.fullPath);
+    node.children.forEach(collectDirs);
+  })(tree);
+
+  const [expanded, setExpanded] = useState<Set<string>>(initialDirs);
+  const [selected, setSelected] = useState<SourceFile | null>(
+    files.find(f => f.path.endsWith("lib.rs")) ?? files[0] ?? null
+  );
+
+  const toggle = (path: string) => {
+    setExpanded(prev => {
+      const next = new Set(prev);
+      next.has(path) ? next.delete(path) : next.add(path);
+      return next;
+    });
+  };
+
+  return (
+    <div style={{ display: "flex", gap: 0, border: "1px solid var(--border)", borderRadius: 8, overflow: "hidden" }}>
+      {/* Navigator panel */}
+      <div style={{
+        width: 220,
+        flexShrink: 0,
+        background: "var(--bg)",
+        borderRight: "1px solid var(--border)",
+        overflowY: "auto",
+        padding: "8px 4px",
+      }}>
+        <div style={{ fontSize: 11, color: "var(--muted)", padding: "0 8px 6px", textTransform: "uppercase", letterSpacing: 1 }}>
+          Source Files
+        </div>
+        {sortNodes(tree.children).map(node => (
+          <NodeRow
+            key={node.fullPath}
+            node={node}
+            depth={0}
+            selected={selected?.path ?? ""}
+            onSelect={setSelected}
+            expanded={expanded}
+            onToggle={toggle}
+          />
+        ))}
+      </div>
+
+      {/* Viewer panel */}
+      <div style={{ flex: 1, overflow: "hidden" }}>
+        {selected
+          ? <RustCodeViewer source={selected.content} filename={selected.path} />
+          : (
+            <div style={{ padding: 24, color: "var(--muted)", fontSize: 13 }}>
+              Select a file to view its source.
+            </div>
+          )
+        }
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ContractPage.tsx
+++ b/frontend/src/pages/ContractPage.tsx
@@ -4,6 +4,8 @@ import { useQuery } from "@tanstack/react-query";
 import { api } from "../api";
 import EventTable from "../components/EventTable";
 import RustCodeViewer from "../components/RustCodeViewer";
+import MigrationBanner from "../components/MigrationBanner";
+import SourceFileTree from "../components/SourceFileTree";
 import SimulateButton from "../components/SimulateButton";
 import InvocationFlowChart, { type InvocationNode } from "../components/InvocationFlowChart";
 
@@ -61,6 +63,12 @@ export default function ContractPage() {
     enabled: !!id,
   });
 
+  const { data: migrationStatus } = useQuery({
+    queryKey: ["migration-status", id],
+    queryFn: () => api.migrationStatus(id),
+    enabled: !!id,
+  });
+
   const downloadAbi = () => {
     api.downloadAbi(id).catch(err => console.error("Download ABI failed:", err));
   };
@@ -77,6 +85,11 @@ export default function ContractPage() {
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+      {/* Issue #84: SEP-49 migration pending banner */}
+      {migrationStatus?.pending && migrationStatus.upgradedAtLedger != null && (
+        <MigrationBanner upgradedAtLedger={migrationStatus.upgradedAtLedger} />
+      )}
+
       {/* Header */}
       <div className="card">
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
@@ -144,12 +157,14 @@ export default function ContractPage() {
         </>
       )}
 
-      {/* Tab: Source Code — Issue #45 */}
+      {/* Tab: Source Code — Issues #45, #85 */}
       {tab === "source" && (
-        <RustCodeViewer
-          source={(meta as any).source ?? DEMO_SOURCE}
-          filename={(meta as any).source_file ?? `${id.slice(0, 8)}.rs`}
-        />
+        meta.source_files && meta.source_files.length > 0
+          ? <SourceFileTree files={meta.source_files} />
+          : <RustCodeViewer
+              source={meta.source ?? DEMO_SOURCE}
+              filename={meta.source_file ?? `${id.slice(0, 8)}.rs`}
+            />
       )}
 
       {/* Tab: Simulate — Issue #46 */}

--- a/indexer/src/api.js
+++ b/indexer/src/api.js
@@ -215,6 +215,14 @@ export function startApi() {
     } catch (e) { res.status(500).json({ error: e.message }); }
   });
 
+  // ── GET /api/contracts/:id/migration-status — Issue #84: SEP-49 migration tracker
+  app.get("/api/contracts/:id/migration-status", async (req, res) => {
+    try {
+      const status = await db.getMigrationStatus(req.params.id);
+      res.json(status);
+    } catch (e) { res.status(500).json({ error: e.message }); }
+  });
+
   // ── POST /api/auth-tree — parse multi-sig ContractAuth trees ───────────────
   // Body: { auth: string[] }  — array of base64 SorobanAuthorizationEntry XDRs
   // Returns: ordered array of { signer, invocations: [{ depth, scope }] }

--- a/indexer/src/db.js
+++ b/indexer/src/db.js
@@ -52,6 +52,8 @@ export const db = {
       ALTER TABLE events ADD COLUMN IF NOT EXISTS upgrade_info JSONB;
       -- Issue #52: storage tier breakdown
       ALTER TABLE events ADD COLUMN IF NOT EXISTS storage_tiers JSONB;
+      -- Issue #85: multi-file source code matching
+      ALTER TABLE contracts ADD COLUMN IF NOT EXISTS source_files JSONB;
     `);
   },
 
@@ -195,11 +197,33 @@ export const db = {
 
   async upsertContractMeta(meta) {
     await pool.query(
-      `INSERT INTO contracts (id, name, description, functions, registered_by)
-       VALUES ($1,$2,$3,$4,$5)
-       ON CONFLICT (id) DO UPDATE SET name=$2, description=$3, functions=$4`,
-      [meta.id, meta.name, meta.description, JSON.stringify(meta.functions), meta.registered_by]
+      `INSERT INTO contracts (id, name, description, functions, registered_by, source_files)
+       VALUES ($1,$2,$3,$4,$5,$6)
+       ON CONFLICT (id) DO UPDATE SET name=$2, description=$3, functions=$4, source_files=$6`,
+      [
+        meta.id, meta.name, meta.description, JSON.stringify(meta.functions), meta.registered_by,
+        meta.source_files ? JSON.stringify(meta.source_files) : null,
+      ]
     );
+  },
+
+  async getMigrationStatus(contractId) {
+    const { rows } = await pool.query(
+      `SELECT
+         MAX(CASE WHEN upgrade_info IS NOT NULL THEN ledger END) AS last_upgrade_ledger,
+         MAX(CASE WHEN function = 'migrate' THEN ledger END)     AS last_migrate_ledger
+       FROM events WHERE contract_id = $1`,
+      [contractId]
+    );
+    const { last_upgrade_ledger, last_migrate_ledger } = rows[0];
+    const pending =
+      last_upgrade_ledger != null &&
+      (last_migrate_ledger == null || Number(last_upgrade_ledger) > Number(last_migrate_ledger));
+    return {
+      pending,
+      upgradedAtLedger: last_upgrade_ledger ? Number(last_upgrade_ledger) : null,
+      migratedAtLedger: last_migrate_ledger ? Number(last_migrate_ledger) : null,
+    };
   },
 
   // ── Vault indexer methods ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **#84 — SEP-49 Compliant Contract Migration Tracker**: Adds a prominent warning banner to the contract detail page that fires whenever a contract was upgraded without a subsequent `migrate()` call, alerting users that external state interactions are suspended pending migration completion.
- **#85 — Multi-File Source Code Matching Architecture**: Extends the Source Code tab with an interactive split-panel directory tree navigator so developers can browse multi-file Rust contract source trees (including nested modules and `Cargo.toml`) after uploading a verified multi-file source bundle.

## Changes

### Backend (`indexer/`)

**`indexer/src/db.js`**
- `db.init()`: adds `ALTER TABLE contracts ADD COLUMN IF NOT EXISTS source_files JSONB` to support multi-file source storage without a destructive migration.
- `db.upsertContractMeta()`: updated `INSERT … ON CONFLICT DO UPDATE` to persist `source_files`; the existing `GET /api/contracts/:id` endpoint returns it automatically via `SELECT *`.
- `db.getMigrationStatus(contractId)`: new method — runs a single conditional `MAX` aggregate over the `events` table to find the ledger of the most recent upgrade event vs. the most recent `migrate()` call, then derives `{ pending, upgradedAtLedger, migratedAtLedger }` with no extra tables or schema objects.

**`indexer/src/api.js`**
- `GET /api/contracts/:id/migration-status`: new endpoint that calls `getMigrationStatus` and returns the JSON payload consumed by the frontend.

### Frontend (`frontend/`)

**`frontend/src/api.ts`**
- New `SourceFile` interface `{ path: string; content: string }`.
- New `MigrationStatus` interface `{ pending, upgradedAtLedger, migratedAtLedger }`.
- `ContractMeta` extended with optional `source`, `source_file`, and `source_files` fields (removes the prior `(meta as any)` casts in ContractPage).
- `api.migrationStatus(id)` added alongside the existing `api.contract(id)`.

**`frontend/src/components/MigrationBanner.tsx`** _(new)_
- Renders a yellow bordered card with the mandatory SEP-49 message: **"Migration Pending — External State Interactions Suspended"**.
- Displays the upgrade ledger number and a one-line SEP-49 explanation.

**`frontend/src/components/SourceFileTree.tsx`** _(new)_
- Accepts `files: SourceFile[]` and builds a recursive `TreeNode` tree from slash-delimited paths.
- Left panel: collapsible directory navigator (directories expand/collapse on click, files open in the viewer); directories sorted before files, alphabetically within each group; file icons differentiate `.rs`, `Cargo.toml`, `.toml`, and `.md` files.
- Right panel: `RustCodeViewer` showing the selected file with full syntax highlighting; defaults to `lib.rs` if present.
- All expand/collapse and selection state is local to the component.

**`frontend/src/pages/ContractPage.tsx`**
- Adds a `useQuery` for `migrationStatus`; renders `<MigrationBanner>` above the header card when `pending === true`.
- Source Code tab now conditionally renders `<SourceFileTree>` when `meta.source_files` is non-empty, falling back to the existing single-file `<RustCodeViewer>` otherwise.

## Test plan

- [ ] Contract that has been upgraded but not yet migrated → banner visible at top of contract detail page
- [ ] Contract where `migrate()` ledger > upgrade ledger → no banner shown
- [ ] Contract with no upgrade history → no banner shown
- [ ] `POST /api/contracts` with `source_files` array → column persisted, returned via `GET /api/contracts/:id`
- [ ] Source Code tab with `source_files` populated → SourceFileTree renders with navigator + viewer
- [ ] Clicking a directory → expands/collapses; clicking a file → updates viewer
- [ ] Source Code tab with no `source_files` → falls back to existing single-file viewer / demo placeholder

Closes #84
Closes #85