### PR TITLE
feat: decode Protocol 26 TTL rent extension host functions

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -49,6 +49,13 @@ export interface DecodedEvent {
   is_clawback?: boolean;
   // Issue #75: AMM swap path hops ["10 USDC", "9.1 EURC", "5.2 XLM"]
   swap_path?: string[];
+  // Protocol 26: TTL extension host function data
+  ttl_extension?: {
+    fn_name: string | null;
+    extend_to: number | null;
+    min_extension: number | null;
+    max_extension: number | null;
+  };
 }
 
 export interface SourceFile {

--- a/frontend/src/components/EventTable.tsx
+++ b/frontend/src/components/EventTable.tsx
@@ -49,6 +49,40 @@ function FunctionBadge({ fn }: { fn: string }) {
   return <span className="badge">{fn}</span>;
 }
 
+/** Inline badge for Protocol 26 TTL extension events. */
+function TTLExtensionBadge({ ext }: { ext: NonNullable<DecodedEvent["ttl_extension"]> }) {
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        padding: "2px 8px",
+        background: "rgba(99,102,241,0.12)",
+        border: "1px solid #6366f1",
+        borderRadius: 4,
+        fontSize: 11,
+        color: "#818cf8",
+        whiteSpace: "nowrap",
+        marginRight: 6,
+        verticalAlign: "middle",
+      }}
+      title="Protocol 26 TTL rent extension"
+    >
+      ⏱ TTL Extension
+      {ext.min_extension != null && (
+        <span style={{ color: "var(--muted)" }}>Requested: +{ext.min_extension} Ledgers</span>
+      )}
+      {ext.max_extension != null && (
+        <span style={{ color: "var(--muted)" }}>Clamp: {ext.max_extension}</span>
+      )}
+      {ext.extend_to != null && (
+        <span style={{ color: "var(--muted)" }}>→ {ext.extend_to}</span>
+      )}
+    </span>
+  );
+}
+
 export default function EventTable({ events }: Props) {
   if (!events.length) return <p style={{ color: "var(--muted)" }}>No events found.</p>;
 
@@ -97,6 +131,7 @@ export default function EventTable({ events }: Props) {
                     ⚠ High Gas
                   </span>
                 )}
