### PR TITLE
feat: add CSV/JSON data export for events and contracts (#215)

### DIFF
--- a/frontend/src/components/ExportButton.tsx
+++ b/frontend/src/components/ExportButton.tsx
@@ -1,0 +1,99 @@
+import { useState, useRef, useEffect } from "react";
+
+type ExportTarget = "events" | "contracts";
+type ExportFormat = "csv" | "json";
+
+interface ExportButtonProps {
+  target: ExportTarget;
+  params?: Record<string, string | undefined>;
+}
+
+export default function ExportButton({ target, params = {} }: ExportButtonProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function close(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", close);
+    return () => document.removeEventListener("mousedown", close);
+  }, []);
+
+  function buildUrl(format: ExportFormat) {
+    const q = new URLSearchParams({ format });
+    for (const [k, v] of Object.entries(params)) {
+      if (v) q.set(k, v);
+    }
+    return `/api/export/${target}?${q}`;
+  }
+
+  function download(format: ExportFormat) {
+    setOpen(false);
+    const a = document.createElement("a");
+    a.href = buildUrl(format);
+    a.download = `${target}.${format}`;
+    a.click();
+  }
+
+  return (
+    <div ref={ref} style={{ position: "relative", display: "inline-block" }}>
+      <button
+        title="Export data"
+        onClick={() => setOpen(o => !o)}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          padding: "6px 14px",
+          background: "var(--surface)",
+          border: "1px solid var(--border)",
+          borderRadius: 6,
+          color: "var(--muted)",
+          cursor: "pointer",
+          fontSize: 13,
+        }}
+      >
+        ↓ Export
+      </button>
+      {open && (
+        <div
+          style={{
+            position: "absolute",
+            right: 0,
+            top: "calc(100% + 4px)",
+            background: "var(--surface)",
+            border: "1px solid var(--border)",
+            borderRadius: 6,
+            overflow: "hidden",
+            zIndex: 100,
+            minWidth: 120,
+            boxShadow: "0 4px 12px rgba(0,0,0,0.3)",
+          }}
+        >
+          {(["csv", "json"] as ExportFormat[]).map(fmt => (
+            <button
+              key={fmt}
+              onClick={() => download(fmt)}
+              style={{
+                display: "block",
+                width: "100%",
+                textAlign: "left",
+                padding: "8px 14px",
+                background: "transparent",
+                border: "none",
+                color: "var(--fg, #e6edf3)",
+                cursor: "pointer",
+                fontSize: 13,
+              }}
+              onMouseEnter={e => (e.currentTarget.style.background = "var(--accent-muted, rgba(255,255,255,0.06))")}
+              onMouseLeave={e => (e.currentTarget.style.background = "transparent")}
+            >
+              {fmt.toUpperCase()}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/ContractPage.tsx
+++ b/frontend/src/pages/ContractPage.tsx
@@ -23,6 +23,7 @@ import QuorumFreezeBadge from "../components/QuorumFreezeBadge";
 import RwaMetadataDisplay from "../components/RwaMetadataDisplay";
 import SourceVerificationBadge from "../components/SourceVerificationBadge";
 import StateDiffTimeline from "../components/StateDiffTimeline";
+import ExportButton from "../components/ExportButton";
 
 // Demo source shown when no verified source is uploaded
 const DEMO_SOURCE = `// Verified source not yet uploaded for this contract.
@@ -394,7 +395,10 @@ export default function ContractPage() {
             </div>
           )}
 
-          <h3>Recent Events</h3>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+            <h3 style={{ margin: 0 }}>Recent Events</h3>
+            <ExportButton target="events" params={{ contract: id }} />
+          </div>
           <div className="card">
             {evLoading ? (
               <p style={{ color: "var(--muted)" }}>Loading…</p>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api";
 import type { DecodedEvent } from "../api";
 import EventTable from "../components/EventTable";
+import ExportButton from "../components/ExportButton";
 import { useEventStream } from "../hooks/useEventStream";
 
 const FUNCTIONS = ["", "swap", "transfer", "mint", "burn", "stake", "unstake", "wrap_native", "unwrap_native"];
@@ -77,6 +78,14 @@ export default function Home() {
             {FUNCTIONS.map(f => <option key={f} value={f}>{f || "All"}</option>)}
           </select>
         </div>
+
+        <ExportButton
+          target="events"
+          params={{
+            fn:   fnFilter || undefined,
+            type: txType !== "all" ? txType : undefined,
+          }}
+        />
       </div>
 
       <div className="card">

--- a/indexer/src/api.js
+++ b/indexer/src/api.js
@@ -642,6 +642,69 @@ export function startApi() {
     }
   });
 
+  // ── Issue #215: CSV/JSON export endpoints ─────────────────────────────────
+
+  function rowsToCsv(rows, columns) {
+    if (!rows.length) return columns.join(",") + "\n";
+    const escape = (v) => {
+      if (v == null) return "";
+      const s = String(v);
+      return s.includes(",") || s.includes('"') || s.includes("\n")
+        ? `"${s.replace(/"/g, '""')}"` : s;
+    };
+    const header = columns.join(",");
+    const body = rows.map(r => columns.map(c => escape(r[c])).join(",")).join("\n");
+    return header + "\n" + body + "\n";
+  }
+
+  const EVENT_COLUMNS = [
+    "seq", "contract_id", "function", "ledger", "tx_hash", "description",
+    "cpu_instructions", "mem_bytes", "fee_charged", "is_clawback", "is_high_bloat_risk",
+  ];
+
+  const CONTRACT_COLUMNS = [
+    "id", "name", "description", "registered_by",
+    "has_circuit_breaker", "is_paused", "is_rwa", "rwa_type", "created_at",
+  ];
+
+  // GET /api/export/events?format=csv|json&contract=&fn=&type=&limit=
+  app.get("/api/export/events", async (req, res) => {
+    try {
+      const format = req.query.format === "json" ? "json" : "csv";
+      const limit  = Math.min(Number(req.query.limit) || 10000, 10000);
+      const rows   = await db.getEventsForExport({
+        contract: req.query.contract,
+        fn:       req.query.fn,
+        type:     req.query.type,
+        limit,
+      });
+      if (format === "json") {
+        res.setHeader("Content-Disposition", 'attachment; filename="events.json"');
+        res.setHeader("Content-Type", "application/json");
+        return res.json(rows);
+      }
+      res.setHeader("Content-Disposition", 'attachment; filename="events.csv"');
+      res.setHeader("Content-Type", "text/csv");
+      return res.send(rowsToCsv(rows, EVENT_COLUMNS));
+    } catch (e) { res.status(500).json({ error: e.message }); }
+  });
+
+  // GET /api/export/contracts?format=csv|json
+  app.get("/api/export/contracts", async (req, res) => {
+    try {
+      const format = req.query.format === "json" ? "json" : "csv";
+      const rows   = await db.getContractsForExport();
+      if (format === "json") {
+        res.setHeader("Content-Disposition", 'attachment; filename="contracts.json"');
+        res.setHeader("Content-Type", "application/json");
+        return res.json(rows);
+      }
+      res.setHeader("Content-Disposition", 'attachment; filename="contracts.csv"');
+      res.setHeader("Content-Type", "text/csv");
+      return res.send(rowsToCsv(rows, CONTRACT_COLUMNS));
+    } catch (e) { res.status(500).json({ error: e.message }); }
+  });
+
   // ── Issue #139: GraphQL endpoint ───────────────────────────────────────────
   attachGraphQL(app);
 

--- a/indexer/src/db.js
+++ b/indexer/src/db.js
@@ -748,4 +748,32 @@ export const db = {
       [contractId, from, amount]
     );
   },
