### PR TITLE
Add SSE transaction status endpoint for pending transactions

### DIFF
--- a/frontend/src/components/SSEStatusIndicator.tsx
+++ b/frontend/src/components/SSEStatusIndicator.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { useTxStatus } from "../hooks/useTxStatus";
+
+export default function SSEStatusIndicator({ txHash }: { txHash?: string | null }) {
+  if (!txHash) return null;
+  const payload = useTxStatus(txHash);
+  const status = payload?.status ?? "pending";
+
+  const colors: Record<string, string> = {
+    pending: "#f59e0b",
+    success: "#10b981",
+    failed: "#ef4444",
+    resource_limit_exceeded: "#7c3aed",
+  };
+  const bgs: Record<string, string> = {
+    pending: "#fef3c7",
+    success: "#d1fae5",
+    failed: "#fee2e2",
+    resource_limit_exceeded: "#f3e8ff",
+  };
+
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 8, marginLeft: 8 }}>
+      <span style={{ width: 10, height: 10, borderRadius: "50%", background: colors[status] }} />
+      <span
+        style={{
+          padding: "4px 8px",
+          borderRadius: 8,
+          background: bgs[status],
+          border: `1px solid ${colors[status]}`,
+          fontSize: 12,
+          color: "var(--text)",
+        }}
+      >
+        {status}
+        {payload?.ledger != null ? ` • #${payload.ledger}` : ""}
+      </span>
+    </span>
+  );
+}

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -2,6 +2,7 @@ import { useParams, Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../api";
 import ResourceCosts from "../components/ResourceCosts";
+import SSEStatusIndicator from "../components/SSEStatusIndicator";
 import StorageTierBreakdown from "../components/StorageTierBreakdown";
 import GasLimitAlert from "../components/GasLimitAlert";
 import FeeSponsorBanner from "../components/FeeSponsorBanner";
@@ -70,7 +71,17 @@ export default function EventPage() {
         )}
         <Row label="Ledger" value={ev.ledger.toLocaleString()} />
         <Row label="Contract" value={<Link to={`/contract/${ev.contract_id}`}>{ev.contract_id}</Link>} />
-        {ev.tx_hash && <Row label="Tx Hash" value={ev.tx_hash} mono />}
+        {ev.tx_hash && (
+          <Row
+            label="Tx Hash"
+            value={
+              <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+                <span style={{ fontFamily: "monospace" }}>{ev.tx_hash}</span>
+                <SSEStatusIndicator txHash={ev.tx_hash} />
+              </span>
+            }
+          />
+        )}
         {ev.raw_topics.length > 0 && <Row label="Topics" value={ev.raw_topics.join(", ")} mono />}
       </div>
 

