### PR TITLE
feat: heuristic fallback param parser for unverified contracts

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -58,6 +58,14 @@ export interface ZkCostDelta {
   saved_pct: number;
 }
 
+export interface HeuristicParam {
+  index: number;
+  raw: string;
+  type: "Address" | "ContractId" | "Amount" | "Hash" | "Symbol" | "Boolean" | "Unknown";
+  value: string;
+  confidence: "likely" | "possible";
+}
+
 export interface DecodedEvent {
   seq: number;
   contract_id: string;
@@ -103,6 +111,8 @@ export interface DecodedEvent {
     keyCount: number;
     feePaid: number | null;
   } | null;
+  // Heuristic fallback params: present when no ABI is registered
+  heuristic_params?: HeuristicParam[];
 }
 
 export interface SourceFile {

--- a/frontend/src/components/HeuristicParams.tsx
+++ b/frontend/src/components/HeuristicParams.tsx
@@ -1,0 +1,78 @@
+import type { HeuristicParam } from "../api";
+
+const TYPE_COLORS: Record<string, { bg: string; fg: string }> = {
+  Address:    { bg: "rgba(88,166,255,0.12)",  fg: "#58a6ff" },
+  ContractId: { bg: "rgba(63,185,80,0.12)",   fg: "#3fb950" },
+  Amount:     { bg: "rgba(210,153,34,0.12)",  fg: "#d29922" },
+  Hash:       { bg: "rgba(139,148,158,0.12)", fg: "#8b949e" },
+  Symbol:     { bg: "rgba(184,128,255,0.12)", fg: "#b880ff" },
+  Boolean:    { bg: "rgba(248,81,73,0.12)",   fg: "#f85149" },
+  Unknown:    { bg: "rgba(139,148,158,0.08)", fg: "#8b949e" },
+};
+
+interface Props {
+  params: HeuristicParam[];
+}
+
+export default function HeuristicParams({ params }: Props) {
+  if (!params || params.length === 0) return null;
+
+  return (
+    <div className="card" style={{ marginTop: 12 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
+        <h4 style={{ fontSize: 13 }}>Heuristic Parameters</h4>
+        <span
+          className="badge yellow"
+          title="No ABI registered — types are guessed from value shape"
+          style={{ fontSize: 11 }}
+        >
+          ⚠ Unverified
+        </span>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {params.map((p) => <ParamRow key={p.index} param={p} />)}
+      </div>
+    </div>
+  );
+}
+
+function ParamRow({ param }: { param: HeuristicParam }) {
+  const colors = TYPE_COLORS[param.type] ?? TYPE_COLORS.Unknown;
+  const label = param.confidence === "likely"
+    ? `Likely ${param.type}`
+    : `Possibly ${param.type}`;
+
+  return (
+    <div style={{ display: "flex", gap: 12, alignItems: "flex-start" }}>
+      <span style={{ color: "var(--muted)", minWidth: 70, fontSize: 12 }}>
+        Param {param.index}
+      </span>
+      <span
+        style={{
+          display: "inline-block",
+          padding: "1px 7px",
+          borderRadius: 10,
+          fontSize: 11,
+          fontWeight: 600,
+          background: colors.bg,
+          color: colors.fg,
+          whiteSpace: "nowrap",
+          minWidth: 100,
+        }}
+        title={`Confidence: ${param.confidence}`}
+      >
+        {label}
+      </span>
+      <span
+        style={{
+          fontFamily: "monospace",
+          fontSize: 12,
+          wordBreak: "break-all",
+          color: "var(--text)",
+        }}
+      >
+        {param.value}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -7,6 +7,7 @@ import FiatValue from "../components/FiatValue";
 import GasLimitAlert from "../components/GasLimitAlert";
 import FeeSponsorBanner from "../components/FeeSponsorBanner";
 import RestoreFootprintPanel from "../components/RestoreFootprintPanel";
+import HeuristicParams from "../components/HeuristicParams";
 
 /** Parse amount and symbol from a transfer description. */
 function parseTransfer(description: string): { amount: number; symbol: string } | null {
@@ -82,6 +83,9 @@ export default function EventPage() {
           <Row label="Topics" value={ev.raw_topics.join(", ")} mono />
         )}
       </div>
+
+      {/* Heuristic parameter guesses when no ABI is registered */}
+      {ev.heuristic_params && <HeuristicParams params={ev.heuristic_params} />}
 
       {/* Fee-Bump sponsorship banner */}
       {ev.fee_bump && <FeeSponsorBanner feeBump={ev.fee_bump} />}

--- a/indexer/src/decoder.js
+++ b/indexer/src/decoder.js
@@ -70,6 +70,7 @@ import { sacLabel, detectSac, detectSacAsset } from "./sac.js";
 import { classifySacSideEffect } from "./sacSideEffect.js";
 import { extractRoleAssignment } from "./roleTracker.js";
 import { decodeRwaEvent } from "./rwaDecoder.js";
+import { parseHeuristic } from "./heuristicParser.js";
 
 // Native XLM Stellar Asset Contract IDs (testnet + mainnet)
 const NATIVE_SAC_IDS = new Set([
@@ -144,6 +145,11 @@ export async function decode(ev) {
         : genericDescription(fnName, topics.slice(1), data, contractLabel);
   }
 
+  // Attach heuristic params when no ABI was available (no fnAbi, not a vault, not RWA)
+  const heuristicParams = (!fnAbi && !vaultMeta && !meta)
+    ? parseHeuristic([...topics.slice(1), ...(data != null ? [data] : [])])
+    : undefined;
+
   const decoded = {
     contract_id: contractId,
     function:    fnName,
@@ -156,6 +162,7 @@ export async function decode(ev) {
     is_clawback: fnName === "clawback",
     is_resource_limit_exceeded: isResourceLimitExceeded(ev),
     ...extractGasCosts(ev),
+    ...(heuristicParams && { heuristic_params: heuristicParams }),
   };
 
   // Protocol 26: detect TTL extension host function calls on this event

--- a/indexer/src/heuristicParser.js
+++ b/indexer/src/heuristicParser.js
@@ -1,0 +1,73 @@
+/**
+ * heuristicParser.js
+ *
+ * Guesses parameter types from raw ScVal-converted strings when no ABI is
+ * available.  Returns an array of guess-tagged objects suitable for storage
+ * and display in the frontend.
+ *
+ * Each item:  { index, raw, type, value, confidence }
+ *   type       — "Address" | "ContractId" | "Amount" | "Hash" | "Symbol" | "Boolean" | "Unknown"
+ *   confidence — "likely" | "possible"
+ */
+
+// Stellar account address: G + 55 base32 chars (total 56)
+const RE_ACCOUNT  = /^G[A-Z2-7]{55}$/;
+// Stellar contract address: C + 55 base32 chars
+const RE_CONTRACT = /^C[A-Z2-7]{55}$/;
+// Transaction/WASM hash: 64 hex chars
+const RE_HASH     = /^[0-9a-f]{64}$/i;
+// Symbol / token ticker: 1–12 uppercase letters/digits
+const RE_SYMBOL   = /^[A-Z][A-Z0-9]{0,11}$/;
+
+/**
+ * Guess the type of a single raw value (string, number, bigint, boolean, etc.)
+ *
+ * @param {*} raw  A value already converted by scValToNative / scValToJs
+ * @returns {{ type: string, value: string, confidence: string }}
+ */
+export function guessType(raw) {
+  const s = String(raw);
+
+  if (typeof raw === "boolean") {
+    return { type: "Boolean", value: s, confidence: "likely" };
+  }
+
+  if (RE_ACCOUNT.test(s)) {
+    return { type: "Address", value: s, confidence: "likely" };
+  }
+
+  if (RE_CONTRACT.test(s)) {
+    return { type: "ContractId", value: s, confidence: "likely" };
+  }
+
+  if (RE_HASH.test(s)) {
+    return { type: "Hash", value: s, confidence: "likely" };
+  }
+
+  // Numeric: could be an amount (i128/u128 from SAC)
+  if (typeof raw === "bigint" || (typeof raw === "number" && !isNaN(raw))) {
+    return { type: "Amount", value: s, confidence: "possible" };
+  }
+
+  // Short all-caps strings look like token symbols
+  if (RE_SYMBOL.test(s) && s.length >= 2) {
+    return { type: "Symbol", value: s, confidence: "possible" };
+  }
+
+  return { type: "Unknown", value: s, confidence: "possible" };
+}
+
+/**
+ * Parse an array of already-native params (topics[1..] + data) into an array
+ * of guess-tagged entries.
+ *
+ * @param {Array} params  Values already decoded by scValToNative / scValToJs
+ * @returns {Array<{ index: number, raw: string, type: string, value: string, confidence: string }>}
+ */
+export function parseHeuristic(params) {
+  return params.map((p, i) => ({
+    index: i + 1,
+    raw:   String(p),
+    ...guessType(p),
+  }));
+}

--- a/indexer/test/heuristicParser.test.js
+++ b/indexer/test/heuristicParser.test.js
@@ -1,0 +1,96 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { guessType, parseHeuristic } from "../src/heuristicParser.js";
+
+// Valid Stellar account address (G + 55 base32 chars)
+const ACCOUNT = "GABC4RENF2IDWVF7XHZJMCDXKFNKAMNCXLNJKQJXN6FOMJHYNW5ZQZQ";
+// Valid Stellar contract address (C + 55 base32 chars)
+const CONTRACT = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+// 64-char hex hash
+const HASH = "a".repeat(64);
+
+describe("guessType", () => {
+  it("identifies a Stellar account address", () => {
+    // Any 56-char G-address should match
+    const addr = "G" + "A".repeat(55);
+    const r = guessType(addr);
+    assert.equal(r.type, "Address");
+    assert.equal(r.confidence, "likely");
+    assert.equal(r.value, addr);
+  });
+
+  it("identifies a Stellar contract address", () => {
+    const addr = "C" + "A".repeat(55);
+    const r = guessType(addr);
+    assert.equal(r.type, "ContractId");
+    assert.equal(r.confidence, "likely");
+  });
+
+  it("identifies a 64-char hex hash", () => {
+    const r = guessType(HASH);
+    assert.equal(r.type, "Hash");
+    assert.equal(r.confidence, "likely");
+  });
+
+  it("identifies a bigint as Amount", () => {
+    const r = guessType(1000000n);
+    assert.equal(r.type, "Amount");
+    assert.equal(r.confidence, "possible");
+  });
+
+  it("identifies a number as Amount", () => {
+    const r = guessType(9876543);
+    assert.equal(r.type, "Amount");
+    assert.equal(r.confidence, "possible");
+  });
+
+  it("identifies an all-caps token symbol", () => {
+    const r = guessType("USDC");
+    assert.equal(r.type, "Symbol");
+    assert.equal(r.confidence, "possible");
+  });
+
+  it("identifies a boolean", () => {
+    assert.equal(guessType(true).type, "Boolean");
+    assert.equal(guessType(false).type, "Boolean");
+  });
+
+  it("returns Unknown for unrecognised strings", () => {
+    const r = guessType("some random text 123");
+    assert.equal(r.type, "Unknown");
+  });
+});
+
+describe("parseHeuristic", () => {
+  it("returns one entry per param with 1-based indexes", () => {
+    const addr = "G" + "A".repeat(55);
+    const results = parseHeuristic([addr, 100n, "USDC"]);
+    assert.equal(results.length, 3);
+    assert.equal(results[0].index, 1);
+    assert.equal(results[1].index, 2);
+    assert.equal(results[2].index, 3);
+  });
+
+  it("preserves raw value as string", () => {
+    const addr = "G" + "A".repeat(55);
+    const results = parseHeuristic([addr]);
+    assert.equal(results[0].raw, addr);
+    assert.equal(results[0].value, addr);
+  });
+
+  it("returns empty array for empty input", () => {
+    assert.deepEqual(parseHeuristic([]), []);
+  });
+
+  it("correctly tags mixed params", () => {
+    const addr    = "G" + "A".repeat(55);
+    const cid     = "C" + "A".repeat(55);
+    const results = parseHeuristic([addr, cid, 500n, "XLM", HASH]);
+
+    assert.equal(results[0].type, "Address");
+    assert.equal(results[1].type, "ContractId");
+    assert.equal(results[2].type, "Amount");
+    assert.equal(results[3].type, "Symbol");
+    assert.equal(results[4].type, "Hash");
+  });
+});


### PR DESCRIPTION
Description:
  
  Closes the UX gap where contracts without a registered ABI displayed raw unformatted values.
  Instead, parameters are now type-guessed and shown with confidence tags.
  
  What changed
  
  - heuristicParser.js — detects Address, ContractId, Hash, Amount, Symbol, Boolean from raw
  native ScVal values using regex/type checks
  - decoder.js — runs the heuristic when no ABI, vault, or metadata is registered; attaches
  heuristic_params to the decoded event
  - HeuristicParams.tsx — renders a card with an ⚠ Unverified badge and colour-coded Likely
  Address, Possibly Amount, etc. tags per parameter
  - EventPage.tsx — shows the component when heuristic_params is present on the event
  
  Before / After
  
  ┌──────────────────────────────────────┬───────┐
  │ Before                               │ After                                              │
  ├──────────────────────────────────────┼────────────────────────────────────────────────────┤
  │ swap(GABC…, CDLZ…, 1000000) raw dump │ Param 1 (Likely Address): GABC… · Param 2 (Likely  │
  │                                      │ ContractId): CDLZ… · Param 3 (Possibly Amount):    │
  │                                      │ 1000000                                            │
  └──────────────────────────────────────┴────────────────────────────────────────────────────┘
  
  Testing
  
  - 12 unit tests in indexer/test/heuristicParser.test.js, all passing

close #30 