### PR TITLE
Add spec-full endpoint and update snapshot

### DIFF
--- a/contracts/explorer/test_snapshots/tests/test_submit_and_get_event.1.json
+++ b/contracts/explorer/test_snapshots/tests/test_submit_and_get_event.1.json
@@ -18,22 +18,56 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
-                },
-                {
-                  "symbol": "swap"
-                },
-                {
-                  "u32": 4521983
-                },
-                {
-                  "string": "Address GABC... swapped 100 USDC \\xe2\\x86\\x92 98.7 XLM on StellarSwap"
-                },
-                {
-                  "vec": []
-                },
-                {
-                  "bytes": ""
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "contract_id"
+                      },
+                      "val": {
+                        "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": "Address GABC... swapped 100 USDC \\xe2\\x86\\x92 98.7 XLM on StellarSwap"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "function"
+                      },
+                      "val": {
+                        "symbol": "swap"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "ledger"
+                      },
+                      "val": {
+                        "u32": 4521983
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "raw_data"
+                      },
+                      "val": {
+                        "bytes": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "raw_topics"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -342,22 +376,56 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
-                },
-                {
-                  "symbol": "swap"
-                },
-                {
-                  "u32": 4521983
-                },
-                {
-                  "string": "Address GABC... swapped 100 USDC \\xe2\\x86\\x92 98.7 XLM on StellarSwap"
-                },
-                {
-                  "vec": []
-                },
-                {
-                  "bytes": ""
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "contract_id"
+                      },
+                      "val": {
+                        "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": "Address GABC... swapped 100 USDC \\xe2\\x86\\x92 98.7 XLM on StellarSwap"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "function"
+                      },
+                      "val": {
+                        "symbol": "swap"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "ledger"
+                      },
+                      "val": {
+                        "u32": 4521983
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "raw_data"
+                      },
+                      "val": {
+                        "bytes": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "raw_topics"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    }
+                  ]
                 }
               ]
             }

--- a/indexer/openapi.yaml
+++ b/indexer/openapi.yaml
@@ -154,6 +154,18 @@ paths:
         "200":
           description: ABI JSON file
 
+  /api/contracts/{id}/spec-full:
+    get:
+      summary: Get full on-chain contract spec (functions and types)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Full contract spec payload
+
   /api/contracts/{id}/transactions:
     get:
       summary: Get paginated transaction history for a contract

--- a/indexer/src/api.js
+++ b/indexer/src/api.js
@@ -266,6 +266,20 @@ export function startApi() {
     }
   });
 
+  // GET /api/contracts/:id/spec-full — fetch full on-chain spec including custom types
+  app.get("/api/contracts/:id/spec-full", async (req, res) => {
+    try {
+      const { fetchContractSpecFull } = await import("./verify_abi.js");
+      const spec = await fetchContractSpecFull(req.params.id);
+      if (spec === null) {
+        return res.status(404).json({ error: "Contract not found or has no WASM spec" });
+      }
+      res.json(spec);
+    } catch (e) {
+      res.status(500).json({ error: e.message });
+    }
+  });
+
   // POST /api/contracts  — register ABI metadata
   app.post("/api/contracts", writeLimiter, requireApiKey, async (req, res) => {
     try {


### PR DESCRIPTION
Adds the missing `GET /api/contracts/:id/spec-full` endpoint and updates the contract snapshot used by tests.