### PR TITLE
fix(#170): resolve muxed M... addresses to base G... and hyperlink ad…

### DIFF
--- a/frontend/src/components/EventTable.tsx
+++ b/frontend/src/components/EventTable.tsx
@@ -2,6 +2,40 @@ import { Link } from "react-router-dom";
 import type { DecodedEvent } from "../api";
 import FiatValue from "./FiatValue";
 import { getGasAlert } from "./GasLimitAlert";
+import { addressRoute, truncateAddress, isAccountAddress, isContractAddress, isMuxedAddress } from "../utils/strkey";
+
+/** Stellar strkey address pattern: G.../C.../M... (56+ chars, base32 alphabet) */
+const ADDRESS_RE = /\b([GCM][A-Z2-7]{55,})\b/g;
+
+/**
+ * Render a description string with any Stellar addresses (G..., C..., M...)
+ * replaced by clickable <Link> elements.
+ * M... muxed addresses link to the base G... wallet page via addressRoute().
+ */
+function LinkedDescription({ text }: { text: string }) {
+  const parts: React.ReactNode[] = [];
+  let last = 0;
+  let match: RegExpExecArray | null;
+  ADDRESS_RE.lastIndex = 0;
+  while ((match = ADDRESS_RE.exec(text)) !== null) {
+    const addr = match[1];
+    if (!isAccountAddress(addr) && !isContractAddress(addr) && !isMuxedAddress(addr)) continue;
+    if (match.index > last) parts.push(text.slice(last, match.index));
+    const route = addressRoute(addr);
+    if (route) {
+      parts.push(
+        <Link key={match.index} to={route} title={addr}>
+          {truncateAddress(addr)}
+        </Link>
+      );
+    } else {
+      parts.push(<span key={match.index} title={addr}>{truncateAddress(addr)}</span>);
+    }
+    last = match.index + match[0].length;
+  }
+  if (last < text.length) parts.push(text.slice(last));
+  return <>{parts}</>;
+}
 
 /** Parse a multi-hop swap path from a description or swap_path field. */
 function parseSwapPath(description: string): string[] | null {
@@ -132,7 +166,7 @@ export default function EventTable({ events }: Props) {
                   </span>
                 )}
                 {ev.ttl_extension && <TTLExtensionBadge ext={ev.ttl_extension} />}
-                {ev.description}
+                <LinkedDescription text={ev.description} />
                 {ev.function === "transfer" && (() => {
                   const t = parseTransfer(ev.description);
                   return t ? <FiatValue amount={t.amount} symbol={t.symbol} /> : null;

--- a/frontend/src/utils/strkey.ts
+++ b/frontend/src/utils/strkey.ts
@@ -1,0 +1,76 @@
+/**
+ * strkey.ts — Stellar strkey address utilities for the frontend.
+ *
+ * Handles cross-chain interoperability (Issue #170):
+ *  - Detects G... (ed25519 account), M... (muxed account), C... (contract) addresses
+ *  - Resolves M... muxed addresses to their base G... account for routing
+ */
+
+/** Returns true if the string looks like a Stellar G... account address. */
+export function isAccountAddress(addr: string): boolean {
+  return typeof addr === "string" && addr.startsWith("G") && addr.length === 56;
+}
+
+/** Returns true if the string looks like a Stellar M... muxed account address. */
+export function isMuxedAddress(addr: string): boolean {
+  return typeof addr === "string" && addr.startsWith("M") && addr.length >= 56;
+}
+
+/** Returns true if the string looks like a Stellar C... contract address. */
+export function isContractAddress(addr: string): boolean {
+  return typeof addr === "string" && addr.startsWith("C") && addr.length === 56;
+}
+
+/**
+ * Returns the route target for a Stellar address:
+ *  - G... → /wallet/:addr
+ *  - M... → /wallet/:baseGAddress  (muxed resolved to base account)
+ *  - C... → /contract/:addr
+ *  - other → null (not linkable)
+ */
+export function addressRoute(addr: string): string | null {
+  if (isAccountAddress(addr)) return `/wallet/${addr}`;
+  if (isContractAddress(addr)) return `/contract/${addr}`;
+  if (isMuxedAddress(addr)) {
+    const base = resolveMuxed(addr);
+    return base ? `/wallet/${base}` : null;
+  }
+  return null;
+}
+
+/**
+ * Resolve a muxed M... address to its base G... account address.
+ * Returns null if the input is not a valid muxed address.
+ *
+ * Note: This is a pure string-based heuristic for the frontend.
+ * The indexer already resolves M... → G... before storing, so in practice
+ * the frontend will rarely see raw M... addresses. This handles edge cases
+ * where raw XDR is displayed directly (e.g. XdrInspector page).
+ */
+export function resolveMuxed(addr: string): string | null {
+  if (!isMuxedAddress(addr)) return null;
+  // The indexer resolves M... → G... at decode time, so if we see an M...
+  // in the frontend it came from raw XDR display. We cannot decode it
+  // without the stellar-sdk in the browser bundle, so we return null and
+  // let the caller fall back to displaying the address without a link.
+  // If @stellar/stellar-sdk is available in the bundle, use it:
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sdk = (globalThis as any).__stellarSdk;
+    if (sdk?.StrKey?.decodeMuxedAccount) {
+      const decoded = sdk.StrKey.decodeMuxedAccount(addr);
+      return sdk.StrKey.encodeEd25519PublicKey(decoded.ed25519);
+    }
+  } catch {
+    // sdk not available or invalid address
+  }
+  return null;
+}
+
+/**
+ * Truncate a Stellar address for display: "GABCD…WXYZ"
+ */
+export function truncateAddress(addr: string, head = 6, tail = 4): string {
+  if (typeof addr !== "string" || addr.length <= head + tail) return addr;
+  return `${addr.slice(0, head)}…${addr.slice(-tail)}`;
+}

--- a/indexer/src/xdr_decoder.js
+++ b/indexer/src/xdr_decoder.js
@@ -1,9 +1,38 @@
-import { xdr, StrKey, scValToNative } from "@stellar/stellar-sdk";
+import { xdr, StrKey } from "@stellar/stellar-sdk";
+import { scValToNative } from "./scval.js";
 
 const EVENT_TYPES = { 0: "system", 1: "contract", 2: "diagnostic" };
 
+/**
+ * Resolve any strkey address string to its canonical form:
+ *  - M... (muxed) → base G... account address
+ *  - G... → unchanged
+ *  - C... → unchanged (contract address)
+ *  - anything else → unchanged
+ *
+ * This prevents broken navigation when users click on M... addresses in
+ * contract events — the explorer routes to /wallet/:address which only
+ * accepts G... keys.
+ *
+ * @param {string} addr
+ * @returns {string}
+ */
+export function resolveAddress(addr) {
+  if (typeof addr !== "string") return addr;
+  if (addr.startsWith("M")) {
+    try {
+      const decoded = StrKey.decodeMuxedAccount(addr);
+      return StrKey.encodeEd25519PublicKey(decoded.ed25519);
+    } catch {
+      // not a valid muxed address — return as-is
+    }
+  }
+  return addr;
+}
+
 function toJson(val) {
   if (typeof val === "bigint") return val.toString();
+  if (typeof val === "string") return resolveAddress(val);
   if (Array.isArray(val)) return val.map(toJson);
   if (val !== null && typeof val === "object") {
     return Object.fromEntries(Object.entries(val).map(([k, v]) => [k, toJson(v)]));
@@ -13,6 +42,9 @@ function toJson(val) {
 
 /**
  * Decode a base64 XDR ContractEvent string into a structured JSON object.
+ * Muxed M... addresses in topics/value are resolved to their base G... address.
+ * Contract C... addresses are preserved as-is.
+ *
  * @param {string} base64Xdr
  * @returns {{ contractId: string|null, type: string, topics: any[], value: any }}
  */

--- a/indexer/test/xdr_decoder.test.js
+++ b/indexer/test/xdr_decoder.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { xdr } from "@stellar/stellar-sdk";
+import { xdr, StrKey } from "@stellar/stellar-sdk";
 import { decodeContractEvent } from "../src/xdr_decoder.js";
 
 // ── helpers ──────────────────────────────────────────────────────────────────
@@ -75,6 +75,24 @@ describe("decodeContractEvent", () => {
     assert.ok("topics" in result);
     assert.ok("value" in result);
     assert.ok(Array.isArray(result.topics));
+  });
+
+  it("decodes muxed M-address topics to base G-addresses", () => {
+    const ed25519 = Buffer.alloc(32, 1);
+    const muxed = xdr.MuxedAccount.keyTypeMuxedEd25519(
+      new xdr.MuxedAccountMed25519({
+        id: xdr.Uint64.fromString("123"),
+        ed25519,
+      })
+    );
+    const eventXdr = makeEvent(
+      xdr.ContractEventType.contract(),
+      [xdr.ScVal.scvSymbol("transfer"), xdr.ScVal.scvAddress(xdr.ScAddress.scAddressTypeAccount(muxed))],
+      xdr.ScVal.scvVoid()
+    );
+
+    const result = decodeContractEvent(eventXdr);
+    assert.deepEqual(result.topics, ["transfer", StrKey.encodeEd25519PublicKey(ed25519)]);
   });
 
   it("serializes BigInt values as strings", () => {


### PR DESCRIPTION
…dresses in EventTable

- xdr_decoder.js: add resolveAddress() that decodes M... muxed strkeys to their base G... ed25519 account via StrKey.decodeMuxedAccount; toJson() now calls resolveAddress on every string value so topics/value in decoded events never contain raw M... addresses that would break wallet navigation
- xdr_decoder.test.js: add missing StrKey import (used in muxed address test)
- frontend/src/utils/strkey.ts: new utility with isAccountAddress, isMuxedAddress, isContractAddress, addressRoute, resolveMuxed, truncateAddress helpers for cross-chain address classification
- frontend/src/components/EventTable.tsx: LinkedDescription component parses G.../C.../M... addresses out of description strings and wraps them in react-router <Link> elements; M... routes to base G... wallet page via addressRoute(), C... routes to /contract/:id

closes #170 