--- a/frontend/src/pages/SandboxPage.tsx
+++ b/frontend/src/pages/SandboxPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import SSEStatusIndicator from "../components/SSEStatusIndicator";
 import { xdr, StrKey, TransactionBuilder, Networks, Contract, Account } from "@stellar/stellar-sdk";
 
 interface ParsedInvocation {
@@ -242,6 +243,8 @@ export default function SandboxPage() {
             {result.latestLedger != null && (
               <span style={{ fontSize: 12, color: "var(--muted)" }}>ledger #{result.latestLedger}</span>
             )}
+              {/** Show SSE status if a tx hash is present in the result */}
+              {(result as any).tx_hash && <SSEStatusIndicator txHash={(result as any).tx_hash} />}
           </div>
 
           {result.error && <p style={{ color: "#f85149", fontSize: 13, marginBottom: 8 }}>{result.error}</p>}

--- a/indexer/src/api.js
+++ b/indexer/src/api.js
@@ -10,7 +10,7 @@ import swaggerUi from "swagger-ui-express";
 import { db } from "./db.js";
 import { analyzeSourceDependencies } from "./dependencyScanner.js";
 import { fetchTokenMetadata } from "./sep41Metadata.js";
-import { attachWebSocketServer } from "./wsEvents.js";
+import { attachWebSocketServer, publishTransactionStatus, getTransactionStatus, onTransactionStatus, offTransactionStatus } from "./wsEvents.js";
 import { verifyAbi } from "./verify_abi.js";
 import { getMetrics } from "./rpcMetrics.js";
 import { getRpcNodeStatus } from "./rpcMultiNode.js";
@@ -42,6 +42,24 @@ function requireApiKey(req, res, next) {
   const key = req.headers["x-api-key"];
   if (!key || key !== API_KEY) return res.status(401).json({ error: "Unauthorized" });
   next();
+}
+
+function parseTxHashes(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value.flatMap((v) => String(v).split(",").map((hash) => hash.trim()).filter(Boolean));
+  return String(value).split(",").map((hash) => hash.trim()).filter(Boolean);
+}
+
+function createSseStream(res) {
+  res.setHeader("Content-Type", "text/event-stream");
+  res.setHeader("Cache-Control", "no-cache, no-transform");
+  res.setHeader("Connection", "keep-alive");
+  res.flushHeaders?.();
+  res.write("retry: 3000\n\n");
+}
+
+function sendSseEvent(res, payload) {
+  res.write(`data: ${JSON.stringify(payload)}\n\n`);
 }
 
 // ── Cache middleware factory ──────────────────────────────────────────────────
@@ -198,6 +216,123 @@ export function startApi() {
       const zk = typeof ev.zk_host_calls === "string" ? JSON.parse(ev.zk_host_calls) : ev.zk_host_calls;
       res.json(zk);
     } catch (e) {
+      res.status(500).json({ error: e.message });
+    }
+  });
+
+  // Issue #118 — Transaction status server-sent events endpoint
+  app.get("/api/transactions/status", async (req, res) => {
+    try {
+      const txHashes = parseTxHashes(req.query.txHashes);
+      if (txHashes.length === 0) {
+        return res.status(400).json({ error: "txHashes query parameter is required" });
+      }
+      createSseStream(res);
+
+      const listeners = new Map();
+      const cleanup = () => {
+        for (const listener of listeners.values()) {
+          offTransactionStatus(listener);
+        }
+        res.end();
+      };
+
+      req.on("close", cleanup);
+
+      for (const txHash of txHashes) {
+        const initialStatus = getTransactionStatus(txHash);
+        if (initialStatus) {
+          sendSseEvent(res, initialStatus);
+          if (initialStatus.status !== "pending") {
+            continue;
+          }
+        } else {
+          sendSseEvent(res, {
+            tx_hash: txHash,
+            status: "pending",
+            ledger: null,
+            error: null,
+          });
+        }
+
+        const listener = (status) => {
+          if (status.tx_hash !== txHash) return;
+          sendSseEvent(res, status);
+          if (status.status !== "pending") {
+            offTransactionStatus(listener);
+          }
+        };
+        listeners.set(txHash, listener);
+        onTransactionStatus(listener);
+      }
+    } catch (e) {
+      res.status(500).json({ error: e.message });
+    }
+  });
+
+  // Issue #118 — single-transaction SSE stream (compat for frontend hook)
+  app.get("/api/transactions/:hash/status/stream", async (req, res) => {
+    try {
+      const txHash = req.params.hash;
+      createSseStream(res);
+
+      const initialStatus = getTransactionStatus(txHash);
+      if (initialStatus) {
+        sendSseEvent(res, initialStatus);
+        if (initialStatus.status !== "pending") {
+          return res.end();
+        }
+      } else {
+        sendSseEvent(res, {
+          tx_hash: txHash,
+          status: "pending",
+          ledger: null,
+          error: null,
+        });
+      }
+
+      const listener = (status) => {
+        if (status.tx_hash !== txHash) return;
+        sendSseEvent(res, status);
+        if (status.status !== "pending") {
+          offTransactionStatus(listener);
+          res.end();
+        }
+      };
+
+      onTransactionStatus(listener);
+      req.on("close", () => {
+        offTransactionStatus(listener);
+        res.end();
+      });
+    } catch (e) {
+      res.status(500).json({ error: e.message });
+    }
+  });
+
+  // Issue #118 — Transaction status polling endpoint
+  app.get("/api/transactions/:hash/status", async (req, res) => {
+    try {
+      const txHash = req.params.hash;
+      const cached = getTransactionStatus(txHash);
+      if (cached) return res.json(cached);
+
+      const { SorobanRpc } = await import("@stellar/stellar-sdk");
+      const server = new SorobanRpc.Server(RPC_URL);
+      const txResult = await server.getTransaction(txHash);
+      const status = txResult?.status === "SUCCESS" ? "success" : txResult?.status === "FAILED" ? "failed" : "pending";
+      const { extractFailureReason } = await import("./diagnosticParser.js");
+      const payload = {
+        tx_hash: txHash,
+        status,
+        ledger: txResult?.ledger ?? null,
+        error: extractFailureReason(txResult),
+      };
+      res.json(payload);
+    } catch (e) {
+      if (e?.message?.includes("404") || e?.message?.includes("not found")) {
+        return res.status(404).json({ error: "Not found" });
+      }
       res.status(500).json({ error: e.message });
     }
   });

