### PR TITLE
feat: factory deployment detector (#130)

### DIFF
--- a/frontend/src/components/FactoryDeploymentTree.tsx
+++ b/frontend/src/components/FactoryDeploymentTree.tsx
@@ -1,0 +1,100 @@
+// Issue #130 — Factory Deployment Event tree display
+
+interface DeployedContract {
+  index: number;
+  contractId?: string;
+  parentContractId?: string | null;
+}
+
+interface FactoryDeployment {
+  factoryContractId: string | null;
+  deployedContracts: DeployedContract[];
+}
+
+interface Props {
+  deployment: FactoryDeployment;
+}
+
+function short(id: string | null | undefined) {
+  if (!id) return "unknown";
+  return id.length > 16 ? `${id.slice(0, 8)}…${id.slice(-6)}` : id;
+}
+
+export default function FactoryDeploymentTree({ deployment }: Props) {
+  const { factoryContractId, deployedContracts } = deployment;
+
+  return (
+    <div
+      className="card"
+      style={{ borderLeft: "4px solid var(--accent)", padding: "12px 16px" }}
+      aria-label="Factory Deployment Event"
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
+        <span
+          style={{
+            background: "var(--accent)",
+            color: "#fff",
+            borderRadius: 4,
+            padding: "2px 8px",
+            fontSize: 12,
+            fontWeight: 700,
+            letterSpacing: 0.5,
+          }}
+        >
+          Factory Deployment Event
+        </span>
+        <span style={{ color: "var(--muted)", fontSize: 13 }}>
+          {deployedContracts.length} contract{deployedContracts.length !== 1 ? "s" : ""} deployed
+        </span>
+      </div>
+
+      {/* Factory root node */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            padding: "8px 12px",
+            background: "var(--surface)",
+            border: "1px solid var(--accent)",
+            borderRadius: 6,
+            fontFamily: "monospace",
+            fontSize: 13,
+          }}
+        >
+          <span style={{ color: "var(--accent)", fontWeight: 700 }}>⬡ Factory</span>
+          <span style={{ color: "var(--muted)" }}>{short(factoryContractId)}</span>
+        </div>
+
+        {/* Deployed sub-contracts */}
+        <div style={{ marginLeft: 24, display: "flex", flexDirection: "column", gap: 4 }}>
+          {deployedContracts.map((c, i) => (
+            <div
+              key={i}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                padding: "6px 12px",
+                background: "var(--surface)",
+                border: "1px solid var(--border)",
+                borderRadius: 6,
+                fontFamily: "monospace",
+                fontSize: 12,
+              }}
+            >
+              <span style={{ color: "var(--muted)" }}>└─</span>
+              <span style={{ color: "var(--text)", fontWeight: 600 }}>
+                Contract #{c.index + 1}
+              </span>
+              {c.contractId && (
+                <span style={{ color: "var(--muted)" }}>{short(c.contractId)}</span>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/indexer/src/factoryDeploymentDetector.js
+++ b/indexer/src/factoryDeploymentDetector.js
@@ -1,0 +1,158 @@
+import { xdr, StrKey } from "@stellar/stellar-sdk";
+
+/**
+ * Recursively collect all CreateContract host functions from an
+ * InvokeHostFunction operation's auth entries and sub-invocations.
+ *
+ * @param {xdr.SorobanAuthorizedInvocation} invocation
+ * @param {string|null} parentContractId
+ * @param {object[]} acc  accumulator
+ */
+function collectCreates(invocation, parentContractId, acc) {
+  try {
+    const fn = invocation.function();
+    if (fn.switch().name === "sorobanAuthorizedFunctionTypeCreateContractV2HostFn" ||
+        fn.switch().name === "sorobanAuthorizedFunctionTypeCreateContractHostFn") {
+      const args = fn.createContractV2HostFn?.() ?? fn.createContractHostFn?.();
+      let newContractId = null;
+      try {
+        const preimage = args.contractIdPreimage?.();
+        if (preimage?.switch().name === "contractIdPreimageFromAddress") {
+          // address-based preimage — contract ID resolved post-execution
+          newContractId = null;
+        }
+      } catch { /* ignore */ }
+      acc.push({ parentContractId, newContractId, raw: fn });
+    }
+  } catch { /* not a create */ }
+
+  // Recurse into sub-invocations
+  try {
+    for (const sub of invocation.subInvocations()) {
+      collectCreates(sub, parentContractId, acc);
+    }
+  } catch { /* no sub-invocations */ }
+}
+
+/**
+ * Extract newly created contract IDs from sorobanMeta.changedEntries.
+ * A "created" contractInstance entry means a new contract was deployed.
+ *
+ * @param {object} sorobanMeta
+ * @returns {string[]}  strkey-encoded contract IDs
+ */
+function extractCreatedContracts(sorobanMeta) {
+  const created = [];
+  try {
+    const changes = sorobanMeta.changedEntries?.() ?? [];
+    for (const change of changes) {
+      try {
+        if (change.switch().name !== "ledgerEntryCreated") continue;
+        const entry = change.created();
+        const contractData = entry.data?.().contractData?.();
+        if (!contractData) continue;
+        if (contractData.key?.().switch().name !== "scvLedgerKeyContractInstance") continue;
+        const contractId = StrKey.encodeContract(contractData.contract().contractId());
+        created.push(contractId);
+      } catch { /* skip */ }
+    }
+  } catch { /* ignore */ }
+  return created;
+}
+
+/**
+ * Detect a factory deployment pattern in a transaction's metadata.
+ *
+ * A factory deployment is when a single transaction deploys 2+ contracts,
+ * typically via a factory contract that calls CreateContract multiple times.
+ *
+ * @param {object} ev  Raw Soroban RPC event (must have ev.txMeta)
+ * @returns {{
+ *   isFactoryDeployment: boolean,
+ *   factoryContractId: string|null,
+ *   deployedContracts: string[],
+ *   deploymentTree: { factoryContractId: string|null, contracts: string[] }
+ * } | null}
+ */
+export function detectFactoryDeployment(ev) {
+  try {
+    const sorobanMeta = ev.txMeta?.v3?.().sorobanMeta?.();
+    if (!sorobanMeta) return null;
+
+    const deployedContracts = extractCreatedContracts(sorobanMeta);
+    if (deployedContracts.length < 2) return null;
+
+    // Try to identify the factory contract from the invoking contract
+    let factoryContractId = null;
+    try {
+      const hf = ev.txMeta.v3?.().operations?.()[0]?.changes?.();
+      // Best-effort: the factory is the contract that initiated the tx
+      factoryContractId = ev.contractId ?? null;
+    } catch { /* ignore */ }
+
+    return {
+      isFactoryDeployment: true,
+      factoryContractId,
+      deployedContracts,
+      deploymentTree: {
+        factoryContractId,
+        contracts: deployedContracts,
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a TransactionEnvelope XDR for factory deployment patterns by
+ * recursively scanning CreateContract operations within the envelope.
+ *
+ * @param {string} txEnvelopeXdr  base64-encoded TransactionEnvelope XDR
+ * @param {string} [factoryContractId]  known factory contract ID (optional)
+ * @returns {{
+ *   isFactoryDeployment: boolean,
+ *   factoryContractId: string|null,
+ *   deployedContracts: { index: number, parentContractId: string|null }[],
+ *   deploymentTree: { factoryContractId: string|null, contracts: object[] }
+ * }}
+ */
+export function parseFactoryDeployment(txEnvelopeXdr, factoryContractId = null) {
+  const env = xdr.TransactionEnvelope.fromXDR(txEnvelopeXdr, "base64");
+
+  let ops;
+  try {
+    ops = env.v1?.().tx().operations() ?? env.tx?.().operations() ?? [];
+  } catch {
+    ops = [];
+  }
+
+  const creates = [];
+
+  for (const op of ops) {
+    try {
+      const body = op.body();
+      if (body.switch().name !== "invokeHostFunction") continue;
+      const ihf = body.invokeHostFunction();
+
+      // Scan auth entries for CreateContract sub-invocations
+      for (const authEntry of ihf.auth()) {
+        try {
+          collectCreates(authEntry.rootInvocation(), factoryContractId, creates);
+        } catch { /* skip */ }
+      }
+    } catch { /* skip non-invoke ops */ }
+  }
+
+  const isFactoryDeployment = creates.length >= 2;
+
+  return {
+    isFactoryDeployment,
+    factoryContractId,
+    deployedContracts: creates.map((c, i) => ({ index: i, parentContractId: c.parentContractId })),
+    deploymentTree: {
+      factoryContractId,
+      contracts: creates.map((c, i) => ({ index: i, parentContractId: c.parentContractId })),
+    },
+  };
+}


### PR DESCRIPTION
Recursively scan CreateContract metadata arrays within a transaction envelope to detect when a single tx deploys multiple contracts (factory pattern). Links sub-contracts back to the primary factory contract ID.

- detectFactoryDeployment(): scans sorobanMeta.changedEntries for ledgerEntryCreated contractInstance entries (≥2 = factory pattern)
- parseFactoryDeployment(): scans TransactionEnvelope XDR auth entries recursively for CreateContract sub-invocations
- FactoryDeploymentTree.tsx: frontend component that groups all newly instantiated contract addresses under a 'Factory Deployment Event' tree

closes #130 