### PR TITLE
feat: render live TTL status and expiration progress bars (#165)

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -173,6 +173,14 @@ export interface TxStatusResponse {
   error?: string | null;
 }
 
+// Issue #165: Live TTL status for contract instance and code entries
+export interface ContractTTL {
+  contract_id: string;
+  current_ledger: number;
+  instance: { live_until_ledger: number | null };
+  code:     { live_until_ledger: number | null };
+}
+
 export interface CircuitBreakerStatus {
   has_circuit_breaker: boolean;
   is_paused: boolean;
@@ -242,6 +250,9 @@ export const api = {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     }).then(r => { if (!r.ok) throw new Error(`API ${r.status}`); return r.json(); }),
+
+  // Issue #165: live TTL status (instance + code expiration ledgers)
+  contractTTL: (id: string) => get<ContractTTL>(`/contracts/${id}/ttl`),
 
   // Issue #140: state-diff timeline
   stateDiffs: (id: string, key?: string) => {

--- a/frontend/src/components/TTLProgressBar.tsx
+++ b/frontend/src/components/TTLProgressBar.tsx
@@ -1,0 +1,121 @@
+/**
+ * TTLProgressBar — Issue #165
+ * Renders a labelled progress bar for a single TTL entry (instance or code).
+ * Shows remaining ledgers, estimated time, and expiration ledger number.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api";
+
+const SECS_PER_LEDGER = 5; // ~5 s per ledger on Stellar mainnet/testnet
+
+function formatRemaining(ledgers: number): string {
+  const secs = ledgers * SECS_PER_LEDGER;
+  const days = Math.floor(secs / 86400);
+  const hours = Math.floor((secs % 86400) / 3600);
+  const mins = Math.floor((secs % 3600) / 60);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${mins}m`;
+  return `${mins}m`;
+}
+
+function statusColor(pct: number): string {
+  if (pct <= 0) return "#6b7280";   // expired — grey
+  if (pct < 10) return "#ef4444";   // critical — red
+  if (pct < 25) return "#f59e0b";   // warning — amber
+  return "#10b981";                  // healthy — green
+}
+
+interface BarProps {
+  label: string;
+  liveUntilLedger: number | null;
+  currentLedger: number;
+}
+
+function Bar({ label, liveUntilLedger, currentLedger }: BarProps) {
+  if (liveUntilLedger === null) {
+    return (
+      <div style={{ marginBottom: 12 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", fontSize: 12, color: "var(--muted)", marginBottom: 4 }}>
+          <span>{label}</span>
+          <span>unavailable</span>
+        </div>
+        <div style={{ height: 6, background: "var(--border)", borderRadius: 3 }} />
+      </div>
+    );
+  }
+
+  const remaining = Math.max(0, liveUntilLedger - currentLedger);
+  // Use a 3-month window (~1.5M ledgers) as the "full" reference for the bar
+  const FULL_WINDOW = 1_555_200; // 90 days × 86400 s / 5 s per ledger
+  const pct = Math.min(100, (remaining / FULL_WINDOW) * 100);
+  const color = statusColor(pct);
+  const isExpired = remaining === 0;
+
+  return (
+    <div style={{ marginBottom: 12 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", fontSize: 12, marginBottom: 4 }}>
+        <span style={{ color: "var(--muted)" }}>{label}</span>
+        <span style={{ color, fontWeight: 600 }}>
+          {isExpired
+            ? "Expired"
+            : `${remaining.toLocaleString()} ledgers · ${formatRemaining(remaining)}`}
+        </span>
+      </div>
+      <div
+        style={{ height: 6, background: "var(--border, #2a2a3e)", borderRadius: 3, overflow: "hidden" }}
+        role="progressbar"
+        aria-valuenow={Math.round(pct)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`${label} TTL`}
+      >
+        <div
+          style={{
+            height: "100%",
+            width: `${Math.max(isExpired ? 0 : 1, pct)}%`,
+            background: color,
+            borderRadius: 3,
+            transition: "width 0.4s ease",
+          }}
+        />
+      </div>
+      <div style={{ fontSize: 11, color: "var(--muted)", marginTop: 3 }}>
+        Expires at ledger {liveUntilLedger.toLocaleString()}
+      </div>
+    </div>
+  );
+}
+
+interface TTLProgressBarProps {
+  contractId: string;
+}
+
+export default function TTLProgressBar({ contractId }: TTLProgressBarProps) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["contract-ttl", contractId],
+    queryFn: () => api.contractTTL(contractId),
+    refetchInterval: 30_000, // refresh every 30 s
+    enabled: !!contractId,
+  });
+
+  if (isLoading) return <p style={{ color: "var(--muted)", fontSize: 13 }}>Loading TTL…</p>;
+  if (isError || !data) return null;
+
+  return (
+    <div
+      className="card"
+      style={{ padding: "14px 16px" }}
+      aria-label="Contract TTL status"
+    >
+      <h3 style={{ fontSize: 13, marginBottom: 12, color: "var(--muted)", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+        TTL / Expiration
+      </h3>
+      <Bar label="Instance" liveUntilLedger={data.instance.live_until_ledger} currentLedger={data.current_ledger} />
+      <Bar label="Code (WASM)" liveUntilLedger={data.code.live_until_ledger} currentLedger={data.current_ledger} />
+      <div style={{ fontSize: 11, color: "var(--muted)", marginTop: 4 }}>
+        Current ledger: {data.current_ledger.toLocaleString()} · ~{SECS_PER_LEDGER}s per ledger
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ContractPage.tsx
+++ b/frontend/src/pages/ContractPage.tsx
@@ -17,6 +17,7 @@ import NetworkComparison from "../components/NetworkComparison";
 import AddressConnectionGraph from "../components/AddressConnectionGraph";
 import WasmHashZone from "../components/WasmHashZone";
 import { useLocalAbi } from "../hooks/useLocalAbi";
+import TTLProgressBar from "../components/TTLProgressBar";
 
 // Demo source shown when no verified source is uploaded
 const DEMO_SOURCE = `// Verified source not yet uploaded for this contract.
@@ -346,6 +347,9 @@ export default function ContractPage() {
               <WasmHashZone />
             </div>
           </details>
+
+          {/* Issue #165: Live TTL expiration progress bars */}
+          <TTLProgressBar contractId={id} />
 
           {meta.functions.length > 0 && (
             <div className="card">

--- a/indexer/src/api.js
+++ b/indexer/src/api.js
@@ -399,6 +399,66 @@ export function startApi() {
     } catch (e) { res.status(500).json({ error: e.message }); }
   });
 
+  // ── Issue #165: Live TTL status for contract instance, code, and persistent storage ──
+  // GET /api/contracts/:id/ttl
+  // Queries the Soroban RPC getLedgerEntries for the contract's instance and code
+  // ledger keys, then returns expiration ledgers alongside the current ledger height.
+  app.get("/api/contracts/:id/ttl", async (req, res) => {
+    try {
+      const contractId = req.params.id;
+      const { SorobanRpc, xdr, Address } = await import("@stellar/stellar-sdk");
+      const server = new SorobanRpc.Server(RPC_URL);
+
+      // Build ledger keys for instance and code entries
+      const contractAddress = Address.fromString(contractId);
+      const instanceKey = xdr.LedgerKey.contractData(
+        new xdr.LedgerKeyContractData({
+          contract: contractAddress.toScAddress(),
+          key: xdr.ScVal.scvLedgerKeyContractInstance(),
+          durability: xdr.ContractDataDurability.persistent(),
+        })
+      );
+      const codeKey = xdr.LedgerKey.contractCode(
+        new xdr.LedgerKeyContractCode({
+          hash: Buffer.alloc(32), // placeholder; resolved below from instance
+        })
+      );
+
+      // Fetch instance entry first to get the WASM hash for the code key
+      const instanceResult = await server.getLedgerEntries(instanceKey);
+      const instanceEntry = instanceResult.entries?.[0] ?? null;
+
+      let instanceTTL = null;
+      let codeTTL = null;
+      let currentLedger = instanceResult.latestLedger ?? 0;
+
+      if (instanceEntry) {
+        instanceTTL = instanceEntry.liveUntilLedgerSeq ?? null;
+
+        // Extract WASM hash from the instance entry to build the code key
+        try {
+          const contractInstance = instanceEntry.val.contractData().val().instance();
+          const wasmHash = contractInstance.executable().wasmHash();
+          const resolvedCodeKey = xdr.LedgerKey.contractCode(
+            new xdr.LedgerKeyContractCode({ hash: wasmHash })
+          );
+          const codeResult = await server.getLedgerEntries(resolvedCodeKey);
+          const codeEntry = codeResult.entries?.[0] ?? null;
+          if (codeEntry) codeTTL = codeEntry.liveUntilLedgerSeq ?? null;
+        } catch {
+          // WASM hash extraction failed — code TTL unavailable
+        }
+      }
+
+      res.json({
+        contract_id: contractId,
+        current_ledger: currentLedger,
+        instance: { live_until_ledger: instanceTTL },
+        code:     { live_until_ledger: codeTTL },
+      });
+    } catch (e) { res.status(500).json({ error: e.message }); }
+  });
+
   // ── Issue #139: GraphQL endpoint ───────────────────────────────────────────
   attachGraphQL(app);
 


### PR DESCRIPTION
## Summary

Closes #165.

Gives users visual clarity over when a contract entry will be archived or permanently deleted.

## Changes

**Indexer**
- `GET /api/contracts/:id/ttl` — fetches instance and code ledger entry expiration ledgers via `SorobanRpc.getLedgerEntries`. Resolves the WASM hash from the instance entry to look up the code entry TTL.

**Frontend**
- `ContractTTL` interface + `api.contractTTL()` in `api.ts`
- New `TTLProgressBar` component: two labelled bars (Instance, Code/WASM), color-coded green/amber/red/grey, ledger countdown + estimated days/hours at ~5s/ledger, auto-refreshes every 30s, accessible via ARIA attributes
- Rendered in ContractPage → Overview tab between the WASM hash zone and Functions list

## Files changed
- `indexer/src/api.js` — new TTL endpoint
- `frontend/src/api.ts` — ContractTTL type + api method
- `frontend/src/components/TTLProgressBar.tsx` — new component
- `frontend/src/pages/ContractPage.tsx` — import + render