### PR TITLE
feat(#169): map fee-bump chain of custody (sponsor → channel → caller)

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -23,8 +23,10 @@ export interface StorageTiers {
 export interface FeeBumpInfo {
   /** Outer fee-paying account (the sponsor). */
   sponsor: string;
-  /** Inner transaction source account (the original caller). */
+  /** Inner transaction source account (channel account — provides sequence number for parallel execution). */
   inner_source: string;
+  /** Actual signing identity from Soroban auth credentials (who authorised the contract logic). */
+  actual_caller: string | null;
 }
 
 export interface DecodedEvent {
@@ -56,6 +58,8 @@ export interface DecodedEvent {
     min_extension: number | null;
     max_extension: number | null;
   };
+  // Issue #169: fee-bump chain of custody
+  fee_bump?: FeeBumpInfo | null;
 }
 
 export interface SourceFile {

--- a/frontend/src/components/FeeSponsorBanner.tsx
+++ b/frontend/src/components/FeeSponsorBanner.tsx
@@ -4,17 +4,44 @@ interface Props {
   feeBump: FeeBumpInfo;
 }
 
+/** Shorten a Stellar address for display. */
+function short(addr: string) {
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
 export default function FeeSponsorBanner({ feeBump }: Props) {
+  const tiers: { role: string; label: string; address: string; color: string }[] = [
+    {
+      role: "Sponsor",
+      label: "Paid the fee",
+      address: feeBump.sponsor,
+      color: "#f0a500",
+    },
+    {
+      role: "Channel Account",
+      label: "Provided sequence number",
+      address: feeBump.inner_source,
+      color: "#58a6ff",
+    },
+    ...(feeBump.actual_caller
+      ? [
+          {
+            role: "Actual Caller",
+            label: "Signed the contract logic",
+            address: feeBump.actual_caller,
+            color: "#3fb950",
+          },
+        ]
+      : []),
+  ];
+
   return (
     <div
       className="card"
-      style={{
-        marginTop: 12,
-        borderLeft: "3px solid var(--accent)",
-        background: "var(--surface, #1a1a2e)",
-      }}
+      style={{ marginTop: 12, borderLeft: "3px solid var(--accent)" }}
+      aria-label="Fee-bump chain of custody"
     >
-      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
         <span
           style={{
             fontSize: 11,
@@ -24,39 +51,46 @@ export default function FeeSponsorBanner({ feeBump }: Props) {
             color: "var(--accent)",
           }}
         >
-          Fee-Bump Sponsored Transaction
+          Fee-Bump · Chain of Custody
         </span>
       </div>
 
-      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-        <AccountRow
-          role="Paid by Sponsor"
-          address={feeBump.sponsor}
-          accent="#58a6ff"
-        />
-        <div style={{ display: "flex", alignItems: "center", paddingLeft: 8 }}>
-          <span style={{ fontSize: 11, color: "var(--muted)" }}>on behalf of</span>
-        </div>
-        <AccountRow
-          role="Caller"
-          address={feeBump.inner_source}
-          accent="var(--text)"
-        />
+      <div style={{ display: "flex", flexDirection: "column", gap: 0 }}>
+        {tiers.map((tier, i) => (
+          <div key={tier.role}>
+            <TierRow {...tier} />
+            {i < tiers.length - 1 && (
+              <div
+                aria-hidden="true"
+                style={{
+                  paddingLeft: 20,
+                  lineHeight: 1,
+                  color: "var(--muted)",
+                  fontSize: 14,
+                  userSelect: "none",
+                }}
+              >
+                ↓
+              </div>
+            )}
+          </div>
+        ))}
       </div>
     </div>
   );
 }
 
-function AccountRow({
+function TierRow({
   role,
+  label,
   address,
-  accent,
+  color,
 }: {
   role: string;
+  label: string;
   address: string;
-  accent: string;
+  color: string;
 }) {
-  const short = `${address.slice(0, 6)}…${address.slice(-4)}`;
   return (
     <div
       style={{
@@ -68,29 +102,29 @@ function AccountRow({
         background: "var(--bg)",
       }}
     >
+      {/* Coloured role pill */}
       <span
         style={{
           minWidth: 130,
           fontSize: 11,
-          fontWeight: 600,
-          color: "var(--muted)",
+          fontWeight: 700,
           textTransform: "uppercase",
           letterSpacing: "0.05em",
+          color,
         }}
       >
         {role}
       </span>
+
+      {/* Address */}
       <code
-        style={{
-          fontSize: 13,
-          fontFamily: "monospace",
-          color: accent,
-          wordBreak: "break-all",
-        }}
+        style={{ fontSize: 13, fontFamily: "monospace", color, wordBreak: "break-all" }}
         title={address}
       >
-        {short}
+        {short(address)}
       </code>
+
+      {/* Full address (truncated) */}
       <span
         style={{
           fontSize: 11,
@@ -104,6 +138,18 @@ function AccountRow({
         title={address}
       >
         {address}
+      </span>
+
+      {/* Role description */}
+      <span
+        style={{
+          fontSize: 11,
+          color: "var(--muted)",
+          whiteSpace: "nowrap",
+          fontStyle: "italic",
+        }}
+      >
+        {label}
       </span>
     </div>
   );

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -5,6 +5,7 @@ import ResourceCosts from "../components/ResourceCosts";
 import StorageTierBreakdown from "../components/StorageTierBreakdown";
 import FiatValue from "../components/FiatValue";
 import GasLimitAlert from "../components/GasLimitAlert";
+import FeeSponsorBanner from "../components/FeeSponsorBanner";
 
 /** Parse amount and symbol from a transfer description. */
 function parseTransfer(description: string): { amount: number; symbol: string } | null {

--- a/indexer/src/db.js
+++ b/indexer/src/db.js
@@ -88,6 +88,9 @@ export const db = {
       -- Protocol 26: TTL extension host function data (extend_to, min_extension, max_extension)
       ALTER TABLE events ADD COLUMN IF NOT EXISTS ttl_extension JSONB;
 
+      -- Issue #169: fee-bump chain of custody (sponsor, channel account, actual caller)
+      ALTER TABLE events ADD COLUMN IF NOT EXISTS fee_bump JSONB;
+
       -- Issue #117: sub-invocation indexing
       CREATE TABLE IF NOT EXISTS sub_invocations (
         id              BIGSERIAL PRIMARY KEY,
@@ -200,8 +203,8 @@ export const db = {
       `INSERT INTO events
          (contract_id, function, ledger, tx_hash, description, raw_topics, raw_data,
           cpu_instructions, mem_bytes, fee_charged, is_high_bloat_risk, upgrade_info, storage_tiers, is_clawback,
-          footprint_contention, ttl_extension)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)
+          footprint_contention, ttl_extension, fee_bump)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)
        ON CONFLICT DO NOTHING`,
       [
         ev.contract_id, ev.function, ev.ledger, ev.tx_hash,
@@ -213,6 +216,7 @@ export const db = {
         ev.is_clawback ?? false,
         ev.footprint_contention ?? false,
         ev.ttl_extension ? JSON.stringify(ev.ttl_extension) : null,
+        ev.fee_bump ? JSON.stringify(ev.fee_bump) : null,
       ]
     );
   },

--- a/indexer/src/feeBumpParser.js
+++ b/indexer/src/feeBumpParser.js
@@ -14,17 +14,51 @@ function muxedToGAddress(ma) {
 }
 
 /**
- * Inspect a TransactionEnvelope for a Fee-Bump wrapper.
+ * Extract the actual caller from the first Soroban authorization entry in the
+ * inner transaction's operations.
  *
- * A Stellar Fee-Bump transaction encloses an inner transaction so that an
- * external account (the sponsor) pays the network fee instead of the inner
- * transaction's source account (the caller).  We extract both parties so the
- * explorer can display:
- *   "Paid by Sponsor: GABC… on behalf of Caller: GXYZ…"
+ * In a high-throughput pipeline the inner transaction's source account is a
+ * channel account used only to provide a sequence number.  The real signing
+ * identity is recorded in the SorobanAuthorizationEntry credentials attached
+ * to the InvokeHostFunction operation.
+ *
+ * @param {xdr.Transaction} innerTx  Already-decoded inner transaction XDR object
+ * @returns {string | null}  G-address of the actual caller, or null if not found
+ */
+function extractActualCaller(innerTx) {
+  try {
+    for (const op of innerTx.operations()) {
+      if (op.body().switch().name !== "invokeHostFunction") continue;
+      const auths = op.body().invokeHostFunctionOp().auth();
+      for (const entry of auths) {
+        const creds = entry.credentials();
+        if (creds.switch().name === "sorobanCredentialsSourceAccount") continue;
+        const scAddr = creds.address().address();
+        if (scAddr.switch().name === "scAddressTypeAccount") {
+          return StrKey.encodeEd25519PublicKey(scAddr.accountId().ed25519());
+        }
+        if (scAddr.switch().name === "scAddressTypeContract") {
+          return StrKey.encodeContract(scAddr.contractId());
+        }
+      }
+    }
+  } catch { /* auth not present or malformed */ }
+  return null;
+}
+
+/**
+ * Inspect a TransactionEnvelope for a Fee-Bump wrapper and extract the full
+ * three-tier chain of custody:
+ *
+ *   Sponsor       — outer fee-paying account (who paid the gas)
+ *   inner_source  — inner transaction source account (channel account used
+ *                   solely to provide a sequence number for parallel execution)
+ *   actual_caller — signing identity from Soroban auth credentials (who
+ *                   actually authorised the contract logic)
  *
  * @param {xdr.TransactionEnvelope | string} envelopeXdr
  *   Accepts an already-decoded XDR object OR a base64-encoded string.
- * @returns {{ sponsor: string, inner_source: string } | null}
+ * @returns {{ sponsor: string, inner_source: string, actual_caller: string | null } | null}
  *   Returns null when the envelope is not a fee-bump transaction.
  */
 export function parseFeeBump(envelopeXdr) {
@@ -41,8 +75,9 @@ export function parseFeeBump(envelopeXdr) {
 
     const innerTx = fbTx.innerTx().v1().tx();
     const inner_source = muxedToGAddress(innerTx.sourceAccount());
+    const actual_caller = extractActualCaller(innerTx);
 
-    return { sponsor, inner_source };
+    return { sponsor, inner_source, actual_caller };
   } catch {
     return null;
   }

--- a/indexer/src/index.js
+++ b/indexer/src/index.js
@@ -13,7 +13,7 @@ import { multiNodeRpc } from "./rpcMultiNode.js";
 import { startMetricsCollector } from "./rpcMetrics.js";
 import { startPruner } from "./pruner.js";
 import { extractStateDiffs } from "./stateDiffIndexer.js";
-import { extractStateDiffs } from "./stateDiffIndexer.js"; // Issue #140
+import { parseFeeBump } from "./feeBumpParser.js";
 
 const RPC_URL      = process.env.SOROBAN_RPC_URL || "https://soroban-testnet.stellar.org";
 const START_LEDGER = Number(process.env.START_LEDGER || 0);
@@ -102,6 +102,19 @@ async function indexLedger(ledger) {
     // Flag footprint contention across transactions in this page's events
     scanFootprintContention(res.events);
 
+    // Issue #169: build a per-page txHash → feeBump cache to avoid redundant
+    // getTransaction calls when multiple events share the same transaction.
+    const feeBumpCache = new Map();
+    const uniqueTxHashes = [...new Set(res.events.map(e => e.txHash).filter(Boolean))];
+    await Promise.all(uniqueTxHashes.map(async (txHash) => {
+      try {
+        const txResult = await withRetry(() => rpc.getTransaction(txHash));
+        if (txResult?.envelopeXdr) {
+          feeBumpCache.set(txHash, parseFeeBump(txResult.envelopeXdr));
+        }
+      } catch { /* non-critical — skip fee-bump for this tx */ }
+    }));
+
     for (const ev of res.events) {
       const decoded = await decode(ev);
       decoded.is_high_bloat_risk = isHighBloatRisk(ev, ev.contractId);
@@ -114,6 +127,7 @@ async function indexLedger(ledger) {
       }
 
       decoded.storage_tiers = classifyStorageWrites(ev);
+      decoded.fee_bump = feeBumpCache.get(ev.txHash) ?? null;
       await db.upsertEvent(decoded);
 
       // Issue #140: persist per-key state diffs for the timeline

--- a/indexer/test/feeBumpParser.test.js
+++ b/indexer/test/feeBumpParser.test.js
@@ -1,0 +1,159 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { xdr, StrKey } from "@stellar/stellar-sdk";
+import { parseFeeBump } from "../src/feeBumpParser.js";
+
+// ── Key fixtures ──────────────────────────────────────────────────────────────
+
+const SPONSOR_KEY  = Buffer.alloc(32, 0xaa);
+const CHANNEL_KEY  = Buffer.alloc(32, 0xbb);
+const CALLER_KEY   = Buffer.alloc(32, 0xcc);
+const CONTRACT_KEY = Buffer.alloc(32, 0x01);
+
+const SPONSOR_ADDR  = StrKey.encodeEd25519PublicKey(SPONSOR_KEY);
+const CHANNEL_ADDR  = StrKey.encodeEd25519PublicKey(CHANNEL_KEY);
+const CALLER_ADDR   = StrKey.encodeEd25519PublicKey(CALLER_KEY);
+
+// ── XDR builders ─────────────────────────────────────────────────────────────
+
+/** Build a SorobanAuthorizationEntry with address credentials for CALLER_KEY. */
+function makeCallerAuthEntry() {
+  const invocation = new xdr.SorobanAuthorizedInvocation({
+    function: xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(
+      new xdr.InvokeContractArgs({
+        contractAddress: xdr.ScAddress.scAddressTypeContract(CONTRACT_KEY),
+        functionName: "swap",
+        args: [],
+      })
+    ),
+    subInvocations: [],
+  });
+
+  return new xdr.SorobanAuthorizationEntry({
+    credentials: xdr.SorobanCredentials.sorobanCredentialsAddress(
+      new xdr.SorobanAddressCredentials({
+        address: xdr.ScAddress.scAddressTypeAccount(
+          xdr.AccountId.publicKeyTypeEd25519(CALLER_KEY)
+        ),
+        nonce: xdr.Int64.fromString("0"),
+        signatureExpirationLedger: 0,
+        signature: xdr.ScVal.scvVoid(),
+      })
+    ),
+    rootInvocation: invocation,
+  });
+}
+
+/** Build a minimal InvokeHostFunction operation with the given auth entries. */
+function makeInvokeOp(authEntries) {
+  return new xdr.Operation({
+    sourceAccount: null,
+    body: xdr.OperationBody.invokeHostFunction(
+      new xdr.InvokeHostFunctionOp({
+        hostFunction: xdr.HostFunction.hostFunctionTypeInvokeContract(
+          new xdr.InvokeContractArgs({
+            contractAddress: xdr.ScAddress.scAddressTypeContract(CONTRACT_KEY),
+            functionName: "swap",
+            args: [],
+          })
+        ),
+        auth: authEntries,
+      })
+    ),
+  });
+}
+
+/** Build a fee-bump envelope wrapping an inner v1 transaction. */
+function makeFeeBumpEnvelope({ withCallerAuth = true } = {}) {
+  const authEntries = withCallerAuth ? [makeCallerAuthEntry()] : [];
+
+  const innerTx = new xdr.Transaction({
+    sourceAccount: xdr.MuxedAccount.keyTypeEd25519(CHANNEL_KEY),
+    fee: 100,
+    seqNum: xdr.SequenceNumber.fromString("1"),
+    cond: xdr.Preconditions.precondNone(),
+    memo: xdr.Memo.memoNone(),
+    operations: [makeInvokeOp(authEntries)],
+    ext: new xdr.TransactionExt(0),
+  });
+
+  const innerEnv = xdr.FeeBumpTransactionInnerTx.envelopeTypeTx(
+    new xdr.TransactionV1Envelope({ tx: innerTx, signatures: [] })
+  );
+
+  const fbTx = new xdr.FeeBumpTransaction({
+    feeSource: xdr.MuxedAccount.keyTypeEd25519(SPONSOR_KEY),
+    fee: xdr.Int64.fromString("1000"),
+    innerTx: innerEnv,
+    ext: new xdr.FeeBumpTransactionExt(0),
+  });
+
+  return xdr.TransactionEnvelope.envelopeTypeTxFeeBump(
+    new xdr.FeeBumpTransactionEnvelope({ tx: fbTx, signatures: [] })
+  ).toXDR("base64");
+}
+
+/** Build a plain (non-fee-bump) v1 envelope. */
+function makePlainEnvelope() {
+  const tx = new xdr.Transaction({
+    sourceAccount: xdr.MuxedAccount.keyTypeEd25519(CHANNEL_KEY),
+    fee: 100,
+    seqNum: xdr.SequenceNumber.fromString("1"),
+    cond: xdr.Preconditions.precondNone(),
+    memo: xdr.Memo.memoNone(),
+    operations: [],
+    ext: new xdr.TransactionExt(0),
+  });
+
+  return xdr.TransactionEnvelope.envelopeTypeTx(
+    new xdr.TransactionV1Envelope({ tx, signatures: [] })
+  ).toXDR("base64");
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("parseFeeBump", () => {
+  it("returns null for a non-fee-bump envelope", () => {
+    assert.equal(parseFeeBump(makePlainEnvelope()), null);
+  });
+
+  it("returns null for invalid input", () => {
+    assert.equal(parseFeeBump("not-valid-xdr"), null);
+    assert.equal(parseFeeBump(null), null);
+  });
+
+  it("extracts sponsor from the outer fee-bump feeSource", () => {
+    const result = parseFeeBump(makeFeeBumpEnvelope());
+    assert.equal(result.sponsor, SPONSOR_ADDR);
+  });
+
+  it("extracts inner_source (channel account) from the inner tx sourceAccount", () => {
+    const result = parseFeeBump(makeFeeBumpEnvelope());
+    assert.equal(result.inner_source, CHANNEL_ADDR);
+  });
+
+  it("extracts actual_caller from Soroban auth credentials", () => {
+    const result = parseFeeBump(makeFeeBumpEnvelope({ withCallerAuth: true }));
+    assert.equal(result.actual_caller, CALLER_ADDR);
+  });
+
+  it("sets actual_caller to null when no Soroban auth credentials are present", () => {
+    const result = parseFeeBump(makeFeeBumpEnvelope({ withCallerAuth: false }));
+    assert.equal(result.actual_caller, null);
+  });
+
+  it("returns all three tiers as distinct addresses", () => {
+    const result = parseFeeBump(makeFeeBumpEnvelope());
+    assert.notEqual(result.sponsor, result.inner_source);
+    assert.notEqual(result.inner_source, result.actual_caller);
+    assert.notEqual(result.sponsor, result.actual_caller);
+  });
+
+  it("accepts a pre-decoded XDR object (not just base64 string)", () => {
+    const env = xdr.TransactionEnvelope.fromXDR(makeFeeBumpEnvelope(), "base64");
+    const result = parseFeeBump(env);
+    assert.equal(result.sponsor, SPONSOR_ADDR);
+    assert.equal(result.inner_source, CHANNEL_ADDR);
+    assert.equal(result.actual_caller, CALLER_ADDR);
+  });
+});


### PR DESCRIPTION
closes #169 
- feeBumpParser: extract actual_caller from SorobanAuthorizationEntry credentials
- db: add fee_bump JSONB column; update upsertEvent
- index: per-page getTransaction cache; attach fee_bump to decoded events
- api.ts: add actual_caller to FeeBumpInfo; add fee_bump to DecodedEvent
- FeeSponsorBanner: three-tier visual (sponsor/channel account/actual caller)
- EventPage: import FeeSponsorBanner
- test: 8 passing tests for parseFeeBump