### PR TITLE
feat(#168): SAC side-effect detection — auto-created account & trustl…

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -56,6 +56,8 @@ export interface DecodedEvent {
     min_extension: number | null;
     max_extension: number | null;
   };
+  // Issue #168: SAC implicit side-effect on the recipient address
+  sac_side_effect?: "account_created" | "trustline_opened";
 }
 
 export interface SourceFile {

--- a/frontend/src/components/EventTable.tsx
+++ b/frontend/src/components/EventTable.tsx
@@ -49,6 +49,36 @@ function FunctionBadge({ fn }: { fn: string }) {
   return <span className="badge">{fn}</span>;
 }
 
+/** Badge for SAC implicit side-effects (auto-created account or trustline). */
+function SacSideEffectBadge({ kind }: { kind: NonNullable<DecodedEvent["sac_side_effect"]> }) {
+  const isAccountCreated = kind === "account_created";
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        padding: "2px 8px",
+        background: isAccountCreated ? "rgba(16,185,129,0.12)" : "rgba(59,130,246,0.12)",
+        border: `1px solid ${isAccountCreated ? "#10b981" : "#3b82f6"}`,
+        borderRadius: 4,
+        fontSize: 11,
+        color: isAccountCreated ? "#34d399" : "#60a5fa",
+        whiteSpace: "nowrap",
+        marginRight: 6,
+        verticalAlign: "middle",
+      }}
+      title={
+        isAccountCreated
+          ? "SAC implicitly created a new Stellar account entry for this recipient"
+          : "SAC implicitly opened a trustline for this asset on the recipient account"
+      }
+    >
+      {isAccountCreated ? "⬡ SAC Auto-Created Account Entry" : "⬡ SAC Native Trustline Open"}
+    </span>
+  );
+}
+
 /** Inline badge for Protocol 26 TTL extension events. */
 function TTLExtensionBadge({ ext }: { ext: NonNullable<DecodedEvent["ttl_extension"]> }) {
   return (
@@ -132,6 +162,7 @@ export default function EventTable({ events }: Props) {
                   </span>
                 )}
                 {ev.ttl_extension && <TTLExtensionBadge ext={ev.ttl_extension} />}
+                {ev.sac_side_effect && <SacSideEffectBadge kind={ev.sac_side_effect} />}
                 {ev.description}
                 {ev.function === "transfer" && (() => {
                   const t = parseTransfer(ev.description);

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -42,6 +42,37 @@ export default function EventPage() {
             }
           />
         )}
+        {ev.sac_side_effect && (
+          <Row
+            label="SAC Side-Effect"
+            value={
+              <span
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 6,
+                  padding: "3px 10px",
+                  background: ev.sac_side_effect === "account_created"
+                    ? "rgba(16,185,129,0.12)"
+                    : "rgba(59,130,246,0.12)",
+                  border: `1px solid ${ev.sac_side_effect === "account_created" ? "#10b981" : "#3b82f6"}`,
+                  borderRadius: 4,
+                  fontSize: 12,
+                  color: ev.sac_side_effect === "account_created" ? "#34d399" : "#60a5fa",
+                }}
+                title={
+                  ev.sac_side_effect === "account_created"
+                    ? "SAC implicitly created a new Stellar account entry for this recipient"
+                    : "SAC implicitly opened a trustline for this asset on the recipient account"
+                }
+              >
+                {ev.sac_side_effect === "account_created"
+                  ? "⬡ SAC Auto-Created Account Entry"
+                  : "⬡ SAC Native Trustline Open"}
+              </span>
+            }
+          />
+        )}
         <Row label="Ledger"      value={ev.ledger.toLocaleString()} />
         <Row label="Contract"    value={<Link to={`/contract/${ev.contract_id}`}>{ev.contract_id}</Link>} />
         {ev.tx_hash && <Row label="Tx Hash" value={ev.tx_hash} mono />}

--- a/indexer/src/decoder.js
+++ b/indexer/src/decoder.js
@@ -65,7 +65,8 @@ function extractGasCosts(ev) {
   return result;
 }
 import { db } from "./db.js";
