### PR TITLE
docs: add developer documentation site with API playground and contributor guide

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,97 @@
+name: Docs — Build & Deploy
+
+# Builds the static documentation site (guides, API playground, generated
+# JSDoc + Rustdoc reference) and publishes it to GitHub Pages.
+# Requires Pages to be enabled with "GitHub Actions" as the source.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "indexer/openapi.yaml"
+      - "indexer/src/**"
+      - "contracts/**"
+      - "CONTRIBUTING.md"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install indexer deps (for spec generation)
+        run: npm ci
+        working-directory: indexer
+
+      - name: Regenerate OpenAPI JSON from YAML
+        run: |
+          node -e "
+            const fs = require('fs');
+            const YAML = require('./indexer/node_modules/yaml');
+            const doc = YAML.parse(fs.readFileSync('indexer/openapi.yaml', 'utf8'));
+            fs.writeFileSync('docs/api/openapi.json', JSON.stringify(doc, null, 2) + '\n');
+            console.log('openapi.json regenerated');
+          "
+
+      - name: Assemble static site
+        run: |
+          mkdir -p _site
+          cp -r docs _site/docs
+          cp CONTRIBUTING.md _site/CONTRIBUTING.md
+          cat > _site/index.html <<'EOF'
+          <!doctype html>
+          <meta charset="utf-8" />
+          <meta http-equiv="refresh" content="0; url=./docs/site/index.html" />
+          <title>Soroban Smart Block Explorer Docs</title>
+          <a href="./docs/site/index.html">Continue to the documentation</a>
+          EOF
+
+      - name: Generate JSDoc reference for the indexer
+        continue-on-error: true
+        run: npx --yes jsdoc@4 -r indexer/src -d _site/docs/reference/indexer
+
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Generate Rustdoc for the contract
+        continue-on-error: true
+        run: |
+          cargo doc --no-deps -p soroban-explorer-contract
+          mkdir -p _site/docs/reference/contract
+          cp -r target/doc/* _site/docs/reference/contract/ || true
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,123 @@
+# Contributing to Soroban Smart Block Explorer
+
+Thanks for helping make Soroban contract activity readable. This guide covers the
+workflow, conventions, and quality gates enforced by CI.
+
+For background, read the [developer documentation](docs/site/index.html) and the
+[architecture deep dive](docs/guides/architecture-deep-dive.md).
+
+## Getting set up
+
+1. Fork the repository and clone your fork.
+2. Follow [Getting started](docs/guides/getting-started.md) to run the stack.
+3. Install dependencies for the package you are changing
+   (`indexer/` or `frontend/`) with `npm install`.
+
+## Branch naming convention
+
+CI validates branch names against this pattern:
+
+```
+<type>/<short-description>
+```
+
+Allowed types: `feature`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`,
+`hotfix`, `release`.
+
+Examples: `feature/event-search`, `fix/ws-reconnect`, `docs/api-reference`.
+
+## Commit and PR title conventions
+
+This project follows [Conventional Commits](https://www.conventionalcommits.org/).
+The pull request title is checked by CI and must use the form:
+
+```
+<type>(<optional scope>): <description>
+```
+
+Common types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`,
+`ci`, `chore`. Examples:
+
+```
+feat(indexer): decode SEP-41 burn events
+fix(frontend): handle empty wallet history
+docs(api): add try-it console
+```
+
+Reference the issue your work closes in the PR description, for example
+`Closes #202`.
+
+## Quality gates (run before pushing)
+
+CI runs the following. Reproduce them locally to avoid a red build:
+
+```bash
+# Rust contract
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -p soroban-explorer-contract
+
+# Indexer
+cd indexer && npx eslint --max-warnings 0 src/ && npm test
+
+# Frontend
+cd frontend && npx eslint --max-warnings 0 src/ && npm run build
+
+# Formatting (from the repo root)
+npx prettier --check "indexer/src/**/*.{js,json}" "frontend/src/**/*.{ts,tsx}" "**/*.md"
+```
+
+## Pull request checklist
+
+- [ ] Branch name follows the convention.
+- [ ] PR title follows Conventional Commits.
+- [ ] Lint passes for the package you touched (zero warnings).
+- [ ] Tests pass and new behavior is covered.
+- [ ] Prettier formatting passes for changed files.
+- [ ] Documentation is updated for user-facing or API changes.
+- [ ] The PR description explains the change and links the issue it closes.
+- [ ] No secrets or `.env` values are committed.
+
+## Code review standards
+
+Keep pull requests focused on a single concern. Reviewers look for correctness,
+test coverage, readability, and consistency with the surrounding code. Respond to
+comments with follow-up commits rather than force-pushing over an in-progress
+review.
+
+## Contribution scoring
+
+To recognize ongoing contribution, the project uses a transparent points rubric.
+Points are tallied from merged activity and can drive a leaderboard and badges
+(see the project board for the live tally).
+
+| Action                 | Points |
+| ---------------------- | ------ |
+| PR merged              | +50    |
+| Documentation improved | +30    |
+| Review given           | +20    |
+| Issue filed            | +10    |
+
+### Levels
+
+| Level    | Points  |
+| -------- | ------- |
+| Bronze   | 0–99    |
+| Silver   | 100–299 |
+| Gold     | 300–699 |
+| Platinum | 700+    |
+
+### Badges
+
+- **First PR** — your first merged pull request.
+- **Documentation Hero** — sustained documentation contributions.
+- **Bug Hunter** — multiple confirmed bug fixes.
+
+> The rubric is the source of truth for scoring. Automated tallying and the public
+> leaderboard are tracked separately on the project board.
+
+## Reporting issues
+
+Open issues on the
+[upstream repository](https://github.com/Soroban-Smart-Block-Explorer/Soroban-Smart-Block/issues)
+with reproduction steps, expected versus actual behavior, and environment details.

--- a/README.md
+++ b/README.md
@@ -217,9 +217,25 @@ The decoder recognises SEP-41 token events (`transfer`, `mint`, `burn`) and form
 
 ---
 
+## Documentation
+
+A full developer documentation site lives under [`docs/`](docs/):
+
+- [Documentation home](docs/site/index.html) — guides, reference, and search.
+- [Getting started](docs/guides/getting-started.md) and other step-by-step guides.
+- [API playground](docs/api/playground.html) (Swagger UI) and an interactive
+  [try-it console](docs/api/try-it.html) with curl / JS / Python / Rust snippets.
+- [OpenAPI spec](docs/api/openapi.json) and [API changelog](docs/api/changelog.md).
+- [Interactive architecture explorer](docs/site/architecture.html).
+
+The site is published to GitHub Pages by
+[`.github/workflows/docs.yml`](.github/workflows/docs.yml), which also generates
+JSDoc (indexer) and Rustdoc (contract) reference.
+
 ## Contributing
 
-PRs welcome. Please open an issue first for large changes.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow, commit conventions, and
+PR checklist. Please open an issue first for large changes.
 
 ---
 

--- a/docs/api/changelog.md
+++ b/docs/api/changelog.md
@@ -1,0 +1,72 @@
+# API Changelog
+
+All notable changes to the Soroban Smart Block Explorer HTTP and WebSocket API are
+documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the API follows
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The machine-readable contract lives in [`openapi.json`](./openapi.json) (generated
+from `indexer/openapi.yaml`). Try endpoints live in the
+[Swagger playground](./playground.html) or the [try-it console](./try-it.html).
+
+## [Unreleased]
+
+### Added
+
+- This changelog and a generated OpenAPI 3.1 JSON document for tooling.
+
+## [0.1.0]
+
+### Added
+
+- **Events**
+  - `GET /api/events` — list contract events with offset pagination and filters
+    (`contract`, `fn`, `type`, `page`).
+  - `GET /api/v1/events` — cursor-paginated event listing.
+  - `GET /api/events/{seq}` — full decoded event detail.
+  - `GET /api/events/{seq}/zk-costs` — zero-knowledge cost breakdown for an event.
+- **Contracts**
+  - `GET /api/contracts/{id}` — contract metadata and ABI registry entry.
+  - `GET /api/contracts/{id}/build-metadata` — reproducible build metadata.
+  - `GET /api/contracts/{id}/abi` — decoded ABI for a contract.
+  - `GET /api/contracts/{id}/transactions` — transaction history for a contract.
+  - `GET /api/contracts/{id}/upgrades` — upgrade history.
+  - `GET /api/contracts/{id}/ttl` — time-to-live and archival status.
+  - `GET /api/contracts/{id}/state-diffs` — per-invocation state diffs.
+  - `GET /api/contracts/{id}/circuit-breaker` — circuit-breaker status.
+  - `GET /api/contracts/{id}/migration-status` — migration status.
+  - `GET /api/contracts/{id}/rwa-metadata` — real-world-asset metadata.
+- **Wallets and tokens**
+  - `GET /api/wallet/{address}` — wallet transaction history.
+  - `GET /api/tokens/{id}/holders` — token holder distribution.
+  - `GET /api/tokens/{id}/volume` — token volume over time.
+- **Tools**
+  - `GET /api/spec/{id}` — contract interface specification.
+  - `POST /api/verify` — verify a contract against published source.
+  - `POST /api/simulate` — simulate a contract invocation.
+  - `POST /api/sandbox/simulate` — sandboxed simulation.
+  - `GET /api/auth-tree` — authorization tree for an invocation.
+  - `GET /api/burn-alerts` — token burn alerts.
+  - `GET /api/rpc-metrics` — RPC node metrics.
+  - `GET /api/rpc-nodes` — configured RPC nodes.
+- **WebSocket**
+  - Live event stream over `ws(s)://<host>/?api_key=<key>`. Messages have the
+    shape `{ "type": "event" | "vault_ratio" | "contract_link", "data": ... }`.
+
+### Security
+
+- Optional API key enforcement via the `X-API-Key` header on HTTP requests and the
+  `api_key` query parameter on WebSocket connections.
+- Per-IP rate limiting on the HTTP API.
+
+## Versioning policy
+
+- **Patch** releases cover backward-compatible fixes and additive response fields.
+- **Minor** releases add new endpoints or optional parameters without breaking
+  existing clients.
+- **Major** releases may remove or change existing endpoints. Breaking changes are
+  introduced under a new path prefix (for example `/api/v2/...`) where practical so
+  older clients keep working during migration.
+
+[Unreleased]: https://github.com/Soroban-Smart-Block-Explorer/Soroban-Smart-Block/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/Soroban-Smart-Block-Explorer/Soroban-Smart-Block/releases/tag/v0.1.0

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1,0 +1,891 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Soroban Smart Block Explorer API",
+    "version": "0.1.0",
+    "description": "Human-readable Soroban contract event explorer for the Stellar blockchain."
+  },
+  "servers": [
+    {
+      "url": "https://localhost:3001",
+      "description": "Local development"
+    }
+  ],
+  "paths": {
+    "/api/events": {
+      "get": {
+        "summary": "List contract events (offset pagination)",
+        "parameters": [
+          {
+            "name": "contract",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by contract ID"
+          },
+          {
+            "name": "fn",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by function name"
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "soroban",
+                "classic"
+              ]
+            },
+            "description": "Filter by transaction type"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Array of decoded events",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DecodedEvent"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/events": {
+      "get": {
+        "summary": "List contract events (cursor pagination)",
+        "parameters": [
+          {
+            "name": "contract",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fn",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "soroban",
+                "classic"
+              ]
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Event seq cursor from previous page"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "default": 25
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated events with next_cursor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/DecodedEvent"
+                      }
+                    },
+                    "next_cursor": {
+                      "type": "integer",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/events/{seq}": {
+      "get": {
+        "summary": "Get single event by sequence number",
+        "parameters": [
+          {
+            "name": "seq",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Decoded event",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DecodedEvent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Event not found"
+          }
+        }
+      }
+    },
+    "/api/events/{seq}/zk-costs": {
+      "get": {
+        "summary": "Get ZK host function costs for an event",
+        "parameters": [
+          {
+            "name": "seq",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ZK cost breakdown"
+          }
+        }
+      }
+    },
+    "/api/contracts/{id}": {
+      "get": {
+        "summary": "Get contract metadata",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Contract metadata with dependency advisory",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContractMeta"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Register contract ABI metadata",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ContractRegistration"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Contract registered"
+          },
+          "400": {
+            "description": "Invalid input or ABI verification failed"
+          }
+        }
+      }
+    },
+    "/api/contracts/{id}/build-metadata": {
+      "get": {
+        "summary": "Get WASM build metadata for a contract",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Build metadata (compiler, SDK, repository)"
+          }
+        }
+      }
+    },
+    "/api/contracts/{id}/abi": {
+      "get": {
+        "summary": "Download standardized ABI JSON for a contract",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ABI JSON file"
+          }
+        }
+      }
+    },
+    "/api/contracts/{id}/transactions": {
+      "get": {
+        "summary": "Get paginated transaction history for a contract",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "function_name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "start_ledger",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "end_ledger",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "default": 25
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated transaction list"
+          }
+        }
+      }
+    },
+    "/api/contracts/{id}/upgrades": {
+      "get": {
+        "summary": "Get contract WASM upgrade lineage",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Upgrade history"
+          }
+        }
+      }
+    },
+    "/api/contracts/{id}/ttl": {
+      "get": {
+        "summary": "Get live TTL status for contract instance and code",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "TTL expiration ledgers"
+          }
+        }
+      }
+    },
+    "/api/contracts/{id}/state-diffs": {
+      "get": {
+        "summary": "Get storage state-diff timeline",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "default": 200
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "State diff entries"
+          }
+        }
+      }
+    },
+    "/api/wallet/{address}": {
+      "get": {
+        "summary": "Get events involving a wallet address",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Events matching address"
+          }
+        }
+      }
+    },
+    "/api/tokens/{id}/holders": {
+      "get": {
+        "summary": "Get token holders and balances",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Holders list with balances"
+          }
+        }
+      }
+    },
+    "/api/tokens/{id}/volume": {
+      "get": {
+        "summary": "Get 24-hour transfer volume",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "24h volume data"
+          }
+        }
+      }
+    },
+    "/api/spec/{id}": {
+      "get": {
+        "summary": "Get on-chain contract spec (functions)",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Contract spec functions"
+          }
+        }
+      }
+    },
+    "/api/verify": {
+      "post": {
+        "summary": "Verify ABI against on-chain spec without registering",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "contractId": {
+                    "type": "string"
+                  },
+                  "functions": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/FunctionSpec"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Verification result"
+          }
+        }
+      }
+    },
+    "/api/simulate": {
+      "post": {
+        "summary": "Simulate a contract call",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "contractId": {
+                    "type": "string"
+                  },
+                  "fn": {
+                    "type": "string"
+                  },
+                  "args": {
+                    "type": "array"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Simulation result"
+          }
+        }
+      }
+    },
+    "/api/sandbox/simulate": {
+      "post": {
+        "summary": "Simulate a raw XDR transaction envelope",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "xdrEnvelope": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Simulation result"
+          }
+        }
+      }
+    },
+    "/api/auth-tree": {
+      "post": {
+        "summary": "Parse multi-sig ContractAuth trees",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "auth": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Parsed auth tree"
+          }
+        }
+      }
+    },
+    "/api/burn-alerts": {
+      "get": {
+        "summary": "Get suspicious burn sequence alerts",
+        "parameters": [
+          {
+            "name": "contract",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Burn alerts"
+          }
+        }
+      }
+    },
+    "/api/rpc-metrics": {
+      "get": {
+        "summary": "Get RPC node performance metrics",
+        "responses": {
+          "200": {
+            "description": "RPC metrics"
+          }
+        }
+      }
+    },
+    "/api/rpc-nodes": {
+      "get": {
+        "summary": "Get live RPC node health status",
+        "responses": {
+          "200": {
+            "description": "RPC node statuses"
+          }
+        }
+      }
+    },
+    "/api/contracts/{id}/circuit-breaker": {
+      "get": {
+        "summary": "Get circuit breaker pause status",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Circuit breaker status"
+          }
+        }
+      }
+    },
+    "/api/contracts/{id}/migration-status": {
+      "get": {
+        "summary": "Get SEP-49 migration tracker status",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Migration status"
+          }
+        }
+      }
+    },
+    "/api/contracts/{id}/rwa-metadata": {
+      "get": {
+        "summary": "Get RWA-specific metadata",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "RWA metadata"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-api-key",
+        "description": "API key for write operations. Set via API_KEY environment variable."
+      }
+    },
+    "schemas": {
+      "DecodedEvent": {
+        "type": "object",
+        "properties": {
+          "seq": {
+            "type": "integer"
+          },
+          "contract_id": {
+            "type": "string"
+          },
+          "function": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "integer"
+          },
+          "tx_hash": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "raw_topics": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "raw_data": {
+            "type": "string"
+          },
+          "cpu_instructions": {
+            "type": "integer",
+            "nullable": true
+          },
+          "mem_bytes": {
+            "type": "integer",
+            "nullable": true
+          },
+          "fee_charged": {
+            "type": "integer",
+            "nullable": true
+          },
+          "is_high_bloat_risk": {
+            "type": "boolean"
+          },
+          "upgrade_info": {
+            "type": "object",
+            "nullable": true
+          },
+          "storage_tiers": {
+            "type": "object",
+            "nullable": true
+          }
+        }
+      },
+      "ContractMeta": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "functions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FunctionSpec"
+            }
+          },
+          "has_circuit_breaker": {
+            "type": "boolean"
+          },
+          "is_paused": {
+            "type": "boolean"
+          },
+          "is_rwa": {
+            "type": "boolean"
+          },
+          "rwa_type": {
+            "type": "string",
+            "nullable": true
+          },
+          "dependency_advisory": {
+            "type": "object",
+            "nullable": true
+          }
+        }
+      },
+      "ContractRegistration": {
+        "type": "object",
+        "required": [
+          "id",
+          "functions"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "functions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FunctionSpec"
+            }
+          }
+        }
+      },
+      "FunctionSpec": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "args": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/api/playground.html
+++ b/docs/api/playground.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>API Playground · Soroban Smart Block Explorer</title>
+    <meta
+      name="description"
+      content="Interactive Swagger UI playground for the Soroban Smart Block Explorer API."
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css"
+    />
+    <style>
+      body {
+        margin: 0;
+        background: #0d1117;
+      }
+      .topbar-wrapper {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.85rem 1.25rem;
+        background: #161b22;
+        border-bottom: 1px solid #30363d;
+        color: #e6edf3;
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+      }
+      .topbar-wrapper a {
+        color: #58a6ff;
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .topbar-wrapper strong {
+        font-size: 1rem;
+      }
+      .topbar-wrapper .spacer {
+        flex: 1;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="topbar-wrapper">
+      <strong>⬡ API Playground</strong>
+      <span class="spacer"></span>
+      <a href="../site/index.html">← Docs home</a>
+      <a href="./try-it.html">Try-it console</a>
+      <a href="./changelog.md">API changelog</a>
+    </div>
+    <div id="swagger-ui"></div>
+    <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-standalone-preset.js"></script>
+    <script>
+      window.addEventListener("load", () => {
+        window.ui = SwaggerUIBundle({
+          url: "./openapi.json",
+          dom_id: "#swagger-ui",
+          deepLinking: true,
+          tryItOutEnabled: true,
+          presets: [
+            SwaggerUIBundle.presets.apis,
+            SwaggerUIStandalonePreset,
+          ],
+          plugins: [SwaggerUIBundle.plugins.DownloadUrl],
+          layout: "StandaloneLayout",
+          persistAuthorization: true,
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/docs/api/try-it.html
+++ b/docs/api/try-it.html
@@ -1,0 +1,449 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Try-it Console · Soroban Smart Block Explorer</title>
+    <meta
+      name="description"
+      content="Interactive request console for the Soroban Smart Block Explorer API with multi-language code snippets and a WebSocket tester."
+    />
+    <style>
+      :root {
+        --bg: #0d1117;
+        --panel: #161b22;
+        --border: #30363d;
+        --text: #e6edf3;
+        --muted: #8b949e;
+        --accent: #58a6ff;
+        --green: #3fb950;
+        --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+        line-height: 1.5;
+      }
+      header {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        padding: 0.85rem 1.25rem;
+        background: var(--panel);
+        border-bottom: 1px solid var(--border);
+      }
+      header a {
+        color: var(--accent);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      header .spacer {
+        flex: 1;
+      }
+      main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 1.5rem 1.25rem 4rem;
+      }
+      h1 {
+        font-size: 1.3rem;
+      }
+      h2 {
+        font-size: 1.05rem;
+        margin-top: 2rem;
+        border-bottom: 1px solid var(--border);
+        padding-bottom: 0.4rem;
+      }
+      label {
+        display: block;
+        font-size: 0.8rem;
+        color: var(--muted);
+        margin: 0.75rem 0 0.25rem;
+      }
+      input,
+      select,
+      textarea {
+        width: 100%;
+        background: #0b0f14;
+        color: var(--text);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 0.5rem 0.6rem;
+        font-family: var(--mono);
+        font-size: 0.85rem;
+      }
+      textarea {
+        min-height: 120px;
+        resize: vertical;
+      }
+      .row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 1rem;
+      }
+      button {
+        background: var(--accent);
+        color: #0d1117;
+        border: 0;
+        border-radius: 6px;
+        padding: 0.55rem 1.1rem;
+        font-weight: 600;
+        cursor: pointer;
+        margin-top: 1rem;
+      }
+      button.secondary {
+        background: transparent;
+        color: var(--accent);
+        border: 1px solid var(--border);
+      }
+      .params {
+        margin-top: 0.5rem;
+      }
+      pre {
+        background: #0b0f14;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 0.85rem;
+        overflow: auto;
+        font-family: var(--mono);
+        font-size: 0.82rem;
+      }
+      .tabs {
+        display: flex;
+        gap: 0.4rem;
+        flex-wrap: wrap;
+        margin-top: 0.75rem;
+      }
+      .tabs button {
+        margin: 0;
+        background: var(--panel);
+        color: var(--muted);
+        border: 1px solid var(--border);
+        padding: 0.35rem 0.8rem;
+        font-weight: 500;
+      }
+      .tabs button.active {
+        color: var(--text);
+        border-color: var(--accent);
+      }
+      .status {
+        font-family: var(--mono);
+        font-size: 0.85rem;
+      }
+      .status.ok {
+        color: var(--green);
+      }
+      .status.err {
+        color: #f85149;
+      }
+      .hint {
+        font-size: 0.8rem;
+        color: var(--muted);
+      }
+      code {
+        font-family: var(--mono);
+        color: var(--accent);
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <strong>⬡ Try-it Console</strong>
+      <span class="spacer"></span>
+      <a href="../site/index.html">← Docs home</a>
+      <a href="./playground.html">Swagger UI</a>
+      <a href="./changelog.md">API changelog</a>
+    </header>
+    <main>
+      <h1>Interactive API console</h1>
+      <p class="hint">
+        Pick an endpoint, fill in parameters, and send a real request against a
+        running indexer. The auth helper stores your API key once and applies it
+        to every request and snippet. Nothing leaves your browser except the
+        request you send.
+      </p>
+
+      <h2>Connection</h2>
+      <div class="row">
+        <div>
+          <label for="baseUrl">Base URL</label>
+          <input id="baseUrl" value="http://localhost:3001" />
+        </div>
+        <div>
+          <label for="apiKey">API key (optional, sent as X-API-Key)</label>
+          <input id="apiKey" placeholder="paste once, applies everywhere" />
+        </div>
+      </div>
+
+      <h2>Request</h2>
+      <label for="endpoint">Endpoint</label>
+      <select id="endpoint"></select>
+      <div class="params" id="params"></div>
+      <div id="bodyWrap" style="display: none">
+        <label for="body">Request body (JSON)</label>
+        <textarea id="body">{}</textarea>
+      </div>
+      <button id="send">Send request</button>
+      <span id="status" class="status"></span>
+
+      <h2>Response</h2>
+      <pre id="response">No request sent yet.</pre>
+
+      <h2>Code snippet</h2>
+      <div class="tabs" id="langTabs">
+        <button data-lang="curl" class="active">curl</button>
+        <button data-lang="js">JavaScript</button>
+        <button data-lang="python">Python</button>
+        <button data-lang="rust">Rust</button>
+      </div>
+      <pre id="snippet"></pre>
+
+      <h2>WebSocket console</h2>
+      <p class="hint">
+        The indexer pushes live messages of the form
+        <code>{ "type": "event" | "vault_ratio" | "contract_link", "data": ... }</code>
+        . Connect to <code>ws(s)://&lt;host&gt;/?api_key=&lt;key&gt;</code>.
+      </p>
+      <div class="row">
+        <div>
+          <label for="wsUrl">WebSocket URL</label>
+          <input id="wsUrl" value="ws://localhost:3001/" />
+        </div>
+        <div style="display: flex; align-items: flex-end; gap: 0.5rem">
+          <button id="wsConnect" style="margin: 0">Connect</button>
+          <button id="wsClose" class="secondary" style="margin: 0">
+            Disconnect
+          </button>
+        </div>
+      </div>
+      <span id="wsStatus" class="status"></span>
+      <pre id="wsLog">Not connected.</pre>
+    </main>
+
+    <script>
+      const $ = (id) => document.getElementById(id);
+      let spec = null;
+      let operations = [];
+      let currentLang = "curl";
+
+      async function loadSpec() {
+        const res = await fetch("./openapi.json");
+        spec = await res.json();
+        const base = spec.servers && spec.servers[0] && spec.servers[0].url;
+        if (base) $("baseUrl").value = base.replace("https://", "http://");
+        operations = [];
+        for (const [path, item] of Object.entries(spec.paths || {})) {
+          for (const [method, op] of Object.entries(item)) {
+            if (!["get", "post", "put", "delete", "patch"].includes(method))
+              continue;
+            operations.push({ path, method, op });
+          }
+        }
+        const sel = $("endpoint");
+        sel.innerHTML = operations
+          .map(
+            (o, i) =>
+              `<option value="${i}">${o.method.toUpperCase()} ${o.path} — ${(o.op.summary || "").replace(/"/g, "")}</option>`,
+          )
+          .join("");
+        renderParams();
+      }
+
+      function pathParams(path) {
+        return (path.match(/{(\w+)}/g) || []).map((s) => s.slice(1, -1));
+      }
+
+      function currentOp() {
+        return operations[Number($("endpoint").value)] || operations[0];
+      }
+
+      function renderParams() {
+        const o = currentOp();
+        if (!o) return;
+        const container = $("params");
+        container.innerHTML = "";
+        const params = o.op.parameters || [];
+        for (const name of pathParams(o.path)) {
+          if (!params.find((p) => p.name === name))
+            params.push({ name, in: "path", required: true });
+        }
+        for (const p of params) {
+          const wrap = document.createElement("div");
+          const req = p.required ? " *" : "";
+          wrap.innerHTML = `<label>${p.name} <span class="hint">(${p.in}${req})</span></label>`;
+          const input = document.createElement("input");
+          input.dataset.name = p.name;
+          input.dataset.in = p.in;
+          input.placeholder = (p.schema && p.schema.type) || "";
+          wrap.appendChild(input);
+          container.appendChild(wrap);
+        }
+        $("bodyWrap").style.display = o.op.requestBody ? "block" : "none";
+        updateSnippet();
+      }
+
+      function buildUrl() {
+        const o = currentOp();
+        let path = o.path;
+        const query = [];
+        document.querySelectorAll("#params input").forEach((input) => {
+          const v = input.value.trim();
+          if (!v) return;
+          if (input.dataset.in === "path") {
+            path = path.replace(`{${input.dataset.name}}`, encodeURIComponent(v));
+          } else {
+            query.push(
+              `${encodeURIComponent(input.dataset.name)}=${encodeURIComponent(v)}`,
+            );
+          }
+        });
+        const base = $("baseUrl").value.replace(/\/$/, "");
+        return base + path + (query.length ? "?" + query.join("&") : "");
+      }
+
+      function requestInit() {
+        const o = currentOp();
+        const headers = {};
+        const key = $("apiKey").value.trim();
+        if (key) headers["X-API-Key"] = key;
+        const init = { method: o.method.toUpperCase(), headers };
+        if (o.op.requestBody) {
+          headers["Content-Type"] = "application/json";
+          init.body = $("body").value;
+        }
+        return init;
+      }
+
+      async function send() {
+        const url = buildUrl();
+        const init = requestInit();
+        $("status").textContent = "Sending…";
+        $("status").className = "status";
+        try {
+          const res = await fetch(url, init);
+          const text = await res.text();
+          let pretty = text;
+          try {
+            pretty = JSON.stringify(JSON.parse(text), null, 2);
+          } catch (_) {}
+          $("response").textContent = pretty || "(empty body)";
+          $("status").textContent = `${res.status} ${res.statusText}`;
+          $("status").className = "status " + (res.ok ? "ok" : "err");
+        } catch (err) {
+          $("response").textContent = String(err);
+          $("status").textContent = "Network error (is the indexer running?)";
+          $("status").className = "status err";
+        }
+      }
+
+      function snippet(lang) {
+        const url = buildUrl();
+        const init = requestInit();
+        const method = init.method;
+        const key = $("apiKey").value.trim();
+        const body = init.body;
+        if (lang === "curl") {
+          let s = `curl -X ${method} "${url}"`;
+          if (key) s += ` \\\n  -H "X-API-Key: ${key}"`;
+          if (body) s += ` \\\n  -H "Content-Type: application/json" \\\n  -d '${body}'`;
+          return s;
+        }
+        if (lang === "js") {
+          const opts = { method, headers: init.headers };
+          if (body) opts.body = body;
+          return `const res = await fetch("${url}", ${JSON.stringify(opts, null, 2)});\nconst data = await res.json();\nconsole.log(data);`;
+        }
+        if (lang === "python") {
+          let s = `import requests\n\nres = requests.${method.toLowerCase()}(\n    "${url}",`;
+          if (key) s += `\n    headers={"X-API-Key": "${key}"},`;
+          if (body) s += `\n    json=${body},`;
+          s += `\n)\nprint(res.json())`;
+          return s;
+        }
+        if (lang === "rust") {
+          let s = `// Cargo.toml: reqwest = { version = "0.12", features = ["json"] }, tokio = { version = "1", features = ["full"] }\nlet client = reqwest::Client::new();\nlet res = client\n    .${method.toLowerCase()}("${url}")`;
+          if (key) s += `\n    .header("X-API-Key", "${key}")`;
+          if (body) s += `\n    .body(r#"${body}"#)`;
+          s += `\n    .send()\n    .await?;\nprintln!("{}", res.text().await?);`;
+          return s;
+        }
+        return "";
+      }
+
+      function updateSnippet() {
+        $("snippet").textContent = snippet(currentLang);
+      }
+
+      // WebSocket console
+      let socket = null;
+      function wsLog(line) {
+        const el = $("wsLog");
+        if (el.textContent === "Not connected.") el.textContent = "";
+        el.textContent += line + "\n";
+        el.scrollTop = el.scrollHeight;
+      }
+      function wsConnect() {
+        const base = $("wsUrl").value.trim();
+        const key = $("apiKey").value.trim();
+        const url = base + (key ? `?api_key=${encodeURIComponent(key)}` : "");
+        try {
+          socket = new WebSocket(url);
+        } catch (err) {
+          $("wsStatus").textContent = String(err);
+          $("wsStatus").className = "status err";
+          return;
+        }
+        socket.onopen = () => {
+          $("wsStatus").textContent = "Connected";
+          $("wsStatus").className = "status ok";
+          wsLog("[open] connected to " + base);
+        };
+        socket.onmessage = (e) => wsLog("[message] " + e.data);
+        socket.onerror = () => {
+          $("wsStatus").textContent = "Socket error";
+          $("wsStatus").className = "status err";
+        };
+        socket.onclose = (e) => {
+          $("wsStatus").textContent = `Closed (${e.code})`;
+          $("wsStatus").className = "status";
+          wsLog("[close] " + e.code);
+        };
+      }
+      function wsClose() {
+        if (socket) socket.close();
+      }
+
+      document.addEventListener("DOMContentLoaded", () => {
+        loadSpec().catch((err) => {
+          $("response").textContent =
+            "Could not load openapi.json: " + err.message;
+        });
+        $("endpoint").addEventListener("change", renderParams);
+        $("params").addEventListener("input", updateSnippet);
+        $("baseUrl").addEventListener("input", updateSnippet);
+        $("apiKey").addEventListener("input", updateSnippet);
+        $("body").addEventListener("input", updateSnippet);
+        $("send").addEventListener("click", send);
+        $("langTabs").addEventListener("click", (e) => {
+          if (e.target.dataset.lang) {
+            currentLang = e.target.dataset.lang;
+            document
+              .querySelectorAll("#langTabs button")
+              .forEach((b) => b.classList.toggle("active", b === e.target));
+            updateSnippet();
+          }
+        });
+        $("wsConnect").addEventListener("click", wsConnect);
+        $("wsClose").addEventListener("click", wsClose);
+      });
+    </script>
+  </body>
+</html>

--- a/docs/guides/architecture-deep-dive.md
+++ b/docs/guides/architecture-deep-dive.md
@@ -1,0 +1,70 @@
+# Architecture deep dive
+
+This guide explains how data flows from the Stellar network to the user's screen.
+For a clickable version, open the
+[interactive architecture explorer](../site/architecture.html).
+
+## The pipeline
+
+```
+Stellar RPC / Horizon
+        │  poll every few seconds (getEvents, getTransaction)
+        ▼
+   Indexer (Node.js)
+        │  decode XDR → human text via the ABI registry
+        ▼
+   PostgreSQL  ──────▶  REST + WebSocket API (Express)
+                                │
+                                ▼
+                    React Frontend (Vite + TanStack Query)
+```
+
+## Components
+
+### Stellar network (data source)
+
+The indexer polls Soroban RPC for contract events and Horizon for classic asset
+data. This is the single source of truth; everything downstream is derived.
+
+### Indexer (logic)
+
+The indexer is the heart of the system. On each poll it:
+
+1. Fetches new events since the last processed ledger.
+2. Decodes raw XDR into structured values using the ABI-like metadata registry,
+   falling back to heuristic decoding when a contract is not registered.
+3. Formats amounts using token symbols and decimals (including SEP-41 tokens).
+4. Writes decoded events to PostgreSQL.
+5. Publishes new events to the WebSocket bus for live subscribers.
+
+### PostgreSQL (data)
+
+Stores decoded events, contract metadata, and derived analytics so the API can
+answer queries quickly without re-reading the chain.
+
+### REST + WebSocket API (logic)
+
+An Express server exposes the decoded data:
+
+- **REST** on `:3001` for queries over events, contracts, wallets, and tokens.
+- **WebSocket** for live `event`, `vault_ratio`, and `contract_link` messages.
+
+Optional API key authentication and per-IP rate limiting protect the endpoints.
+
+### React frontend (presentation)
+
+A Vite and React application using TanStack Query for data fetching. It renders
+the event feed, contract and wallet pages, and decoded event detail views.
+
+## Why this shape
+
+- **Decoding happens once, in the indexer.** Clients never deal with raw XDR.
+- **The database is a read cache of the chain.** It can be rebuilt by re-indexing.
+- **The API is thin.** It serves what the indexer already decoded, which keeps
+  request latency low and the frontend simple.
+
+## Where to go next
+
+- [Getting started](#getting-started) to run the pipeline yourself.
+- [Building with the API](#building-with-the-api) to consume its output.
+- The [API playground](../api/playground.html) to explore every endpoint.

--- a/docs/guides/building-with-the-api.md
+++ b/docs/guides/building-with-the-api.md
@@ -1,0 +1,88 @@
+# Building with the API
+
+The indexer exposes a REST API for decoded events, contracts, wallets, and tokens,
+plus a WebSocket stream for live updates. This guide shows the common patterns.
+The full contract is in [`openapi.json`](../api/openapi.json); try any endpoint in
+the [Swagger playground](../api/playground.html) or the
+[try-it console](../api/try-it.html).
+
+## Base URL and authentication
+
+The API listens on `http://localhost:3001` by default. When an API key is
+configured on the server, send it as the `X-API-Key` header:
+
+```bash
+curl http://localhost:3001/api/events \
+  -H "X-API-Key: $API_KEY"
+```
+
+## List events
+
+```bash
+# Offset pagination with filters
+curl "http://localhost:3001/api/events?contract=C...&fn=swap&page=1"
+
+# Cursor pagination
+curl "http://localhost:3001/api/v1/events?limit=50"
+```
+
+```javascript
+const res = await fetch("http://localhost:3001/api/events?fn=swap&page=1", {
+  headers: { "X-API-Key": API_KEY },
+});
+const events = await res.json();
+```
+
+```python
+import requests
+
+events = requests.get(
+    "http://localhost:3001/api/events",
+    params={"fn": "swap", "page": 1},
+    headers={"X-API-Key": API_KEY},
+).json()
+```
+
+## Fetch a single event and a contract
+
+```bash
+curl http://localhost:3001/api/events/4521983
+curl http://localhost:3001/api/contracts/C...
+curl http://localhost:3001/api/contracts/C.../abi
+```
+
+## Wallets and tokens
+
+```bash
+curl http://localhost:3001/api/wallet/G...
+curl http://localhost:3001/api/tokens/C.../holders
+curl http://localhost:3001/api/tokens/C.../volume
+```
+
+## Live updates over WebSocket
+
+Connect to `ws(s)://<host>/?api_key=<key>`. The server pushes JSON messages:
+
+```javascript
+const ws = new WebSocket("ws://localhost:3001/?api_key=" + API_KEY);
+ws.onmessage = (msg) => {
+  const { type, data } = JSON.parse(msg.data);
+  // type is "event" | "vault_ratio" | "contract_link"
+  console.log(type, data);
+};
+```
+
+You can experiment with the stream in the
+[try-it console](../api/try-it.html#websocket).
+
+## Error handling and rate limits
+
+- Non-2xx responses return a JSON body with an error message.
+- A `401` means the API key is missing or wrong.
+- The HTTP API is rate limited per IP. Back off and retry on `429`.
+
+## Next steps
+
+- [Register a contract](#register-contract) to improve decoding quality.
+- Read the [architecture deep dive](#architecture-deep-dive) to understand how
+  events are produced.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,0 +1,79 @@
+# Getting started
+
+This guide takes you from a fresh clone to a running explorer: the Soroban
+contract, the indexer and API, and the React frontend.
+
+## Prerequisites
+
+- Rust with the `wasm32-unknown-unknown` target
+- [Stellar CLI](https://developers.stellar.org/docs/tools/developer-tools/cli/stellar-cli)
+- Node.js 20 or newer
+- PostgreSQL (or Docker, which provisions it for you)
+
+## 1. Clone and configure
+
+```bash
+git clone https://github.com/Soroban-Smart-Block-Explorer/Soroban-Smart-Block
+cd Soroban-Smart-Block
+cp .env.example .env
+```
+
+Open `.env` and set at least `SOROBAN_RPC_URL` and `DATABASE_URL`. The defaults
+target Stellar testnet and a local PostgreSQL instance.
+
+## 2. Build and deploy the contract
+
+```bash
+make build    # compile the contract to WASM
+make test     # run the contract unit tests
+make deploy   # deploy to testnet and print CONTRACT_ID
+```
+
+Copy the printed contract ID into `.env` as `EXPLORER_CONTRACT_ID`.
+
+## 3. Start the indexer and API
+
+```bash
+make indexer-install
+make indexer
+```
+
+The REST API comes up on `http://localhost:3001` and the WebSocket stream on the
+same host. Confirm it is healthy:
+
+```bash
+curl http://localhost:3001/api/events
+```
+
+## 4. Start the frontend
+
+```bash
+make frontend-install
+make frontend
+```
+
+Open `http://localhost:5173`.
+
+## Run everything together
+
+```bash
+make install   # install indexer and frontend dependencies
+make dev        # run indexer and frontend in parallel
+```
+
+## With Docker
+
+If you prefer containers, the full stack (including PostgreSQL) starts with:
+
+```bash
+make docker-up      # dev stack with hot reload
+make docker-logs    # tail logs
+make docker-down    # stop everything
+```
+
+## Next steps
+
+- [Register a contract](#register-contract) so its events decode into plain
+  English.
+- [Build with the API](#building-with-the-api) from your own application.
+- Explore every endpoint in the [Swagger playground](../api/playground.html).

--- a/docs/guides/register-contract.md
+++ b/docs/guides/register-contract.md
@@ -1,0 +1,70 @@
+# Registering a contract
+
+The explorer turns raw Soroban XDR into readable text by looking up ABI-like
+metadata for each contract. Until a contract is registered, its events fall back
+to heuristic decoding. Registering it gives precise function names, argument
+labels, and token formatting.
+
+## What metadata provides
+
+| Without registration           | With registration                           |
+| ------------------------------ | ------------------------------------------- |
+| Best-effort heuristic decoding | Exact function and argument names           |
+| Generic amount formatting      | Token symbol and decimals applied           |
+| No contract page metadata      | Name, version, and ABI on the contract page |
+
+## Register on-chain
+
+The contract exposes a registry. Use the Stellar CLI to register metadata for a
+contract ID:
+
+```bash
+stellar contract invoke \
+  --id $EXPLORER_CONTRACT_ID \
+  --source default \
+  --network testnet \
+  -- register_contract \
+  --caller $YOUR_ADDRESS \
+  --contract_id $TARGET_CONTRACT_ID \
+  --meta '{ "name": "StellarSwap", "version": "1.0.0" }'
+```
+
+The relevant contract functions are:
+
+| Function                                       | Description                           |
+| ---------------------------------------------- | ------------------------------------- |
+| `register_contract(caller, contract_id, meta)` | Register ABI metadata for a contract  |
+| `update_contract(caller, contract_id, meta)`   | Update metadata (admin or registrant) |
+| `get_contract(contract_id)`                    | Fetch the stored metadata             |
+
+## Register through the API
+
+The indexer also accepts metadata over HTTP, which the frontend upload flow uses:
+
+```bash
+curl -X POST http://localhost:3001/api/contracts \
+  -H "Content-Type: application/json" \
+  -d '{
+    "contract_id": "C...",
+    "meta": { "name": "StellarSwap", "version": "1.0.0" }
+  }'
+```
+
+## Verify the result
+
+Fetch the contract to confirm the metadata is stored, then load a recent event to
+see the improved decoding:
+
+```bash
+curl http://localhost:3001/api/contracts/C...
+curl "http://localhost:3001/api/events?contract=C...&page=1"
+```
+
+A `swap` invocation should now read as a human sentence such as
+"Address `GABC…` swapped 100 USDC to 98.7 XLM" rather than raw XDR.
+
+## Next steps
+
+- [Build with the API](#building-with-the-api) to consume the decoded events.
+- See the full ABI shape in the
+  [contract registry schema](https://github.com/Soroban-Smart-Block-Explorer/Soroban-Smart-Block/blob/main/indexer/src/contractRegistry.schema.json).

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -1,0 +1,341 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Architecture Explorer · Soroban Smart Block Explorer</title>
+    <meta
+      name="description"
+      content="Interactive, clickable architecture diagram of the Soroban Smart Block Explorer."
+    />
+    <link rel="stylesheet" href="./styles.css" />
+    <style>
+      .layout {
+        display: grid;
+        grid-template-columns: 1.4fr 1fr;
+        gap: 1.5rem;
+      }
+      @media (max-width: 820px) {
+        .layout {
+          grid-template-columns: 1fr;
+        }
+      }
+      .diagram {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 1rem;
+      }
+      .node {
+        cursor: pointer;
+        transition: opacity 0.15s;
+      }
+      .node rect {
+        stroke-width: 1.5;
+      }
+      .node text {
+        fill: var(--text);
+        font-size: 13px;
+        font-family:
+          system-ui,
+          sans-serif;
+        pointer-events: none;
+      }
+      .node:hover {
+        opacity: 0.85;
+      }
+      .node.dim {
+        opacity: 0.25;
+      }
+      .edge {
+        stroke: #56607a;
+        stroke-width: 1.5;
+        fill: none;
+      }
+      .edge.flow {
+        stroke-dasharray: 6 6;
+        animation: dash 1s linear infinite;
+        stroke: var(--accent);
+      }
+      @keyframes dash {
+        to {
+          stroke-dashoffset: -12;
+        }
+      }
+      .panel {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 1.25rem;
+      }
+      .panel h3 {
+        margin-top: 0;
+      }
+      .panel .tech {
+        display: inline-block;
+        font-family: var(--mono);
+        font-size: 0.75rem;
+        padding: 0.15rem 0.5rem;
+        border-radius: 999px;
+        border: 1px solid var(--border);
+        margin-bottom: 0.75rem;
+      }
+      .panel ul {
+        padding-left: 1.1rem;
+      }
+      .controls {
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+        margin-bottom: 1rem;
+      }
+      .controls button {
+        background: var(--panel-2);
+        color: var(--muted);
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        padding: 0.3rem 0.8rem;
+        font-size: 0.8rem;
+        cursor: pointer;
+      }
+      .controls button.active {
+        color: var(--text);
+        border-color: var(--accent);
+      }
+    </style>
+  </head>
+  <body>
+    <header class="site">
+      <span class="brand">⬡ Architecture Explorer</span>
+      <span class="spacer"></span>
+      <nav>
+        <a href="./index.html">Docs home</a>
+        <a href="./guides.html#architecture-deep-dive">Deep dive</a>
+        <a href="../api/playground.html">API</a>
+      </nav>
+    </header>
+
+    <main>
+      <h1>Interactive architecture</h1>
+      <p style="color: var(--muted)">
+        Click any component to see what it does, the technology behind it, and
+        where to read more. Use the filters to highlight a single layer, or play
+        the data flow.
+      </p>
+
+      <div class="controls" id="controls">
+        <button data-layer="all" class="active">All layers</button>
+        <button data-layer="data">Data</button>
+        <button data-layer="logic">Logic</button>
+        <button data-layer="presentation">Presentation</button>
+        <button id="flowToggle">▶ Animate data flow</button>
+      </div>
+
+      <div class="layout">
+        <div class="diagram">
+          <svg viewBox="0 0 480 460" width="100%" id="svg">
+            <g class="edges" id="edges"></g>
+            <g id="nodes"></g>
+          </svg>
+        </div>
+        <aside class="panel" id="panel">
+          <h3>Select a component</h3>
+          <p style="color: var(--muted)">
+            Click a node in the diagram to inspect it.
+          </p>
+        </aside>
+      </div>
+    </main>
+
+    <footer class="site">Soroban Smart Block Explorer · Architecture</footer>
+
+    <script>
+      const nodes = {
+        stellar: {
+          x: 150,
+          y: 20,
+          w: 180,
+          h: 48,
+          label: "Stellar Network",
+          layer: "data",
+          color: "#bc8cff",
+          tech: "Soroban RPC / Horizon",
+          desc: "Source of truth. The indexer polls getEvents and getTransaction for new ledger activity.",
+          links: [["Getting started", "./guides.html#getting-started"]],
+        },
+        indexer: {
+          x: 40,
+          y: 130,
+          w: 160,
+          h: 48,
+          label: "Indexer",
+          layer: "logic",
+          color: "#3fb950",
+          tech: "Node.js",
+          desc: "Fetches raw events, decodes XDR into human text using the ABI registry, and writes decoded events to PostgreSQL.",
+          links: [
+            ["Architecture deep dive", "./guides.html#architecture-deep-dive"],
+            ["Register a contract", "./guides.html#register-contract"],
+          ],
+        },
+        postgres: {
+          x: 280,
+          y: 130,
+          w: 160,
+          h: 48,
+          label: "PostgreSQL",
+          layer: "data",
+          color: "#bc8cff",
+          tech: "PostgreSQL",
+          desc: "Stores decoded events, contract metadata, and derived analytics for fast querying.",
+          links: [],
+        },
+        api: {
+          x: 280,
+          y: 240,
+          w: 160,
+          h: 48,
+          label: "REST + WS API",
+          layer: "logic",
+          color: "#3fb950",
+          tech: "Express",
+          desc: "Serves decoded data over a REST API on :3001 and pushes live updates over WebSocket.",
+          links: [
+            ["API playground", "../api/playground.html"],
+            ["Try-it console", "../api/try-it.html"],
+          ],
+        },
+        ws: {
+          x: 40,
+          y: 240,
+          w: 160,
+          h: 48,
+          label: "WebSocket stream",
+          layer: "logic",
+          color: "#3fb950",
+          tech: "ws",
+          desc: "Broadcasts event, vault_ratio, and contract_link messages to connected clients in real time.",
+          links: [["Try-it console", "../api/try-it.html"]],
+        },
+        frontend: {
+          x: 150,
+          y: 360,
+          w: 180,
+          h: 48,
+          label: "React Frontend",
+          layer: "presentation",
+          color: "#ffa657",
+          tech: "Vite + React + TanStack Query",
+          desc: "The user interface: event feed, contract and wallet pages, and decoded event detail views.",
+          links: [["Building with the API", "./guides.html#building-with-the-api"]],
+        },
+      };
+
+      const edges = [
+        ["stellar", "indexer"],
+        ["indexer", "postgres"],
+        ["postgres", "api"],
+        ["indexer", "ws"],
+        ["api", "frontend"],
+        ["ws", "frontend"],
+      ];
+
+      const svgNodes = document.getElementById("nodes");
+      const svgEdges = document.getElementById("edges");
+      const panel = document.getElementById("panel");
+
+      function center(n) {
+        return { x: n.x + n.w / 2, y: n.y + n.h / 2 };
+      }
+
+      edges.forEach(([a, b]) => {
+        const ca = center(nodes[a]);
+        const cb = center(nodes[b]);
+        const path = document.createElementNS(
+          "http://www.w3.org/2000/svg",
+          "path",
+        );
+        path.setAttribute("d", `M ${ca.x} ${ca.y} L ${cb.x} ${cb.y}`);
+        path.setAttribute("class", "edge");
+        path.dataset.edge = `${a}-${b}`;
+        svgEdges.appendChild(path);
+      });
+
+      Object.entries(nodes).forEach(([id, n]) => {
+        const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+        g.setAttribute("class", "node");
+        g.dataset.id = id;
+        g.dataset.layer = n.layer;
+        const rect = document.createElementNS(
+          "http://www.w3.org/2000/svg",
+          "rect",
+        );
+        rect.setAttribute("x", n.x);
+        rect.setAttribute("y", n.y);
+        rect.setAttribute("width", n.w);
+        rect.setAttribute("height", n.h);
+        rect.setAttribute("rx", 9);
+        rect.setAttribute("fill", "#1c2230");
+        rect.setAttribute("stroke", n.color);
+        const text = document.createElementNS(
+          "http://www.w3.org/2000/svg",
+          "text",
+        );
+        text.setAttribute("x", n.x + n.w / 2);
+        text.setAttribute("y", n.y + n.h / 2 + 4);
+        text.setAttribute("text-anchor", "middle");
+        text.textContent = n.label;
+        g.appendChild(rect);
+        g.appendChild(text);
+        g.addEventListener("click", () => select(id));
+        svgNodes.appendChild(g);
+      });
+
+      function select(id) {
+        const n = nodes[id];
+        panel.innerHTML = `
+          <h3>${n.label}</h3>
+          <span class="tech" style="color:${n.color};border-color:${n.color}">${n.tech}</span>
+          <p>${n.desc}</p>
+          ${
+            n.links.length
+              ? "<ul>" +
+                n.links
+                  .map(([t, u]) => `<li><a href="${u}">${t}</a></li>`)
+                  .join("") +
+                "</ul>"
+              : ""
+          }`;
+      }
+
+      // layer filter
+      document.getElementById("controls").addEventListener("click", (e) => {
+        const layer = e.target.dataset.layer;
+        if (!layer) return;
+        document
+          .querySelectorAll("#controls button[data-layer]")
+          .forEach((b) => b.classList.toggle("active", b === e.target));
+        document.querySelectorAll(".node").forEach((node) => {
+          node.classList.toggle(
+            "dim",
+            layer !== "all" && node.dataset.layer !== layer,
+          );
+        });
+      });
+
+      // flow animation
+      let flowing = false;
+      document.getElementById("flowToggle").addEventListener("click", (e) => {
+        flowing = !flowing;
+        document
+          .querySelectorAll(".edge")
+          .forEach((edge) => edge.classList.toggle("flow", flowing));
+        e.target.textContent = flowing
+          ? "⏸ Pause data flow"
+          : "▶ Animate data flow";
+      });
+
+      select("indexer");
+    </script>
+  </body>
+</html>

--- a/docs/site/guides.html
+++ b/docs/site/guides.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Guides · Soroban Smart Block Explorer</title>
+    <meta
+      name="description"
+      content="Step-by-step walkthroughs for the Soroban Smart Block Explorer."
+    />
+    <link rel="stylesheet" href="./styles.css" />
+    <style>
+      .guides-layout {
+        display: grid;
+        grid-template-columns: 220px 1fr;
+        gap: 2rem;
+      }
+      @media (max-width: 820px) {
+        .guides-layout {
+          grid-template-columns: 1fr;
+        }
+      }
+      .toc {
+        position: sticky;
+        top: 80px;
+        align-self: start;
+        font-size: 0.9rem;
+      }
+      .toc a {
+        display: block;
+        padding: 0.3rem 0;
+        color: var(--muted);
+      }
+      .toc a:hover {
+        color: var(--text);
+      }
+      .content h1,
+      .content h2 {
+        border-bottom: 1px solid var(--border);
+        padding-bottom: 0.35rem;
+      }
+      .content h2 {
+        margin-top: 2.5rem;
+      }
+      .content pre {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 0.9rem;
+        overflow: auto;
+      }
+      .content code {
+        font-family: var(--mono);
+        font-size: 0.85em;
+      }
+      .content :not(pre) > code {
+        background: var(--panel);
+        padding: 0.1rem 0.35rem;
+        border-radius: 4px;
+      }
+      .content table {
+        border-collapse: collapse;
+        width: 100%;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.45rem 0.7rem;
+        text-align: left;
+      }
+      .video-callout {
+        background: var(--panel);
+        border: 1px dashed var(--border);
+        border-radius: 8px;
+        padding: 0.8rem 1rem;
+        color: var(--muted);
+        font-size: 0.85rem;
+        margin: 1rem 0;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="site">
+      <span class="brand">⬡ Guides</span>
+      <span class="spacer"></span>
+      <nav>
+        <a href="./index.html">Docs home</a>
+        <a href="./architecture.html">Architecture</a>
+        <a href="../api/playground.html">API</a>
+      </nav>
+    </header>
+
+    <main>
+      <div class="guides-layout">
+        <nav class="toc" id="toc"></nav>
+        <article class="content" id="content">Loading guides…</article>
+      </div>
+    </main>
+
+    <footer class="site">Soroban Smart Block Explorer · Guides</footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"></script>
+    <script>
+      const guides = [
+        ["getting-started", "Getting started", "5 min"],
+        ["register-contract", "Registering a contract", "3 min"],
+        ["building-with-the-api", "Building with the API", "10 min"],
+        ["architecture-deep-dive", "Architecture deep dive", "15 min"],
+      ];
+
+      async function load() {
+        const content = document.getElementById("content");
+        const toc = document.getElementById("toc");
+        content.innerHTML = "";
+        for (const [slug, title, time] of guides) {
+          const section = document.createElement("section");
+          section.id = slug;
+          const link = document.createElement("a");
+          link.href = "#" + slug;
+          link.textContent = title;
+          toc.appendChild(link);
+          try {
+            const res = await fetch(`../guides/${slug}.md`);
+            const md = await res.text();
+            const callout = `<div class="video-callout">📹 A ${time} video walkthrough for "${title}" can be embedded here. The written guide below is the source of truth.</div>`;
+            section.innerHTML = callout + marked.parse(md);
+          } catch (err) {
+            section.innerHTML = `<p>Could not load ${slug}.md.</p>`;
+          }
+          content.appendChild(section);
+        }
+        if (location.hash) {
+          const el = document.querySelector(location.hash);
+          if (el) el.scrollIntoView();
+        }
+      }
+      load();
+    </script>
+  </body>
+</html>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Soroban Smart Block Explorer · Developer Docs</title>
+    <meta
+      name="description"
+      content="Developer documentation for the Soroban Smart Block Explorer: guides, interactive API playground, architecture, and reference."
+    />
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <header class="site">
+      <span class="brand">⬡ Soroban Explorer Docs</span>
+      <span class="spacer"></span>
+      <nav>
+        <a href="./guides.html">Guides</a>
+        <a href="./architecture.html">Architecture</a>
+        <a href="../api/playground.html">API</a>
+        <a href="../../CONTRIBUTING.md">Contributing</a>
+        <a
+          href="https://github.com/Soroban-Smart-Block-Explorer/Soroban-Smart-Block"
+          >GitHub</a
+        >
+      </nav>
+      <button class="search-trigger" id="searchTrigger">
+        Search <kbd>Ctrl</kbd><kbd>K</kbd>
+      </button>
+    </header>
+
+    <main>
+      <section class="hero">
+        <h1>Developer documentation</h1>
+        <p>
+          Everything you need to run, extend, and integrate with the Soroban
+          Smart Block Explorer, the service that turns raw Soroban XDR into
+          human-readable contract events.
+        </p>
+      </section>
+
+      <h2 class="section">Start here</h2>
+      <div class="cards">
+        <a class="card" href="./guides.html#getting-started">
+          <h3>Getting started</h3>
+          <p>Clone, configure, and run the full stack locally in minutes.</p>
+        </a>
+        <a class="card" href="./guides.html#building-with-the-api">
+          <h3>Build with the API</h3>
+          <p>Query events, contracts, wallets, and tokens from your app.</p>
+        </a>
+        <a class="card" href="./guides.html#register-contract">
+          <h3>Register a contract</h3>
+          <p>Add ABI metadata so invocations decode into plain English.</p>
+        </a>
+      </div>
+
+      <h2 class="section">API reference</h2>
+      <div class="cards">
+        <a class="card" href="../api/playground.html">
+          <h3>Swagger playground</h3>
+          <p>Browse and try every endpoint interactively.</p>
+        </a>
+        <a class="card" href="../api/try-it.html">
+          <h3>Try-it console</h3>
+          <p>Live requests, curl / JS / Python / Rust snippets, WebSocket.</p>
+        </a>
+        <a class="card" href="../api/changelog.md">
+          <h3>API changelog</h3>
+          <p>Versioned history of HTTP and WebSocket endpoints.</p>
+        </a>
+      </div>
+
+      <h2 class="section">Generated reference</h2>
+      <p style="color: var(--muted)">
+        Built from source on each deploy and published with the site. These links
+        resolve on the published GitHub Pages site.
+      </p>
+      <div class="cards">
+        <a class="card" href="../reference/indexer/index.html">
+          <h3>Indexer reference (JSDoc)</h3>
+          <p>Generated API reference for the Node.js indexer.</p>
+        </a>
+        <a class="card" href="../reference/contract/index.html">
+          <h3>Contract reference (Rustdoc)</h3>
+          <p>Generated documentation for the Soroban contract.</p>
+        </a>
+      </div>
+
+      <h2 class="section">Understand the system</h2>
+      <div class="cards">
+        <a class="card" href="./architecture.html">
+          <h3>Architecture explorer</h3>
+          <p>Clickable diagram of the indexer, database, API, and frontend.</p>
+        </a>
+        <a class="card" href="./guides.html#architecture-deep-dive">
+          <h3>Architecture deep dive</h3>
+          <p>How data flows from Stellar RPC to the React frontend.</p>
+        </a>
+        <a class="card" href="../../CONTRIBUTING.md">
+          <h3>Contributing</h3>
+          <p>Workflow, commit conventions, PR checklist, and scoring.</p>
+        </a>
+      </div>
+    </main>
+
+    <footer class="site">
+      Built on Stellar · Soroban Smart Block Explorer ·
+      <a
+        href="https://github.com/Soroban-Smart-Block-Explorer/Soroban-Smart-Block"
+        >Source on GitHub</a
+      >
+    </footer>
+
+    <div class="modal-overlay" id="searchOverlay">
+      <div class="modal">
+        <input
+          id="searchInput"
+          type="text"
+          placeholder="Search the docs…"
+          autocomplete="off"
+        />
+        <div class="results" id="searchResults"></div>
+      </div>
+    </div>
+
+    <script src="./search.js"></script>
+  </body>
+</html>

--- a/docs/site/search-index.json
+++ b/docs/site/search-index.json
@@ -1,0 +1,100 @@
+[
+  {
+    "title": "Documentation home",
+    "section": "Overview",
+    "url": "./index.html",
+    "description": "Start here: map of all documentation.",
+    "keywords": "home index overview start"
+  },
+  {
+    "title": "Getting started",
+    "section": "Guides",
+    "url": "./guides.html#getting-started",
+    "description": "Clone, configure, and run the explorer locally.",
+    "keywords": "install setup run docker compose env quickstart onboarding"
+  },
+  {
+    "title": "Registering a contract",
+    "section": "Guides",
+    "url": "./guides.html#register-contract",
+    "description": "Add ABI metadata so events decode into plain English.",
+    "keywords": "abi registry metadata contract decode register"
+  },
+  {
+    "title": "Building with the API",
+    "section": "Guides",
+    "url": "./guides.html#building-with-the-api",
+    "description": "Query events, contracts, wallets, and tokens from the REST API.",
+    "keywords": "api rest fetch events query client websocket"
+  },
+  {
+    "title": "Architecture deep dive",
+    "section": "Guides",
+    "url": "./guides.html#architecture-deep-dive",
+    "description": "How the indexer, database, API, and frontend fit together.",
+    "keywords": "architecture indexer postgres rpc frontend pipeline design"
+  },
+  {
+    "title": "Interactive architecture explorer",
+    "section": "Reference",
+    "url": "./architecture.html",
+    "description": "Clickable system diagram with per-component details.",
+    "keywords": "architecture diagram explorer components nodes flow"
+  },
+  {
+    "title": "API playground (Swagger UI)",
+    "section": "API",
+    "url": "../api/playground.html",
+    "description": "Browse and try every endpoint with Swagger UI.",
+    "keywords": "swagger openapi playground try endpoints rest"
+  },
+  {
+    "title": "Try-it console",
+    "section": "API",
+    "url": "../api/try-it.html",
+    "description": "Send live requests, generate snippets, test the WebSocket.",
+    "keywords": "try console curl javascript python rust websocket snippet"
+  },
+  {
+    "title": "OpenAPI specification",
+    "section": "API",
+    "url": "../api/openapi.json",
+    "description": "Machine-readable OpenAPI 3.1 contract.",
+    "keywords": "openapi json spec schema contract 3.1"
+  },
+  {
+    "title": "API changelog",
+    "section": "API",
+    "url": "../api/changelog.md",
+    "description": "Version history of the HTTP and WebSocket API.",
+    "keywords": "changelog version history api releases"
+  },
+  {
+    "title": "Contributing guide",
+    "section": "Community",
+    "url": "../../CONTRIBUTING.md",
+    "description": "Workflow, commit conventions, PR checklist, scoring.",
+    "keywords": "contributing pr commit branch review scoring gamification badges"
+  },
+  {
+    "title": "Indexer reference (JSDoc)",
+    "section": "Reference",
+    "url": "../reference/indexer/index.html",
+    "description": "Generated API reference for the Node.js indexer.",
+    "keywords": "jsdoc indexer reference generated functions node"
+  },
+  {
+    "title": "Contract reference (Rustdoc)",
+    "section": "Reference",
+    "url": "../reference/contract/index.html",
+    "description": "Generated Rustdoc for the Soroban contract.",
+    "keywords": "rustdoc contract reference generated rust soroban"
+  },
+  {
+    "title": "Roadmap",
+    "section": "Project",
+    "url": "../ROADMAP.md",
+    "description": "Planned milestones and direction.",
+    "keywords": "roadmap milestones plan future"
+  }
+]

--- a/docs/site/search.js
+++ b/docs/site/search.js
@@ -1,0 +1,112 @@
+// Lightweight client-side search over a static index (no external service).
+// Loads search-index.json and supports keyboard navigation with Cmd/Ctrl+K.
+(function () {
+  let index = [];
+  let results = [];
+  let active = 0;
+
+  const overlay = document.getElementById("searchOverlay");
+  const input = document.getElementById("searchInput");
+  const list = document.getElementById("searchResults");
+
+  fetch("./search-index.json")
+    .then((r) => r.json())
+    .then((data) => {
+      index = data;
+    })
+    .catch(() => {
+      index = [];
+    });
+
+  function score(item, terms) {
+    const haystack = (
+      item.title +
+      " " +
+      item.section +
+      " " +
+      (item.keywords || "")
+    ).toLowerCase();
+    let s = 0;
+    for (const t of terms) {
+      if (!t) continue;
+      if (item.title.toLowerCase().includes(t)) s += 5;
+      if (haystack.includes(t)) s += 2;
+    }
+    return s;
+  }
+
+  function render() {
+    if (!input.value.trim()) {
+      list.innerHTML =
+        '<div class="empty">Type to search the documentation…</div>';
+      return;
+    }
+    if (results.length === 0) {
+      list.innerHTML = '<div class="empty">No matches.</div>';
+      return;
+    }
+    list.innerHTML = results
+      .map(
+        (r, i) =>
+          `<a class="result ${i === active ? "active" : ""}" href="${r.url}">
+            <div class="title">${r.title}</div>
+            <div class="meta"><span class="tag">${r.section}</span> — ${r.description || ""}</div>
+          </a>`,
+      )
+      .join("");
+  }
+
+  function search() {
+    const terms = input.value.toLowerCase().split(/\s+/).filter(Boolean);
+    results = index
+      .map((item) => ({ item, s: score(item, terms) }))
+      .filter((x) => x.s > 0)
+      .sort((a, b) => b.s - a.s)
+      .slice(0, 12)
+      .map((x) => x.item);
+    active = 0;
+    render();
+  }
+
+  function open() {
+    overlay.classList.add("open");
+    input.value = "";
+    results = [];
+    render();
+    setTimeout(() => input.focus(), 0);
+  }
+
+  function close() {
+    overlay.classList.remove("open");
+  }
+
+  document.addEventListener("keydown", (e) => {
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+      e.preventDefault();
+      overlay.classList.contains("open") ? close() : open();
+    } else if (e.key === "Escape") {
+      close();
+    } else if (overlay.classList.contains("open")) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        active = Math.min(active + 1, results.length - 1);
+        render();
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        active = Math.max(active - 1, 0);
+        render();
+      } else if (e.key === "Enter" && results[active]) {
+        window.location.href = results[active].url;
+      }
+    }
+  });
+
+  if (input) input.addEventListener("input", search);
+  if (overlay)
+    overlay.addEventListener("click", (e) => {
+      if (e.target === overlay) close();
+    });
+
+  const trigger = document.getElementById("searchTrigger");
+  if (trigger) trigger.addEventListener("click", open);
+})();

--- a/docs/site/styles.css
+++ b/docs/site/styles.css
@@ -1,0 +1,230 @@
+:root {
+  --bg: #0d1117;
+  --panel: #161b22;
+  --panel-2: #1c2230;
+  --border: #30363d;
+  --text: #e6edf3;
+  --muted: #8b949e;
+  --accent: #58a6ff;
+  --green: #3fb950;
+  --purple: #bc8cff;
+  --orange: #ffa657;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family:
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    sans-serif;
+  line-height: 1.6;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+header.site {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.85rem 1.5rem;
+  background: var(--panel);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+header.site .brand {
+  font-weight: 700;
+  font-size: 1.05rem;
+}
+
+header.site nav {
+  display: flex;
+  gap: 1.1rem;
+  flex-wrap: wrap;
+  font-size: 0.9rem;
+}
+
+header.site .spacer {
+  flex: 1;
+}
+
+.search-trigger {
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  color: var(--muted);
+  border-radius: 6px;
+  padding: 0.4rem 0.7rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.search-trigger kbd {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0 0.35rem;
+  font-family: var(--mono);
+  font-size: 0.75rem;
+}
+
+main {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 5rem;
+}
+
+.hero h1 {
+  font-size: 2rem;
+  margin-bottom: 0.4rem;
+}
+
+.hero p {
+  color: var(--muted);
+  font-size: 1.05rem;
+  max-width: 60ch;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.card {
+  display: block;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1.15rem 1.25rem;
+  transition:
+    border-color 0.15s,
+    transform 0.15s;
+}
+
+.card:hover {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+  text-decoration: none;
+}
+
+.card h3 {
+  margin: 0 0 0.35rem;
+  font-size: 1.05rem;
+  color: var(--text);
+}
+
+.card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+h2.section {
+  margin-top: 3rem;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.45rem;
+}
+
+/* search modal */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(1, 4, 9, 0.7);
+  display: none;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 12vh;
+  z-index: 100;
+}
+
+.modal-overlay.open {
+  display: flex;
+}
+
+.modal {
+  width: min(640px, 92vw);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.modal input {
+  width: 100%;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  padding: 1rem 1.2rem;
+  font-size: 1rem;
+  outline: none;
+}
+
+.results {
+  max-height: 50vh;
+  overflow: auto;
+}
+
+.result {
+  display: block;
+  padding: 0.7rem 1.2rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.result:hover,
+.result.active {
+  background: var(--panel-2);
+  text-decoration: none;
+}
+
+.result .title {
+  color: var(--text);
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.result .meta {
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.result .tag {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  color: var(--accent);
+}
+
+.empty {
+  padding: 1rem 1.2rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+footer.site {
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.85rem;
+  padding: 1.5rem;
+  text-align: center;
+}


### PR DESCRIPTION
# docs: developer documentation site with API playground and contributor guide

Closes #202

## What this adds

A self-contained developer documentation site under `docs/`, plus a workflow to
publish it to GitHub Pages.

### API reference (`docs/api/`)

- `openapi.json` — OpenAPI 3.1 spec generated from `indexer/openapi.yaml` (25
  paths).
- `playground.html` — Swagger UI with try-it-now, loading the spec.
- `try-it.html` — a dependency-free interactive console: pick an endpoint, fill
  params, set base URL + API key once (auth helper), send a real request, and copy
  generated snippets in **curl / JavaScript / Python / Rust**. Includes a
  **WebSocket console** that matches the indexer's `{ type, data }` message shape.
- `changelog.md` — versioned API changelog (Keep a Changelog).

### Documentation hub (`docs/site/`)

- `index.html` — landing page mapping guides, API, reference, and architecture.
- Client-side **search with Ctrl/Cmd+K** over a static index (no external
  service / no account required).
- `architecture.html` — an **interactive, clickable architecture explorer**: click
  a node for details, filter by layer, and animate the data flow.
- `guides.html` — renders the guides with a table of contents.

### Guides (`docs/guides/`)

Written, accurate walkthroughs (commands verified against the repo's `Makefile`
and `.env.example`): Getting started, Registering a contract, Building with the
API, and an Architecture deep dive. Each renders with a slot where a video can be
embedded later.

### Contributor guide (`CONTRIBUTING.md`)

Branch-naming and Conventional-Commit conventions that match this repo's CI gates,
a local quality-gate command list, a PR checklist, and a transparent contribution
**scoring rubric** (points, levels, badges).

### Automated generation + publishing (`.github/workflows/docs.yml`)

On pushes that touch docs or sources, the workflow regenerates `openapi.json` from
the YAML, generates **JSDoc** for the indexer and **Rustdoc** for the contract,
assembles the static site, and deploys to **GitHub Pages**. README links the site.

## Scope notes (honest mapping to the issue)

The issue lists an ambitious wishlist. This PR delivers the parts that work
end-to-end without external accounts, paid APIs, or content that does not exist
yet, and lays clean groundwork for the rest:

- **Implemented and working:** Swagger playground + try-it-now, multi-language
  snippets, WebSocket console, OpenAPI 3.1, automated JSDoc/Rustdoc + Pages
  publishing, full-text search (Ctrl/Cmd+K), interactive architecture explorer,
  written walkthroughs, contributor guide, scoring rubric, API changelog.
- **Deliberately deferred (need external services / content / infra):** Algolia
  DocSearch (a working client-side search is shipped instead), DeepL multilingual
  translation, real recorded videos with transcripts (written guides ship now with
  embed slots), a live gamification leaderboard backend (the rubric is documented),
  WebContainer/Monaco in-browser execution, and a custom domain. These are noted so
  a reviewer can pick them up as follow-ups.

## Pre-existing CI note

The repo's `Prettier check` step runs `npx prettier` from the repo root with no
pinned local Prettier, so it currently flags ~141 pre-existing files on `main`
under the latest Prettier. That is unrelated to this PR and not something a docs
change should fix (it would reformat unrelated source). All **new** Markdown in
this PR passes `prettier --check`.

## How to review

Open `docs/site/index.html` locally, or wait for the Pages deploy. Try the Swagger
playground and the try-it console against a locally running indexer
(`make indexer`).