+
+  // Issue #215: data export — events (CSV/JSON)
+  async getEventsForExport({ contract, fn, type, limit = 10000 } = {}) {
+    const conditions = [];
+    const params = [];
+    if (contract) { params.push(contract); conditions.push(`contract_id = $${params.length}`); }
+    if (fn)       { params.push(fn);       conditions.push(`function = $${params.length}`); }
+    if (type === "soroban") { conditions.push(`contract_id IS NOT NULL AND contract_id <> ''`); }
+    if (type === "classic") { conditions.push(`(contract_id IS NULL OR contract_id = '')`); }
+    const where = conditions.length ? `WHERE ${conditions.join(" AND ")}` : "";
+    params.push(Math.min(limit, 10000));
+    const { rows } = await pool.query(
+      `SELECT seq, contract_id, function, ledger, tx_hash, description,
+              cpu_instructions, mem_bytes, fee_charged, is_clawback, is_high_bloat_risk
+       FROM events ${where} ORDER BY seq DESC LIMIT $${params.length}`,
+      params
+    );
+    return rows;
+  },
+
+  // Issue #215: data export — registered contracts (CSV/JSON)
+  async getContractsForExport() {
+    const { rows } = await pool.query(
+      `SELECT id, name, description, registered_by, has_circuit_breaker, is_paused, is_rwa, rwa_type, created_at
+       FROM contracts ORDER BY created_at DESC`
+    );
+    return rows;
+  },
 };


### PR DESCRIPTION
Summary
Closes #215

Adds minimal, dependency-free CSV and JSON export for events and contracts, integrated cleanly into the existing API and UI patterns.

GET /api/export/events?format=csv|json — exports up to 10,000 events; supports the same filters as the existing events endpoint (contract, fn, type, limit)
GET /api/export/contracts?format=csv|json — exports all registered contracts
ExportButton component — a self-contained dropdown that builds the download URL from current filter state and triggers a browser file download (no extra npm dependencies)
Home page — Export button added to the filters row; respects active function filter and transaction type
ContractPage — Export button added next to "Recent Events", scoped to that contract