### PR TITLE
Add WASM build metadata indexing and metadata API

### DIFF
--- a/indexer/src/api.js
+++ b/indexer/src/api.js
@@ -60,6 +60,15 @@ export function startApi() {
     } catch (e) { res.status(500).json({ error: e.message }); }
   });
 
+  // GET /api/contracts/:id/build-metadata — WASM build metadata (compiler, SDK, repo link)
+  app.get("/api/contracts/:id/build-metadata", async (req, res) => {
+    try {
+      const meta = await db.getWasmBuildMetadata(req.params.id);
+      if (!meta) return res.status(404).json({ error: "No build metadata found for this contract" });
+      res.json(meta);
+    } catch (e) { res.status(500).json({ error: e.message }); }
+  });
+
   // GET /api/contracts/:id/abi — download standardized ABI JSON
   app.get("/api/contracts/:id/abi", async (req, res) => {
     try {

--- a/indexer/src/db.js
+++ b/indexer/src/db.js
@@ -130,6 +130,22 @@ export const db = {
       );
       CREATE INDEX IF NOT EXISTS idx_state_diff_contract_ledger
         ON storage_state_diffs(contract_id, ledger ASC);
+
+      -- WASM build metadata extracted from UploadContractWasm operations
+      CREATE TABLE IF NOT EXISTS wasm_build_metadata (
+        wasm_hash   TEXT PRIMARY KEY,
+        contract_id TEXT,
+        sdk_version TEXT,
+        compiler    TEXT,
+        optimizer   TEXT,
+        repository  TEXT,
+        commit      TEXT,
+        producers   JSONB,
+        ledger      BIGINT,
+        tx_hash     TEXT,
+        indexed_at  TIMESTAMPTZ DEFAULT NOW()
+      );
+      CREATE INDEX IF NOT EXISTS idx_wasm_meta_contract ON wasm_build_metadata(contract_id);
     `);
   },
 
@@ -543,5 +559,34 @@ export const db = {
       params
     );
     return rows;
+  },
+
+  // ── WASM build metadata ────────────────────────────────────────────────────
+
+  async upsertWasmBuildMetadata({ wasm_hash, contract_id, sdk_version, compiler, optimizer, repository, commit, producers, ledger, tx_hash }) {
+    await pool.query(
+      `INSERT INTO wasm_build_metadata
+         (wasm_hash, contract_id, sdk_version, compiler, optimizer, repository, commit, producers, ledger, tx_hash)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+       ON CONFLICT (wasm_hash) DO UPDATE SET
+         contract_id = COALESCE(EXCLUDED.contract_id, wasm_build_metadata.contract_id),
+         sdk_version = COALESCE(EXCLUDED.sdk_version, wasm_build_metadata.sdk_version),
+         compiler    = COALESCE(EXCLUDED.compiler,    wasm_build_metadata.compiler),
+         optimizer   = COALESCE(EXCLUDED.optimizer,   wasm_build_metadata.optimizer),
+         repository  = COALESCE(EXCLUDED.repository,  wasm_build_metadata.repository),
+         commit      = COALESCE(EXCLUDED.commit,      wasm_build_metadata.commit),
+         producers   = COALESCE(EXCLUDED.producers,   wasm_build_metadata.producers)`,
+      [wasm_hash, contract_id ?? null, sdk_version ?? null, compiler ?? null,
+       optimizer ?? null, repository ?? null, commit ?? null,
+       producers ? JSON.stringify(producers) : null, ledger ?? null, tx_hash ?? null]
+    );
+  },
+
+  async getWasmBuildMetadata(contract_id) {
+    const { rows } = await pool.query(
+      `SELECT * FROM wasm_build_metadata WHERE contract_id = $1 ORDER BY ledger DESC LIMIT 1`,
+      [contract_id]
+    );
+    return rows[0] ?? null;
   },
 };

--- a/indexer/src/index.js
+++ b/indexer/src/index.js
@@ -12,8 +12,8 @@ import { startBurnDetector } from "./burnDetector.js";
 import { multiNodeRpc } from "./rpcMultiNode.js";
 import { startMetricsCollector } from "./rpcMetrics.js";
 import { startPruner } from "./pruner.js";
-import { extractStateDiffs } from "./stateDiffIndexer.js";
 import { extractStateDiffs } from "./stateDiffIndexer.js"; // Issue #140
+import { extractBuildMetadata } from "./wasmBuildMetadata.js";
 
 const RPC_URL      = process.env.SOROBAN_RPC_URL || "https://soroban-testnet.stellar.org";
 const START_LEDGER = Number(process.env.START_LEDGER || 0);
@@ -79,6 +79,42 @@ const cursorRef = {
 let _cursor = 0;
 
 /**
+ * For each unique tx_hash in the event batch, fetch the transaction and check
+ * whether any operation is an UploadContractWasm.  When found, extract build
+ * metadata from the raw WASM bytes and persist it.
+ *
+ * @param {string[]} txHashes  Deduplicated list of tx hashes from this page
+ * @param {number}   ledger    Current ledger number
+ */
+async function indexWasmUploads(txHashes, ledger) {
+  for (const txHash of txHashes) {
+    try {
+      const tx = await withRetry(() => rpc.getTransaction(txHash));
+      if (!tx?.envelopeXdr) continue;
+
+      const { xdr } = await import("@stellar/stellar-sdk");
+      const envelope = xdr.TransactionEnvelope.fromXDR(tx.envelopeXdr, "base64");
+      const ops = envelope.tx?.().operations?.() ?? envelope.v1?.().tx?.().operations?.() ?? [];
+
+      for (const op of ops) {
+        const body = op.body();
+        if (body.switch().name !== "invokeHostFunction") continue;
+        const hf = body.invokeHostFunctionOp().hostFunction();
+        if (hf.switch().name !== "hostFunctionTypeUploadContractWasm") continue;
+
+        const wasmBytes = hf.wasm();
+        const meta = extractBuildMetadata(wasmBytes);
+        await db.upsertWasmBuildMetadata({ ...meta, ledger, tx_hash: txHash });
+        console.log(`[${ledger}] WASM upload indexed: ${meta.wasm_hash.slice(0, 16)}… compiler=${meta.compiler ?? "unknown"}`);
+      }
+    } catch (err) {
+      // Non-fatal: log and continue
+      console.error(`[wasmUpload] tx ${txHash}: ${err.message}`);
+    }
+  }
+}
+
+/**
  * Fetch and process ALL events for a given startLedger, handling pagination
  * boundaries when a ledger contains more than PAGE_LIMIT events (Issue #33).
  *
@@ -102,8 +138,10 @@ async function indexLedger(ledger) {
     // Flag footprint contention across transactions in this page's events
     scanFootprintContention(res.events);
 
-    for (const ev of res.events) {
-      const decoded = await decode(ev);
+    // Collect unique tx hashes for WASM upload detection
+    const pageTxHashes = [...new Set(res.events.map(ev => ev.txHash).filter(Boolean))];
+
+    for (const ev of res.events) {      const decoded = await decode(ev);
       decoded.is_high_bloat_risk = isHighBloatRisk(ev, ev.contractId);
       decoded.footprint_contention = ev.footprint_contention ?? false;
 
@@ -133,6 +171,11 @@ async function indexLedger(ledger) {
       
       console.log(`[${ev.ledger}] ${decoded.function}: ${decoded.description}`);
     }
+
+    // Scan transactions for UploadContractWasm operations (non-blocking)
+    indexWasmUploads(pageTxHashes, ledger).catch(err =>
+      console.error("[wasmUpload] batch error:", err.message)
+    );
 
     // Issue #37 — record the latest ledger hash for re-org detection
     if (res.latestLedger && res.latestLedgerHash) {

--- a/indexer/src/wasmBuildMetadata.js
+++ b/indexer/src/wasmBuildMetadata.js
@@ -1,0 +1,171 @@
+/**
+ * wasmBuildMetadata.js
+ *
+ * Parses WASM custom sections to extract reproducible-build metadata:
+ *   - contractenvmetav0  → Soroban SDK / environment version
+ *   - build_metadata     → compiler version, optimizer, repo URL (Stellar-standard)
+ *   - producers          → LLVM / Rust toolchain info (WebAssembly producers section)
+ *
+ * Also computes the SHA-256 hash of the raw WASM bytes for fingerprinting.
+ */
+
+import { createHash } from "crypto";
+
+const WASM_MAGIC = 0x0061736d;
+
+/** Read an unsigned LEB-128 integer from buf at offset. */
+function readLEB128(buf, offset) {
+  let result = 0, shift = 0, byte;
+  do {
+    byte = buf[offset++];
+    result |= (byte & 0x7f) << shift;
+    shift += 7;
+  } while (byte & 0x80);
+  return { value: result, offset };
+}
+
+/**
+ * Iterate over every custom section (id=0) in a WASM binary.
+ * Yields { name: string, payload: Buffer } for each one found.
+ */
+function* customSections(buf) {
+  if (buf.length < 8 || buf.readUInt32BE(0) !== WASM_MAGIC) return;
+
+  let pos = 8; // skip magic (4) + version (4)
+  while (pos < buf.length) {
+    const sectionId = buf[pos++];
+    const { value: sectionSize, offset: afterSize } = readLEB128(buf, pos);
+    pos = afterSize;
+    const sectionEnd = pos + sectionSize;
+
+    if (sectionId === 0 && pos < sectionEnd) {
+      const { value: nameLen, offset: nameStart } = readLEB128(buf, pos);
+      const nameEnd = nameStart + nameLen;
+      const name = buf.toString("utf8", nameStart, nameEnd);
+      const payload = buf.slice(nameEnd, sectionEnd);
+      yield { name, payload };
+    }
+
+    pos = sectionEnd;
+  }
+}
+
+/**
+ * Parse the `build_metadata` custom section used by Stellar/Soroban tooling.
+ * The section is a sequence of null-terminated key=value pairs.
+ * Known keys: compiler, optimizer, repository, commit
+ */
+function parseBuildMetadataSection(payload) {
+  const text = payload.toString("utf8");
+  const result = {};
+  // Split on null bytes or newlines; each entry is "key=value"
+  for (const entry of text.split(/[\0\n]+/)) {
+    const eq = entry.indexOf("=");
+    if (eq > 0) {
+      const key = entry.slice(0, eq).trim();
+      const val = entry.slice(eq + 1).trim();
+      if (key && val) result[key] = val;
+    }
+  }
+  return result;
+}
+
+/**
+ * Parse the WebAssembly `producers` custom section.
+ * Format: field-count { field-name value-count { name version }* }*
+ * Returns a flat object like { language: "Rust 1.78.0", "processed-by": "rustc 1.78.0" }
+ */
+function parseProducersSection(payload) {
+  const result = {};
+  try {
+    let pos = 0;
+    const { value: fieldCount, offset: o0 } = readLEB128(payload, pos);
+    pos = o0;
+    for (let i = 0; i < fieldCount; i++) {
+      const { value: fnLen, offset: o1 } = readLEB128(payload, pos);
+      pos = o1;
+      const fieldName = payload.toString("utf8", pos, pos + fnLen);
+      pos += fnLen;
+
+      const { value: valCount, offset: o2 } = readLEB128(payload, pos);
+      pos = o2;
+      const parts = [];
+      for (let j = 0; j < valCount; j++) {
+        const { value: nLen, offset: o3 } = readLEB128(payload, pos);
+        pos = o3;
+        const name = payload.toString("utf8", pos, pos + nLen);
+        pos += nLen;
+        const { value: vLen, offset: o4 } = readLEB128(payload, pos);
+        pos = o4;
+        const version = payload.toString("utf8", pos, pos + vLen);
+        pos += vLen;
+        parts.push(version ? `${name} ${version}` : name);
+      }
+      result[fieldName] = parts.join(", ");
+    }
+  } catch {
+    // malformed section — return whatever we parsed so far
+  }
+  return result;
+}
+
+/**
+ * Parse the `contractenvmetav0` section (3 bytes: major, minor, patch).
+ */
+function parseEnvMetaSection(payload) {
+  if (payload.length < 3) return null;
+  return {
+    major: payload[0],
+    minor: payload[1],
+    patch: payload[2],
+  };
+}
+
+/**
+ * Extract all build metadata from a WASM binary buffer.
+ *
+ * @param {Buffer|Uint8Array} wasm
+ * @returns {{
+ *   wasm_hash: string,           // SHA-256 hex of the raw bytes
+ *   sdk_version: string|null,    // e.g. "v21.1.0" from contractenvmetav0
+ *   compiler: string|null,       // e.g. "rustc 1.78.0"
+ *   optimizer: string|null,      // e.g. "wasm-opt 116"
+ *   repository: string|null,     // repo URL if embedded
+ *   commit: string|null,         // git commit hash if embedded
+ *   producers: object,           // raw producers section fields
+ * }}
+ */
+export function extractBuildMetadata(wasm) {
+  const buf = Buffer.isBuffer(wasm) ? wasm : Buffer.from(wasm);
+
+  const meta = {
+    wasm_hash:   createHash("sha256").update(buf).digest("hex"),
+    sdk_version: null,
+    compiler:    null,
+    optimizer:   null,
+    repository:  null,
+    commit:      null,
+    producers:   {},
+  };
+
+  for (const { name, payload } of customSections(buf)) {
+    if (name === "contractenvmetav0") {
+      const v = parseEnvMetaSection(payload);
+      if (v) meta.sdk_version = `v${v.major}.${v.minor}.${v.patch}`;
+    } else if (name === "build_metadata") {
+      const bm = parseBuildMetadataSection(payload);
+      if (bm.compiler)   meta.compiler   = bm.compiler;
+      if (bm.optimizer)  meta.optimizer  = bm.optimizer;
+      if (bm.repository) meta.repository = bm.repository;
+      if (bm.commit)     meta.commit     = bm.commit;
+    } else if (name === "producers") {
+      meta.producers = parseProducersSection(payload);
+      // Populate compiler from producers if not already set by build_metadata
+      if (!meta.compiler && meta.producers["processed-by"]) {
+        meta.compiler = meta.producers["processed-by"];
+      }
+    }
+  }
+
+  return meta;
+}


### PR DESCRIPTION
Closes #171

---

This PR adds support for extracting WASM build metadata from UploadContractWasm transactions, persisting it in a new database table, and exposing it through a new `/api/contracts/:id/build-metadata` endpoint. The implementation also includes a non-blocking scanner for WASM upload transactions during indexer processing.