### PR TITLE
feat(#197): Dockerize the full stack (PostgreSQL + Indexer + Frontend)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,16 @@
+# ═══════════════════════════════════════════════════════════════════════════
+# Soroban Smart Block Explorer — Environment Configuration
+# ═══════════════════════════════════════════════════════════════════════════
+# Copy this file to .env and adjust values for your environment.
+#   cp .env.example .env
+# ═══════════════════════════════════════════════════════════════════════════
+
+# ── Stellar Network ────────────────────────────────────────────────────────────
 # Soroban RPC endpoint (testnet default)
 SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+
+# Comma-separated fallback RPC URLs for multi-node resilience
+SOROBAN_RPC_URLS=
 
 # Horizon API (for classic asset data)
 HORIZON_URL=https://horizon-testnet.stellar.org
@@ -7,21 +18,100 @@ HORIZON_URL=https://horizon-testnet.stellar.org
 # Network passphrase
 NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
 
-# PostgreSQL connection string
-DATABASE_URL=postgres://user:password@localhost:5432/soroban_explorer
+# ── PostgreSQL ─────────────────────────────────────────────────────────────────
+# Connection string used by the indexer at runtime
+DATABASE_URL=postgres://soroban:soroban_secret@localhost:5432/soroban_explorer
 
-# Indexer settings
-START_LEDGER=0
-POLL_MS=5000
+# Docker Compose will use these to create the database automatically
+POSTGRES_USER=soroban
+POSTGRES_PASSWORD=soroban_secret
+POSTGRES_DB=soroban_explorer
+POSTGRES_PORT=5432
 
-# API server port
+# ── Indexer ────────────────────────────────────────────────────────────────────
+# API server port (default 3001)
 PORT=3001
+
+# Start indexing from this ledger number (0 = latest - 100)
+START_LEDGER=0
+
+# Poll interval in milliseconds
+POLL_MS=5000
 
 # Deployed explorer contract ID (set after `make deploy`)
 EXPLORER_CONTRACT_ID=
 
-# GitHub ABI sync
+# ── Pruning & Cleanup ──────────────────────────────────────────────────────────
+# Cron expression for the temporary-storage pruning job
+PRUNE_CRON="0 3 * * *"
+
+# How many ledgers ahead to keep before pruning old temporary storage diffs
+PRUNE_LEDGER_BUFFER=10000
+
+# Max TTL ledgers for temporary storage entries
+MAX_TEMP_TTL_LEDGERS=1000
+
+# ── Multi-Node RPC ─────────────────────────────────────────────────────────────
+# Threshold (in ledgers) before considering an RPC node lagging behind
+RPC_LAG_THRESHOLD=10
+
+# RPC call timeout in milliseconds
+RPC_CALL_TIMEOUT_MS=30000
+
+# ── Metrics & Monitoring ───────────────────────────────────────────────────────
+# Interval for health/RPC latency probe metrics (ms)
+METRICS_PROBE_INTERVAL_MS=60000
+
+# Max samples retained in the metrics ring buffer
+METRICS_MAX_SAMPLES=1000
+
+# ── GitHub ABI Sync ────────────────────────────────────────────────────────────
+# GitHub personal access token (needs public_repo scope for public repos)
 GITHUB_TOKEN=
 ABI_REPO=Soroban-Smart-Block-Explorer/verified-abis
 ABI_PATH=contracts
 ABI_SYNC_CRON=*/10 * * * *
+
+# ── Gas Guzzlers ───────────────────────────────────────────────────────────────
+# Interval between gas consumption leaderboard recomputation (ms)
+GAS_GUZZLERS_INTERVAL_MS=3600000
+
+# ── Bloat Detection ────────────────────────────────────────────────────────────
+# Threshold for flagging high bloat-risk contracts (events per ledger)
+BLOAT_THRESHOLD=50
+
+# ── Metadata Cache ─────────────────────────────────────────────────────────────
+# Cache TTL for contract metadata lookups (seconds)
+METADATA_CACHE_TTL=300
+
+# ─── Simulation ────────────────────────────────────────────────────────────────
+# Source account for transaction simulations
+SIMULATE_SOURCE=
+
+# ── SAC Assets ─────────────────────────────────────────────────────────────────
+# Comma-separated list of Stellar Asset Contract IDs to track
+SAC_ASSETS=
+
+# ── Verification ───────────────────────────────────────────────────────────────
+# Auto-verify ABI on upload
+VERIFY_ON_UPLOAD=true
+
+# ── Redis (optional) ───────────────────────────────────────────────────────────
+REDIS_URL=
+
+# ── Docker Compose Overrides ───────────────────────────────────────────────────
+# Point these to the dev Dockerfiles for hot-reloading:
+#   INDEXER_DOCKERFILE=Dockerfile.dev
+#   FRONTEND_DOCKERFILE=Dockerfile.dev
+#
+# Mount source directories for live code changes:
+#   FRONTEND_MOUNT=./frontend/src
+
+# Frontend port mapping (default 80 for prod Nginx, 5173 for dev Vite)
+FRONTEND_PORT=80
+
+# Adminer port (dev only)
+ADMINER_PORT=8080
+
+# PgHero port (dev only)
+PGHERO_PORT=8081

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: build test deploy indexer frontend clean
+.PHONY: build test deploy indexer frontend clean \
+	docker-up docker-down docker-build docker-logs docker-test docker-staging docker-prod
 
 # ── Contract ──────────────────────────────────────────────────────────────────
 build:
@@ -34,6 +35,45 @@ frontend:
 
 frontend-build:
 	cd frontend && npm run build
+
+# ── Docker ─────────────────────────────────────────────────────────────────────
+# Start dev stack (hot-reload via docker-compose.override.yml)
+# Uses Dockerfile.dev for indexer + frontend with source mounts
+docker-up:
+	docker compose up -d
+
+# Start production stack (no overrides, uses Dockerfile)
+docker-prod:
+	docker compose -f docker-compose.yml --profile prod up -d
+
+# Start staging stack (mirror of prod)
+docker-staging:
+	docker compose -f docker-compose.yml --profile staging up -d
+
+# CI / integration test stack
+docker-test:
+	docker compose -f docker-compose.yml --profile test up -d --abort-on-container-exit
+
+# Stop all containers
+docker-down:
+	docker compose down
+
+# Build all images without running
+docker-build:
+	docker compose build
+
+# Tail logs from all services
+docker-logs:
+	docker compose logs -f
+
+# Rebuild a specific service (e.g., make docker-rebuild indexer)
+docker-rebuild:
+	docker compose build $(filter-out $@,$(MAKECMDGOALS))
+	docker compose up -d $(filter-out $@,$(MAKECMDGOALS))
+
+# Check container health status
+docker-ps:
+	docker compose ps
 
 # ── All ───────────────────────────────────────────────────────────────────────
 install: indexer-install frontend-install

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,33 @@
+# Docker Compose override for development (hot-reloading, source mounts)
+#
+# This file is loaded automatically by Docker Compose when present.
+# It merges with docker-compose.yml — no --profile flag needed.
+#
+# Usage:
+#   docker compose up -d
+#
+# To run without overrides (production-like):
+#   docker compose -f docker-compose.yml --profile prod up -d
+
+services:
+  indexer:
+    # Mount source for hot-reload (Node.js --watch detects in-place changes)
+    volumes:
+      - ./indexer/src:/app/src
+    build:
+      dockerfile: Dockerfile.dev
+
+  frontend:
+    # Mount source for Vite HMR
+    volumes:
+      - ./frontend/src:/app/src
+      - ./frontend/index.html:/app/index.html
+    build:
+      dockerfile: Dockerfile.dev
+    environment:
+      # Tell Vite dev server to proxy API calls to the indexer container
+      VITE_API_URL: http://indexer:3001
+      # Match the healthcheck in docker-compose.yml to the Vite dev server port
+      FRONTEND_CONTAINER_PORT: "5173"
+    ports:
+      - "${FRONTEND_PORT:-5173}:5173"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,139 @@
+# Soroban Smart Block Explorer — Docker Compose
+# Profiles:  dev (default)   — hot-reload, debug tooling
+#            prod            — production-grade, multi-arch images
+#            test            — ephemeral CI stack
+#            staging         — pre-production mirror
+#
+# Usage:
+#   docker compose up                   # dev profile (default)
+#   docker compose --profile prod up    # production
+#   docker compose --profile test up    # CI / integration tests
+#   docker compose --profile staging up # staging environment
+
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "10m"
+    max-file: "3"
+
+x-healthcheck: &pg-healthcheck
+  test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-soroban} -d ${POSTGRES_DB:-soroban_explorer}"]
+  interval: 10s
+  timeout: 5s
+  retries: 5
+  start_period: 30s
+
+services:
+  # ── PostgreSQL ────────────────────────────────────────────────────────────
+  postgres:
+    image: postgres:16-alpine
+    container_name: soroban-postgres
+    restart: unless-stopped
+    profiles: ["dev", "test", "staging", "prod"]
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-soroban}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-soroban_secret}
+      POSTGRES_DB: ${POSTGRES_DB:-soroban_explorer}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck: *pg-healthcheck
+    logging: *default-logging
+    networks:
+      - soroban-net
+
+  # ── Indexer ───────────────────────────────────────────────────────────────
+  indexer:
+    container_name: soroban-indexer
+    restart: unless-stopped
+    profiles: ["dev", "test", "staging", "prod"]
+    build:
+      context: ./indexer
+      dockerfile: ${INDEXER_DOCKERFILE:-Dockerfile}
+    env_file:
+      - path: .env
+        required: true
+    environment:
+      DATABASE_URL: ${INDEXER_DATABASE_URL:-postgres://${POSTGRES_USER:-soroban}:${POSTGRES_PASSWORD:-soroban_secret}@postgres:5432/${POSTGRES_DB:-soroban_explorer}}
+      PORT: ${INDEXER_PORT:-3001}
+      NODE_ENV: ${NODE_ENV:-development}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:${INDEXER_PORT:-3001}/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
+    logging: *default-logging
+    networks:
+      - soroban-net
+
+  # ── Frontend ──────────────────────────────────────────────────────────────
+  frontend:
+    container_name: soroban-frontend
+    restart: unless-stopped
+    profiles: ["dev", "test", "staging", "prod"]
+    build:
+      context: ./frontend
+      dockerfile: ${FRONTEND_DOCKERFILE:-Dockerfile}
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      VITE_API_URL: ${VITE_API_URL:-http://indexer:3001}
+      NODE_ENV: ${NODE_ENV:-development}
+    depends_on:
+      indexer:
+        condition: service_started
+    ports:
+      - "${FRONTEND_PORT:-80}:${FRONTEND_CONTAINER_PORT:-80}"
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:${FRONTEND_CONTAINER_PORT:-80}/ || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    logging: *default-logging
+    networks:
+      - soroban-net
+
+  # ── Dev-only Tools ────────────────────────────────────────────────────────
+  adminer:
+    image: adminer:latest
+    container_name: soroban-adminer
+    profiles: ["dev"]
+    restart: unless-stopped
+    ports:
+      - "${ADMINER_PORT:-8080}:8080"
+    depends_on:
+      - postgres
+    networks:
+      - soroban-net
+
+  pghero:
+    image: ankane/pghero:latest
+    container_name: soroban-pghero
+    profiles: ["dev"]
+    restart: unless-stopped
+    environment:
+      DATABASE_URL: ${INDEXER_DATABASE_URL:-postgres://${POSTGRES_USER:-soroban}:${POSTGRES_PASSWORD:-soroban_secret}@postgres:5432/${POSTGRES_DB:-soroban_explorer}}
+    ports:
+      - "${PGHERO_PORT:-8081}:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - soroban-net
+
+networks:
+  soroban-net:
+    driver: bridge
+
+volumes:
+  pgdata:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+.git
+.gitignore
+dist
+.env
+.env.*

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,18 @@
+# Soroban Explorer Frontend — Development Image
+# Uses Vite dev server for HMR.
+FROM node:20-alpine
+WORKDIR /app
+
+# wget is needed for Docker healthcheck
+RUN apk add --no-cache wget
+
+# Install deps first (layer caching)
+COPY package*.json ./
+RUN npm ci
+
+# Copy the rest of the source
+COPY . .
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+// In Docker, the indexer API lives at the hostname "indexer".
+// Override via VITE_API_URL env var to match the container network.
+const apiTarget = process.env.VITE_API_URL || "http://localhost:3001";
+
 export default defineConfig({
   plugins: [react()],
-  server: { proxy: { "/api": "http://localhost:3001" } },
+  server: { proxy: { "/api": apiTarget } },
 });

--- a/indexer/.dockerignore
+++ b/indexer/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.git
+.gitignore
+test
+*.test.js
+.env
+.env.*

--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -5,7 +5,7 @@ RUN npm ci --only=production
 
 FROM node:20-alpine
 WORKDIR /app
-RUN apk add --no-cache tini
+RUN apk add --no-cache tini wget
 COPY --from=build /app/node_modules ./node_modules
 COPY . .
 USER node

--- a/indexer/Dockerfile.dev
+++ b/indexer/Dockerfile.dev
@@ -1,0 +1,18 @@
+# Soroban Explorer Indexer — Development Image
+# Uses Node.js built-in --watch for hot-reload.
+FROM node:20-alpine
+WORKDIR /app
+
+RUN apk add --no-cache tini wget
+
+# Install deps first (layer caching)
+COPY package*.json ./
+RUN npm ci
+
+# Copy the rest of the source
+COPY . .
+
+EXPOSE 3001
+
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["node", "--watch", "src/index.js"]

--- a/indexer/src/api.js
+++ b/indexer/src/api.js
@@ -23,6 +23,9 @@ export function startApi() {
   const app = express();
   app.use(express.json());
 
+  // ── Health check (used by Docker Compose) ──────────────────────────────
+  app.get("/health", (_req, res) => res.json({ status: "ok" }));
+
   // ── Existing endpoints ──────────────────────────────────────────────────────
 
   // GET /api/events?contract=&fn=&page=


### PR DESCRIPTION
## Summary

Closes #197 — Dockerize the full stack (PostgreSQL + Indexer + Frontend).

## Changes

### New files
- **docker-compose.yml** — Multi-profile Docker Compose with `dev`, `test`, `staging`, and `prod` profiles. Includes PostgreSQL 16, Indexer, Frontend, and dev-only tooling (Adminer, PgHero).
- **docker-compose.override.yml** — Dev-specific overrides with source volume mounts for hot-reloading via Node.js `--watch` and Vite HMR.
- **indexer/Dockerfile.dev** — Dev Dockerfile with `--watch` hot-reload and `wget` for healthchecks.
- **frontend/Dockerfile.dev** — Dev Dockerfile using Vite dev server on port 5173 with HMR.
- **indexer/.dockerignore** / **frontend/.dockerignore** — Exclude unnecessary files from Docker builds.

### Modified files
- **indexer/Dockerfile** — Added `wget` for healthcheck support.
- **indexer/src/api.js** — Added `GET /health` endpoint for container health checks.
- **frontend/vite.config.ts** — Reads `VITE_API_URL` env var to support Docker container networking.
- **.env.example** — Comprehensive environment variable documentation (all config options).
- **Makefile** — Added Docker targets (`docker-up`, `docker-prod`, `docker-down`, `docker-build`, etc.).

## Usage

```bash
# Development (hot-reload, debug tools)
make docker-up

# Production (optimized builds, nginx)
make docker-prod

# Tail logs
make docker-logs
```