+                {ev.ttl_extension && <TTLExtensionBadge ext={ev.ttl_extension} />}
                 {ev.description}
                 {ev.function === "transfer" && (() => {
                   const t = parseTransfer(ev.description);

--- a/indexer/src/db.js
+++ b/indexer/src/db.js
@@ -85,6 +85,9 @@ export const db = {
       -- Issue #134: resource-limit-exceeded flag
       ALTER TABLE events ADD COLUMN IF NOT EXISTS is_resource_limit_exceeded BOOLEAN NOT NULL DEFAULT FALSE;
 
+      -- Protocol 26: TTL extension host function data (extend_to, min_extension, max_extension)
+      ALTER TABLE events ADD COLUMN IF NOT EXISTS ttl_extension JSONB;
+
       -- Issue #117: sub-invocation indexing
       CREATE TABLE IF NOT EXISTS sub_invocations (
         id              BIGSERIAL PRIMARY KEY,
@@ -197,8 +200,8 @@ export const db = {
       `INSERT INTO events
          (contract_id, function, ledger, tx_hash, description, raw_topics, raw_data,
           cpu_instructions, mem_bytes, fee_charged, is_high_bloat_risk, upgrade_info, storage_tiers, is_clawback,
-          footprint_contention)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+          footprint_contention, ttl_extension)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)
        ON CONFLICT DO NOTHING`,
       [
         ev.contract_id, ev.function, ev.ledger, ev.tx_hash,
@@ -209,6 +212,7 @@ export const db = {
         ev.storage_tiers ? JSON.stringify(ev.storage_tiers) : null,
         ev.is_clawback ?? false,
         ev.footprint_contention ?? false,
+        ev.ttl_extension ? JSON.stringify(ev.ttl_extension) : null,
       ]
     );
   },

--- a/indexer/src/decoder.js
+++ b/indexer/src/decoder.js
@@ -1,4 +1,5 @@
 import { xdr, scValToNative, StrKey } from "@stellar/stellar-sdk";
+import { parseTTLHostFunction, formatTTLExtension } from "./ttlExtensionParser.js";
 
 // Issue #134 — result codes that indicate block compute capacity was exhausted
 const RESOURCE_LIMIT_CODES = new Set([
@@ -153,6 +154,14 @@ export async function decode(ev) {
     is_resource_limit_exceeded: isResourceLimitExceeded(ev),
     ...extractGasCosts(ev),
   };
+
+  // Protocol 26: detect TTL extension host function calls on this event
+  const ttlExt = parseTTLHostFunction(ev.hostFunction ?? ev.host_function ?? ev.operation ?? null);
+  if (ttlExt) {
+    decoded.ttl_extension = ttlExt;
+    // Enrich description so the ledger history row is self-explanatory
+    decoded.description = formatTTLExtension(ttlExt);
+  }
 
   // Persist role assignment if this event carries one
   const roleAssignment = extractRoleAssignment(decoded);

--- a/indexer/src/ttlExtensionParser.js
+++ b/indexer/src/ttlExtensionParser.js
@@ -1,92 +1,129 @@
 /**
- * TTL Extension and StateRent Parser
- * Issue #63: Parse and Label StateRent & TTL Modifications
- * Parses ExtendCurrentContractInstanceOp and ExtendCurrentContractCodeOp operations
+ * TTL Extension Parser — Protocol 26
+ *
+ * Protocol 26 replaced the old ExtendCurrentContractInstanceOp / ExtendCurrentContractCodeOp
+ * operations with host function calls that carry three explicit parameters:
+ *
+ *   extend_to      – absolute ledger number the entry should live until
+ *   min_extension  – minimum ledger delta the caller requested
+ *   max_extension  – maximum ledger delta allowed (enforced clamp)
+ *
+ * This module parses those host function invocations from the XDR structures
+ * surfaced by the Soroban RPC and returns a structured record suitable for
+ * storage and display.
  */
+
+// Host function names emitted by Protocol 26 for TTL extension
+const TTL_HOST_FN_NAMES = new Set([
+  "extend_contract_instance_ttl",
+  "extend_contract_code_ttl",
+  "extend_ttl",           // generic alias used in some SDK versions
+]);
 
 /**
- * Parse TTL extension operation from XDR
- * @param {Object} operation - The operation object
- * @returns {Object} Parsed TTL extension details
+ * Parse a Protocol 26 TTL extension from a host function invocation.
+ *
+ * The `hostFn` object is expected to have the shape produced by
+ * `scValToNative()` on the InvokeHostFunctionOp args, or the raw
+ * operation object from the Soroban RPC transaction envelope.
+ *
+ * @param {object} hostFn  Host function invocation object
+ * @returns {{ extend_to: number|null, min_extension: number|null, max_extension: number|null, fn_name: string|null } | null}
+ *   Returns null when the object is not a TTL extension call.
  */
-function parseTTLExtension(operation) {
-  const result = {
-    operationType: null,
-    targetKey: null,
-    extendToLedger: null,
-    costXlm: null,
-    timestamp: null,
-  };
+function parseTTLHostFunction(hostFn) {
+  if (!hostFn) return null;
 
-  if (!operation) return result;
+  const fnName = hostFn.function_name ?? hostFn.fn_name ?? hostFn.type ?? null;
 
-  // ExtendCurrentContractInstanceOp
-  if (operation.ext && operation.ext.v === 1) {
-    result.operationType = "ExtendCurrentContractInstance";
-    result.targetKey = operation.contractId || null;
-    result.extendToLedger = operation.extendTo || null;
-  }
+  // Accept both the canonical names and the legacy operation type strings
+  const isExtend =
+    (fnName && TTL_HOST_FN_NAMES.has(fnName)) ||
+    (typeof fnName === "string" && fnName.toLowerCase().includes("extend"));
 
-  // ExtendCurrentContractCodeOp
-  if (operation.type === "extendContractCode") {
-    result.operationType = "ExtendCurrentContractCode";
-    result.targetKey = operation.codeHash || null;
-    result.extendToLedger = operation.extendTo || null;
-  }
+  if (!isExtend) return null;
 
-  // Extract cost from transaction metadata
-  if (operation.meta && operation.meta.result && operation.meta.result.costOuter) {
-    const cost = operation.meta.result.costOuter;
-    result.costXlm = (cost.cpuInstrs + cost.memBytes) / 1_000_000; // Simple cost estimation
-  }
+  // Protocol 26 parameters may appear as direct fields or inside an `args` map
+  const args = hostFn.args ?? hostFn;
 
-  return result;
+  const extend_to     = _num(args.extend_to     ?? args.extendTo     ?? hostFn.extend_to     ?? hostFn.extendTo);
+  const min_extension = _num(args.min_extension ?? args.minExtension ?? hostFn.min_extension ?? hostFn.minExtension);
+  const max_extension = _num(args.max_extension ?? args.maxExtension ?? hostFn.max_extension ?? hostFn.maxExtension);
+
+  // Must have at least one Protocol 26 field to be considered a valid record
+  if (extend_to === null && min_extension === null && max_extension === null) return null;
+
+  return { fn_name: fnName, extend_to, min_extension, max_extension };
 }
 
 /**
- * Extract all TTL modifications from a transaction
- * @param {Object} transaction - The transaction object
- * @returns {Array} Array of TTL modification details
+ * Extract all TTL extension records from a transaction.
+ *
+ * Walks `transaction.operations` and, for each InvokeHostFunctionOp,
+ * attempts to parse a TTL extension.  Also handles the legacy
+ * ExtendCurrentContractInstanceOp / ExtendCurrentContractCodeOp shapes
+ * for backward compatibility with pre-Protocol-26 data.
+ *
+ * @param {object} transaction  Raw transaction object from the Soroban RPC
+ * @returns {Array<{ fn_name: string, extend_to: number|null, min_extension: number|null, max_extension: number|null, ledger: number, tx_hash: string }>}
  */
-function extractTTLModifications(transaction) {
-  const modifications = [];
+function extractTTLExtensions(transaction) {
+  if (!transaction?.operations) return [];
 
-  if (!transaction || !transaction.operations) {
-    return modifications;
-  }
+  const results = [];
 
   for (const op of transaction.operations) {
-    if (
-      (op.type && op.type.includes("extend")) ||
-      (op.body && op.body.extendOp)
-    ) {
-      const parsed = parseTTLExtension(op);
-      if (parsed.operationType) {
-        modifications.push({
-          ...parsed,
-          ledger: transaction.ledger,
-          hash: transaction.hash,
-          timestamp: transaction.timestamp,
-        });
-      }
+    // Protocol 26: InvokeHostFunctionOp wrapping a TTL host function
+    const parsed = parseTTLHostFunction(op.hostFunction ?? op.host_function ?? op);
+    if (parsed) {
+      results.push({
+        ...parsed,
+        ledger:    transaction.ledger   ?? null,
+        tx_hash:   transaction.hash     ?? null,
+        timestamp: transaction.timestamp ?? null,
+      });
+      continue;
+    }
+
+    // Legacy (pre-Protocol-26) fallback
+    if (op.type === "extendContractCode" || op.type === "extendContractInstance" ||
+        (op.ext?.v === 1 && (op.contractId || op.codeHash))) {
+      results.push({
+        fn_name:       op.type ?? "extend_ttl",
+        extend_to:     _num(op.extendTo ?? op.extend_to),
+        min_extension: null,
+        max_extension: null,
+        ledger:        transaction.ledger   ?? null,
+        tx_hash:       transaction.hash     ?? null,
+        timestamp:     transaction.timestamp ?? null,
+      });
     }
   }
 
-  return modifications;
+  return results;
 }
 
 /**
- * Calculate rent paid in a TTL extension
- * @param {Object} extensionOp - The parsed extension operation
- * @returns {number} Rent paid in stroops (1 XLM = 10M stroops)
+ * Build a human-readable label for a TTL extension record.
+ * Matches the display format: "Action: TTL Extension | Requested: +X Ledgers | Enforced Clamp: Y Ledgers"
+ *
+ * @param {{ extend_to: number|null, min_extension: number|null, max_extension: number|null }} ext
+ * @returns {string}
  */
-function calculateRentPaid(extensionOp) {
-  if (!extensionOp.costXlm) return 0;
-  return Math.round(extensionOp.costXlm * 10_000_000);
+function formatTTLExtension(ext) {
+  const parts = ["Action: TTL Extension"];
+  if (ext.min_extension != null) parts.push(`Requested: +${ext.min_extension} Ledgers`);
+  if (ext.max_extension != null) parts.push(`Enforced Clamp: ${ext.max_extension} Ledgers`);
+  if (ext.extend_to     != null) parts.push(`Extend To: ${ext.extend_to}`);
+  return parts.join(" | ");
 }
 
-module.exports = {
-  parseTTLExtension,
-  extractTTLModifications,
-  calculateRentPaid,
-};
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function _num(v) {
+  if (v == null) return null;
+  const n = Number(v);
+  return isNaN(n) ? null : n;
+}
+
+module.exports = { parseTTLHostFunction, extractTTLExtensions, formatTTLExtension };

--- a/indexer/test/ttlExtensionParser.test.js
+++ b/indexer/test/ttlExtensionParser.test.js
@@ -1,97 +1,184 @@
 /**
- * TTL Extension Parser Tests
- * Issue #63: Parse and Label StateRent & TTL Modifications
+ * TTL Extension Parser Tests — Protocol 26
  */
 
 const {
-  parseTTLExtension,
-  extractTTLModifications,
-  calculateRentPaid,
+  parseTTLHostFunction,
+  extractTTLExtensions,
+  formatTTLExtension,
 } = require("../src/ttlExtensionParser");
 
-describe("TTL Extension Parser", () => {
-  describe("parseTTLExtension", () => {
-    test("parses ExtendCurrentContractInstance operation", () => {
-      const operation = {
-        ext: { v: 1 },
-        contractId: "CONTRACT123",
-        extendTo: 100000,
-        meta: {
-          result: {
-            costOuter: { cpuInstrs: 1000, memBytes: 500 },
+describe("parseTTLHostFunction", () => {
+  test("parses Protocol 26 extend_contract_instance_ttl with all three fields", () => {
+    const result = parseTTLHostFunction({
+      function_name: "extend_contract_instance_ttl",
+      args: { extend_to: 500000, min_extension: 17280, max_extension: 34560 },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result.fn_name).toBe("extend_contract_instance_ttl");
+    expect(result.extend_to).toBe(500000);
+    expect(result.min_extension).toBe(17280);
+    expect(result.max_extension).toBe(34560);
+  });
+
+  test("parses Protocol 26 extend_contract_code_ttl with top-level fields", () => {
+    const result = parseTTLHostFunction({
+      function_name: "extend_contract_code_ttl",
+      extend_to: 600000,
+      min_extension: 8640,
+      max_extension: 17280,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result.extend_to).toBe(600000);
+    expect(result.min_extension).toBe(8640);
+    expect(result.max_extension).toBe(17280);
+  });
+
+  test("parses generic extend_ttl alias", () => {
+    const result = parseTTLHostFunction({
+      function_name: "extend_ttl",
+      args: { extend_to: 400000, min_extension: 5000, max_extension: 10000 },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result.fn_name).toBe("extend_ttl");
+  });
+
+  test("accepts camelCase field aliases (extendTo, minExtension, maxExtension)", () => {
+    const result = parseTTLHostFunction({
+      function_name: "extend_ttl",
+      extendTo: 300000,
+      minExtension: 1000,
+      maxExtension: 2000,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result.extend_to).toBe(300000);
+    expect(result.min_extension).toBe(1000);
+    expect(result.max_extension).toBe(2000);
+  });
+
+  test("returns null for non-TTL host function", () => {
+    expect(parseTTLHostFunction({ function_name: "transfer", args: {} })).toBeNull();
+  });
+
+  test("returns null when no Protocol 26 fields are present", () => {
+    // Has the right name but no actual parameters — not a valid record
+    expect(parseTTLHostFunction({ function_name: "extend_ttl" })).toBeNull();
+  });
+
+  test("returns null for null input", () => {
+    expect(parseTTLHostFunction(null)).toBeNull();
+  });
+
+  test("handles partial fields — only extend_to present", () => {
+    const result = parseTTLHostFunction({
+      function_name: "extend_ttl",
+      args: { extend_to: 200000 },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result.extend_to).toBe(200000);
+    expect(result.min_extension).toBeNull();
+    expect(result.max_extension).toBeNull();
+  });
+});
+
+describe("extractTTLExtensions", () => {
+  test("extracts Protocol 26 TTL extension from transaction operations", () => {
+    const tx = {
+      ledger: 50000,
+      hash: "TXHASH123",
+      timestamp: Date.now(),
+      operations: [
+        {
+          hostFunction: {
+            function_name: "extend_contract_instance_ttl",
+            args: { extend_to: 500000, min_extension: 17280, max_extension: 34560 },
           },
         },
-      };
+      ],
+    };
 
-      const result = parseTTLExtension(operation);
+    const results = extractTTLExtensions(tx);
 
-      expect(result.operationType).toBe("ExtendCurrentContractInstance");
-      expect(result.targetKey).toBe("CONTRACT123");
-      expect(result.extendToLedger).toBe(100000);
-      expect(result.costXlm).toBeCloseTo(0.0015, 5);
-    });
-
-    test("parses ExtendCurrentContractCode operation", () => {
-      const operation = {
-        type: "extendContractCode",
-        codeHash: "HASH123",
-        extendTo: 150000,
-      };
-
-      const result = parseTTLExtension(operation);
-
-      expect(result.operationType).toBe("ExtendCurrentContractCode");
-      expect(result.targetKey).toBe("HASH123");
-      expect(result.extendToLedger).toBe(150000);
-    });
-
-    test("returns empty result for invalid operation", () => {
-      const result = parseTTLExtension(null);
-
-      expect(result.operationType).toBeNull();
-      expect(result.targetKey).toBeNull();
-    });
+    expect(results).toHaveLength(1);
+    expect(results[0].extend_to).toBe(500000);
+    expect(results[0].min_extension).toBe(17280);
+    expect(results[0].max_extension).toBe(34560);
+    expect(results[0].ledger).toBe(50000);
+    expect(results[0].tx_hash).toBe("TXHASH123");
   });
 
-  describe("extractTTLModifications", () => {
-    test("extracts all TTL modifications from transaction", () => {
-      const transaction = {
-        ledger: 50000,
-        hash: "TXHASH123",
-        timestamp: Date.now(),
-        operations: [
-          {
-            type: "extendContractCode",
-            codeHash: "HASH1",
-            extendTo: 100000,
+  test("extracts multiple TTL extensions from one transaction", () => {
+    const tx = {
+      ledger: 60000,
+      hash: "TXHASH456",
+      operations: [
+        {
+          hostFunction: {
+            function_name: "extend_contract_instance_ttl",
+            args: { extend_to: 500000, min_extension: 17280, max_extension: 34560 },
           },
-          {
-            type: "extendContractInstance",
-            contractId: "CONTRACT1",
-            extendTo: 100500,
+        },
+        {
+          hostFunction: {
+            function_name: "extend_contract_code_ttl",
+            args: { extend_to: 510000, min_extension: 17280, max_extension: 34560 },
           },
-        ],
-      };
+        },
+      ],
+    };
 
-      const result = extractTTLModifications(transaction);
-
-      expect(result).toHaveLength(2);
-      expect(result[0].operationType).toBe("ExtendCurrentContractCode");
-      expect(result[1].operationType).toBe("ExtendCurrentContractInstance");
-    });
+    expect(extractTTLExtensions(tx)).toHaveLength(2);
   });
 
-  describe("calculateRentPaid", () => {
-    test("calculates rent paid in stroops", () => {
-      const extensionOp = { costXlm: 0.5 };
-      const rent = calculateRentPaid(extensionOp);
+  test("handles legacy extendContractCode operation shape", () => {
+    const tx = {
+      ledger: 40000,
+      hash: "LEGACY",
+      operations: [{ type: "extendContractCode", extendTo: 100000 }],
+    };
 
-      expect(rent).toBe(5_000_000);
-    });
+    const results = extractTTLExtensions(tx);
 
-    test("returns 0 for missing cost", () => {
-      const rent = calculateRentPaid({});
-      expect(rent).toBe(0);
-    });
+    expect(results).toHaveLength(1);
+    expect(results[0].extend_to).toBe(100000);
+    expect(results[0].min_extension).toBeNull();
+  });
+
+  test("returns empty array for transaction with no TTL operations", () => {
+    const tx = {
+      ledger: 1,
+      hash: "X",
+      operations: [{ type: "transfer", amount: 100 }],
+    };
+
+    expect(extractTTLExtensions(tx)).toHaveLength(0);
+  });
+
+  test("returns empty array for null input", () => {
+    expect(extractTTLExtensions(null)).toHaveLength(0);
+  });
+});
+
+describe("formatTTLExtension", () => {
+  test("formats all three Protocol 26 fields", () => {
+    const label = formatTTLExtension({ extend_to: 500000, min_extension: 17280, max_extension: 34560 });
+
+    expect(label).toBe("Action: TTL Extension | Requested: +17280 Ledgers | Enforced Clamp: 34560 Ledgers | Extend To: 500000");
+  });
+
+  test("omits absent fields", () => {
+    const label = formatTTLExtension({ extend_to: null, min_extension: 17280, max_extension: null });
+
+    expect(label).toBe("Action: TTL Extension | Requested: +17280 Ledgers");
+  });
+
+  test("returns base label when all fields are null", () => {
+    expect(formatTTLExtension({ extend_to: null, min_extension: null, max_extension: null }))
+      .toBe("Action: TTL Extension");
   });
 });


### PR DESCRIPTION
Parse extend_contract_instance_ttl / extend_contract_code_ttl host function calls introduced in Protocol 26 and surface their parameters (extend_to, min_extension, max_extension) in the contract transaction ledger history.

Changes:
- ttlExtensionParser.js: rewritten to handle Protocol 26 host function shape; exports parseTTLHostFunction, extractTTLExtensions, and formatTTLExtension; retains legacy ExtendCurrentContractInstanceOp fallback for pre-P26 data
- decoder.js: calls parseTTLHostFunction on each incoming event and attaches ttl_extension + replaces description with the formatted label (Action: TTL Extension | Requested: +X Ledgers | Enforced Clamp: Y)
- db.js: adds ttl_extension JSONB column via idempotent ALTER TABLE and stores it in upsertEvent
- api.ts: adds ttl_extension field to DecodedEvent interface
- EventTable.tsx: renders TTLExtensionBadge (indigo pill) for events that carry ttl_extension data
- ttlExtensionParser.test.js: 16 tests covering all three exports and edge cases (partial fields, camelCase aliases, legacy ops, null input)
closes #166 