### PR TITLE
feat: #74 support PYUSD clawback compliance tracking

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -31,6 +31,8 @@ export interface DecodedEvent {
   upgrade_info?: { type: "upgrade"; oldHash: string; newHash: string };
   // Issue #52: storage tier breakdown
   storage_tiers?: StorageTiers;
+  // Issue #74: clawback compliance flag
+  is_clawback?: boolean;
 }
 
 export interface ContractMeta {

--- a/frontend/src/components/EventTable.tsx
+++ b/frontend/src/components/EventTable.tsx
@@ -50,6 +50,11 @@ export default function EventTable({ events }: Props) {
                 <FunctionBadge fn={ev.function} />
               </td>
               <td style={{ ...td, maxWidth: 480, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {ev.is_clawback && (
+                  <span className="badge clawback" style={{ marginRight: 6 }} title="Mandatory authority intervention">
+                    ⚠ COMPLIANCE: CLAWBACK
+                  </span>
+                )}
                 {ev.description}
               </td>
             </tr>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -58,3 +58,4 @@ button:hover { opacity: 0.85; }
 .badge.yellow { background: #3a2e0a; color: var(--yellow); }
 .badge.wrap { background: #0d2a3a; color: #58c4f5; }
 .badge.unwrap { background: #2a1a0d; color: #e8a44a; }
+.badge.clawback { background: #3a0d0d; color: #f85149; }

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -22,6 +22,16 @@ export default function EventPage() {
       <div className="card" style={{ display: "grid", gap: 12 }}>
         <Row label="Description" value={ev.description} highlight />
         <Row label="Function"    value={ev.function} badge />
+        {ev.is_clawback && (
+          <Row
+            label="Compliance"
+            value={
+              <span className="badge clawback" title="Mandatory authority intervention">
+                ⚠ COMPLIANCE: CLAWBACK — mandatory authority intervention
+              </span>
+            }
+          />
+        )}
         <Row label="Ledger"      value={ev.ledger.toLocaleString()} />
         <Row label="Contract"    value={<Link to={`/contract/${ev.contract_id}`}>{ev.contract_id}</Link>} />
         {ev.tx_hash && <Row label="Tx Hash" value={ev.tx_hash} mono />}

--- a/indexer/src/db.js
+++ b/indexer/src/db.js
@@ -24,6 +24,8 @@ export const db = {
         upgrade_info     JSONB,
         -- Issue #52: storage tier breakdown
         storage_tiers    JSONB,
+        -- Issue #74: clawback compliance flag
+        is_clawback      BOOLEAN NOT NULL DEFAULT FALSE,
         created_at       TIMESTAMPTZ DEFAULT NOW()
       );
       CREATE INDEX IF NOT EXISTS idx_events_contract ON events(contract_id);
@@ -52,6 +54,8 @@ export const db = {
       ALTER TABLE events ADD COLUMN IF NOT EXISTS upgrade_info JSONB;
       -- Issue #52: storage tier breakdown
       ALTER TABLE events ADD COLUMN IF NOT EXISTS storage_tiers JSONB;
+      -- Issue #74: clawback compliance flag
+      ALTER TABLE events ADD COLUMN IF NOT EXISTS is_clawback BOOLEAN NOT NULL DEFAULT FALSE;
     `);
   },
 
@@ -64,8 +68,8 @@ export const db = {
     await pool.query(
       `INSERT INTO events
          (contract_id, function, ledger, tx_hash, description, raw_topics, raw_data,
-          cpu_instructions, mem_bytes, fee_charged, is_high_bloat_risk, upgrade_info, storage_tiers)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+          cpu_instructions, mem_bytes, fee_charged, is_high_bloat_risk, upgrade_info, storage_tiers, is_clawback)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
        ON CONFLICT DO NOTHING`,
       [
         ev.contract_id, ev.function, ev.ledger, ev.tx_hash,
@@ -74,6 +78,7 @@ export const db = {
         ev.is_high_bloat_risk ?? false,
         ev.upgrade ? JSON.stringify(ev.upgrade) : null,
         ev.storage_tiers ? JSON.stringify(ev.storage_tiers) : null,
+        ev.is_clawback ?? false,
       ]
     );
   },

--- a/indexer/src/decoder.js
+++ b/indexer/src/decoder.js
@@ -115,6 +115,7 @@ export async function decode(ev) {
     raw_topics:  topics.map(String),
     raw_data:    JSON.stringify(data),
     ...(isSac && { sac_asset: assetCode }),
+    is_clawback: fnName === "clawback",
     ...extractGasCosts(ev),
   };
   };
@@ -184,6 +185,10 @@ function buildDescription(fn, args, data, contractName) {
     case "burn": {
       const [from, amount, token] = args;
       return `${amount} ${token ?? ""} burned from ${fmt(from)} on ${contractName}`;
+    }
+    case "clawback": {
+      const [admin, from, amount, token] = args;
+      return `CLAWBACK: ${amount} ${token ?? ""} recovered from ${fmt(from)} by authority ${fmt(admin)} on ${contractName}`;
     }
     default:
       return genericDescription(fn, args, data, contractName);

--- a/indexer/src/sep41.js
+++ b/indexer/src/sep41.js
@@ -90,6 +90,26 @@ export function extractApprove(event) {
 }
 
 /**
+ * Extract a SEP-41 clawback event.
+ * Topics: [Symbol("clawback"), admin: Address, from: Address]
+ * Data:   amount (i128 as BigInt)
+ *
+ * @param {{ topics: any[], value: any }} event
+ * @returns {{ type: 'clawback', admin: string, from: string, amount: string } | null}
+ */
+export function extractClawback(event) {
+  const { topics, value } = event;
+  if (topics[0] !== "clawback") return null;
+  const [, admin, from] = topics;
+  return {
+    type: "clawback",
+    admin: String(admin),
+    from: String(from),
+    amount: String(value),
+  };
+}
+
+/**
  * Try all SEP-41 extractors in order and return the first match, or null.
  *
  * @param {{ topics: any[], value: any }} event
@@ -101,6 +121,7 @@ export function extractSep41Event(event) {
     extractMint(event) ??
     extractBurn(event) ??
     extractApprove(event) ??
+    extractClawback(event) ??
     null
   );
 }

--- a/indexer/test/sep41Clawback.test.js
+++ b/indexer/test/sep41Clawback.test.js
@@ -1,0 +1,45 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { extractClawback, extractSep41Event } from "../src/sep41.js";
+
+const ADMIN = "GABC1234ADMIN";
+const FROM  = "GXYZ5678VICTIM";
+const AMOUNT = "500000000";
+
+describe("extractClawback", () => {
+  it("returns structured clawback for matching event", () => {
+    const event = { topics: ["clawback", ADMIN, FROM], value: AMOUNT };
+    const result = extractClawback(event);
+    assert.deepStrictEqual(result, {
+      type: "clawback",
+      admin: ADMIN,
+      from: FROM,
+      amount: AMOUNT,
+    });
+  });
+
+  it("returns null for non-clawback events", () => {
+    assert.strictEqual(extractClawback({ topics: ["transfer", ADMIN, FROM], value: AMOUNT }), null);
+    assert.strictEqual(extractClawback({ topics: ["mint", ADMIN, FROM], value: AMOUNT }), null);
+    assert.strictEqual(extractClawback({ topics: ["burn", FROM], value: AMOUNT }), null);
+  });
+});
+
+describe("extractSep41Event — clawback via dispatcher", () => {
+  it("dispatches clawback events correctly", () => {
+    const event = { topics: ["clawback", ADMIN, FROM], value: AMOUNT };
+    const result = extractSep41Event(event);
+    assert.ok(result);
+    assert.strictEqual(result.type, "clawback");
+    assert.strictEqual(result.from, FROM);
+    assert.strictEqual(result.admin, ADMIN);
+    assert.strictEqual(result.amount, AMOUNT);
+  });
+
+  it("does not match clawback for transfer events", () => {
+    const event = { topics: ["transfer", FROM, ADMIN], value: AMOUNT };
+    const result = extractSep41Event(event);
+    assert.ok(result);
+    assert.strictEqual(result.type, "transfer");
+  });
+});


### PR DESCRIPTION
- Add extractClawback() SEP-41 extractor (admin, from, amount)
- Decode clawback events with human-readable CLAWBACK description
- Set is_clawback flag on decoded event records
- Add is_clawback column to events table with migration guard
- Render ⚠ COMPLIANCE: CLAWBACK badge in EventTable and EventPage
- Add tests for extractClawback and extractSep41Event dispatcher

Closes #74 