--- a/indexer/src/index.js
+++ b/indexer/src/index.js
@@ -15,7 +15,7 @@ import { extractStateDiffs } from "./stateDiffIndexer.js";
 import { parseFeeBump } from "./feeBumpParser.js";
 import { detectEvictions } from "./archivalEvictionDetector.js";
 import { parseAndDescribeRestore } from "./restoreFootprintParser.js";
-import { publish } from "./wsEvents.js";
+import { publish, publishTransactionStatus } from "./wsEvents.js";
 import { extractBuildMetadata } from "./wasmBuildMetadata.js";
 import { scanFootprintContention } from "./footprintContentionScanner.js";
 import { handleVaultEvent, refreshAllVaults } from "./vaultIndexer.js";
@@ -113,6 +113,21 @@ async function indexLedger(ledger) {
             // Issue #167: parse RestoreFootprintOp if present
             const restore = parseAndDescribeRestore(txResult.envelopeXdr, txResult.resultMetaXdr ?? null);
             if (restore.isRestoreOp) restoreCache.set(txHash, restore);
+          }
+
+          // Publish a transaction status event for clients
+          try {
+            const status = txResult?.status === "SUCCESS" ? "success" : txResult?.status === "FAILED" ? "failed" : "pending";
+            const { extractFailureReason } = await import("./diagnosticParser.js");
+            const payload = {
+              tx_hash: txHash,
+              status,
+              ledger: txResult?.ledger ?? null,
+              error: extractFailureReason(txResult),
+            };
+            publishTransactionStatus(payload);
+          } catch (err) {
+            /* non-fatal */
           }
         } catch {
           /* non-critical — skip fee-bump/restore for this tx */

--- a/indexer/src/wsEvents.js
+++ b/indexer/src/wsEvents.js
@@ -15,8 +15,31 @@ const API_KEY = process.env.API_KEY;
 const bus = new EventEmitter();
 bus.setMaxListeners(0);
 
+const txStatusCache = new Map();
+
 export function publish(event) {
   bus.emit("event", event);
+}
+
+export function publishTransactionStatus(status) {
+  const existing = txStatusCache.get(status.tx_hash);
+  if (existing && existing.status === status.status && existing.ledger === status.ledger && existing.error === status.error) {
+    return;
+  }
+  txStatusCache.set(status.tx_hash, status);
+  bus.emit("transaction_status", status);
+}
+
+export function getTransactionStatus(txHash) {
+  return txStatusCache.get(txHash) || null;
+}
+
+export function onTransactionStatus(listener) {
+  bus.on("transaction_status", listener);
+}
+
+export function offTransactionStatus(listener) {
+  bus.off("transaction_status", listener);
 }
 
 export function publishVaultRatio(snapshot) {


### PR DESCRIPTION
Close #203 

This PR adds Server-Sent Events support for monitoring pending transaction status. It enables a simpler client-side integration via EventSource and improves compatibility with proxies/load balancers.

Changes:
- Added SSE endpoint GET /api/transactions/status for batch transaction monitoring.
- Added compatibility endpoint GET /api/transactions/:hash/status/stream for the frontend hook.
- Preserved fallback polling via GET /api/transactions/:hash/status.

Implemented in indexer/src/api.js with support for existing SSE client behavior.