-import { sacLabel, detectSac } from "./sac.js";
+import { sacLabel, detectSac, detectSacAsset } from "./sac.js";
+import { classifySacSideEffect } from "./sacSideEffect.js";
 import { extractRoleAssignment } from "./roleTracker.js";
 import { decodeRwaEvent } from "./rwaDecoder.js";
 
@@ -114,6 +115,7 @@ export async function decode(ev) {
   const vaultMeta = await db.getVault(contractId).catch(() => null);
 
   const { isSac, assetCode } = detectSac(contractId);
+  const { assetIssuer } = detectSacAsset(contractId);
   const contractLabel = vaultMeta?.name
     ? `${vaultMeta.name} (Vault)`
     : isSac
@@ -161,6 +163,18 @@ export async function decode(ev) {
     decoded.ttl_extension = ttlExt;
     // Enrich description so the ledger history row is self-explanatory
     decoded.description = formatTTLExtension(ttlExt);
+  }
+
+  // SAC side-effect: detect auto-created account entry or implicit trustline open
+  if (isSac && (fnName === "transfer" || fnName === "mint")) {
+    // transfer topics: [fn, from, to] → to is topics[2]
+    // mint topics:     [fn, to]       → to is topics[1]
+    const toAddr = fnName === "transfer" ? topics[2] : topics[1];
+    if (typeof toAddr === "string" && toAddr.startsWith("G")) {
+      classifySacSideEffect(toAddr, assetCode, assetIssuer)
+        .then(kind => { if (kind) decoded.sac_side_effect = kind; })
+        .catch(() => {});
+    }
   }
 
   // Persist role assignment if this event carries one

--- a/indexer/src/sac.js
+++ b/indexer/src/sac.js
@@ -9,9 +9,9 @@ import { Asset, Contract, Networks } from "@stellar/stellar-sdk";
 const NETWORK_PASSPHRASE = process.env.NETWORK_PASSPHRASE || Networks.TESTNET;
 
 /**
- * Build a lookup map of SAC contract ID → classic asset code for a list of assets.
+ * Build a lookup map of SAC contract ID → { code, issuer } for a list of assets.
  * @param {Array<{code: string, issuer?: string}>} assets
- * @returns {Map<string, string>}  contractId → "USDC" | "XLM" etc.
+ * @returns {Map<string, {code: string, issuer: string|null}>}
  */
 function buildSacMap(assets) {
   const map = new Map();
@@ -19,7 +19,7 @@ function buildSacMap(assets) {
     try {
       const asset = issuer ? new Asset(code, issuer) : Asset.native();
       const contractId = new Contract(asset.contractId(NETWORK_PASSPHRASE)).contractId();
-      map.set(contractId, issuer ? code : "XLM");
+      map.set(contractId, { code: issuer ? code : "XLM", issuer: issuer ?? null });
     } catch {
       // skip malformed entries
     }
@@ -41,8 +41,22 @@ const _sacMap = buildSacMap(KNOWN_ASSETS);
  * @returns {{ isSac: boolean, assetCode: string|null }}
  */
 export function detectSac(contractId) {
-  const assetCode = _sacMap.get(contractId) ?? null;
-  return { isSac: assetCode !== null, assetCode };
+  const entry = _sacMap.get(contractId) ?? null;
+  return { isSac: entry !== null, assetCode: entry?.code ?? null };
+}
+
+/**
+ * Full asset info for a SAC contract ID.
+ * @param {string} contractId
+ * @returns {{ isSac: boolean, assetCode: string|null, assetIssuer: string|null }}
+ */
+export function detectSacAsset(contractId) {
+  const entry = _sacMap.get(contractId) ?? null;
+  return {
+    isSac: entry !== null,
+    assetCode: entry?.code ?? null,
+    assetIssuer: entry?.issuer ?? null,
+  };
 }
 
 /**

--- a/indexer/src/sacSideEffect.js
+++ b/indexer/src/sacSideEffect.js
@@ -1,0 +1,76 @@
+/**
+ * SAC side-effect detection.
+ *
+ * When the Stellar Asset Contract transfers tokens to a G-address that either:
+ *   (a) does not exist on-chain yet  → "SAC Auto-Created Account Entry"
+ *   (b) exists but has no trustline  → "SAC Native Trustline Open"
+ *
+ * We probe Horizon once per (address, assetCode) pair and cache the result for
+ * the lifetime of the process so we never re-query the same address twice.
+ */
+
+const HORIZON_URL = process.env.HORIZON_URL || "https://horizon-testnet.stellar.org";
+
+/** @type {Map<string, "account_created" | "trustline_opened" | null>} */
+const _cache = new Map();
+
+/**
+ * Classify the SAC side-effect for a transfer/mint to `toAddress`.
+ *
+ * @param {string} toAddress   Stellar G-address of the recipient
+ * @param {string} assetCode   Classic asset code, e.g. "USDC" or "XLM"
+ * @param {string} [assetIssuer]  Issuer G-address (omit for native XLM)
+ * @returns {Promise<"account_created" | "trustline_opened" | null>}
+ *   "account_created"  — account entry did not exist (SAC created it)
+ *   "trustline_opened" — account exists but had no trustline (SAC opened it)
+ *   null               — no implicit side-effect detected (or lookup failed)
+ */
+export async function classifySacSideEffect(toAddress, assetCode, assetIssuer) {
+  // Only G-addresses can have account entries / trustlines
+  if (!toAddress || !toAddress.startsWith("G")) return null;
+
+  const cacheKey = `${toAddress}:${assetCode}:${assetIssuer ?? "native"}`;
+  if (_cache.has(cacheKey)) return _cache.get(cacheKey);
+
+  let result = null;
+  try {
+    const res = await fetch(`${HORIZON_URL}/accounts/${toAddress}`, {
+      signal: AbortSignal.timeout(4000),
+    });
+
+    if (res.status === 404) {
+      // Account does not exist — SAC will auto-create it
+      result = "account_created";
+    } else if (res.ok) {
+      const account = await res.json();
+      // Native XLM: every account implicitly holds XLM, no trustline needed
+      if (!assetIssuer || assetCode === "XLM") {
+        result = null;
+      } else {
+        // Check whether the trustline for this asset already exists
+        const hasTrustline = account.balances?.some(
+          b => b.asset_code === assetCode && b.asset_issuer === assetIssuer
+        );
+        result = hasTrustline ? null : "trustline_opened";
+      }
+    }
+  } catch {
+    // Network error or timeout — skip silently
+    result = null;
+  }
+
+  _cache.set(cacheKey, result);
+  return result;
+}
+
+/**
+ * Human-readable label for a SAC side-effect classification.
+ *
+ * @param {"account_created" | "trustline_opened" | null} kind
+ * @returns {string | null}
+ */
+export function sacSideEffectLabel(kind) {
+  if (kind === "account_created") return "SAC Auto-Created Account Entry";
+  if (kind === "trustline_opened") return "SAC Native Trustline Open";
+  return null;
+}

--- a/indexer/test/sacSideEffect.test.js
+++ b/indexer/test/sacSideEffect.test.js
@@ -1,0 +1,117 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { sacSideEffectLabel } from "../src/sacSideEffect.js";
+
+// ── sacSideEffectLabel ────────────────────────────────────────────────────────
+
+describe("sacSideEffectLabel", () => {
+  it("returns correct label for account_created", () => {
+    assert.strictEqual(sacSideEffectLabel("account_created"), "SAC Auto-Created Account Entry");
+  });
+
+  it("returns correct label for trustline_opened", () => {
+    assert.strictEqual(sacSideEffectLabel("trustline_opened"), "SAC Native Trustline Open");
+  });
+
+  it("returns null for null input", () => {
+    assert.strictEqual(sacSideEffectLabel(null), null);
+  });
+
+  it("returns null for unknown kind", () => {
+    assert.strictEqual(sacSideEffectLabel("unknown"), null);
+  });
+});
+
+// ── classifySacSideEffect — mocked fetch ─────────────────────────────────────
+
+describe("classifySacSideEffect", () => {
+  let classifySacSideEffect;
+  let originalFetch;
+
+  /**
+   * We mock globalThis.fetch before importing the module so the in-process
+   * cache starts empty for each describe block.  Because ESM modules are
+   * cached by Node we re-import with a cache-busting query string.
+   */
+  before(async () => {
+    originalFetch = globalThis.fetch;
+  });
+
+  after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns account_created when Horizon returns 404", async () => {
+    globalThis.fetch = async () => ({ status: 404, ok: false });
+    // Fresh import to bypass module-level cache
+    const mod = await import(`../src/sacSideEffect.js?bust=${Math.random()}`);
+    classifySacSideEffect = mod.classifySacSideEffect;
+
+    const result = await classifySacSideEffect("GNEWACCOUNT", "USDC", "GISSUER");
+    assert.strictEqual(result, "account_created");
+  });
+
+  it("returns trustline_opened when account exists but has no matching trustline", async () => {
+    globalThis.fetch = async () => ({
+      status: 200,
+      ok: true,
+      json: async () => ({
+        balances: [
+          { asset_code: "XLM", asset_type: "native" },
+        ],
+      }),
+    });
+    const mod = await import(`../src/sacSideEffect.js?bust=${Math.random()}`);
+    classifySacSideEffect = mod.classifySacSideEffect;
+
+    const result = await classifySacSideEffect("GEXISTING", "USDC", "GISSUER");
+    assert.strictEqual(result, "trustline_opened");
+  });
+
+  it("returns null when account already has the trustline", async () => {
+    globalThis.fetch = async () => ({
+      status: 200,
+      ok: true,
+      json: async () => ({
+        balances: [
+          { asset_code: "USDC", asset_issuer: "GISSUER", asset_type: "credit_alphanum4" },
+        ],
+      }),
+    });
+    const mod = await import(`../src/sacSideEffect.js?bust=${Math.random()}`);
+    classifySacSideEffect = mod.classifySacSideEffect;
+
+    const result = await classifySacSideEffect("GEXISTING", "USDC", "GISSUER");
+    assert.strictEqual(result, null);
+  });
+
+  it("returns null for native XLM (no issuer)", async () => {
+    globalThis.fetch = async () => ({
+      status: 200,
+      ok: true,
+      json: async () => ({ balances: [] }),
+    });
+    const mod = await import(`../src/sacSideEffect.js?bust=${Math.random()}`);
+    classifySacSideEffect = mod.classifySacSideEffect;
+
+    const result = await classifySacSideEffect("GEXISTING", "XLM", null);
+    assert.strictEqual(result, null);
+  });
+
+  it("returns null for non-G addresses (contract addresses)", async () => {
+    const mod = await import(`../src/sacSideEffect.js?bust=${Math.random()}`);
+    classifySacSideEffect = mod.classifySacSideEffect;
+
+    const result = await classifySacSideEffect("CCONTRACTADDRESS", "USDC", "GISSUER");
+    assert.strictEqual(result, null);
+  });
+
+  it("returns null when fetch throws (network error)", async () => {
+    globalThis.fetch = async () => { throw new Error("network error"); };
+    const mod = await import(`../src/sacSideEffect.js?bust=${Math.random()}`);
+    classifySacSideEffect = mod.classifySacSideEffect;
+
+    const result = await classifySacSideEffect("GFAILADDR", "USDC", "GISSUER");
+    assert.strictEqual(result, null);
+  });
+});


### PR DESCRIPTION
…ine open labels

- Add sacSideEffect.js: probes Horizon to classify SAC transfer/mint side-effects as account_created or trustline_opened (in-process cache)
- Extend sac.js: store asset issuer in map, export detectSacAsset()
- decoder.js: annotate SAC transfer/mint events with sac_side_effect field
- api.ts: add sac_side_effect to DecodedEvent interface
- EventTable/EventPage: render ⬡ SAC Auto-Created Account Entry and ⬡ SAC Native Trustline Open badges
- 10 unit tests covering all classification branches


closes #168 