### PR TITLE
feat: add API authentication and distributed rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,35 @@ VERIFY_ON_UPLOAD=true
 # ── Redis (optional) ───────────────────────────────────────────────────────────
 REDIS_URL=
 
+# ── API Authentication & Rate Limiting ─────────────────────────────────────────
+# Bearer token for admin endpoint authentication (POST /api/admin/*)
+ADMIN_SECRET=
+
+# JSON blob overriding default per-tier rate limits
+# Example: {"unauthenticated":{"rpm":60,"burst":10},"free":{"rpm":1000,"burst":50}}
+RATE_LIMIT_CONFIG=
+
+# Comma-separated ISO-3166-1 alpha-2 country codes to block entirely
+# Example: CN,RU,KP
+GEO_BLOCK_LIST=
+
+# JSON map of ISO-3166-1 alpha-2 country code → float multiplier applied to base tier limit
+# Example: {"CN":0.5,"IN":0.8}
+GEO_RATE_MULTIPLIERS=
+
+# Absolute path to a MaxMind GeoLite2-Country.mmdb database file
+# Geo-based limiting is skipped (pass-through) when this is unset or the file is absent
+GEOIP_DB_PATH=
+
+# Stripe webhook signing secret (from Stripe Dashboard → Webhooks)
+STRIPE_WEBHOOK_SECRET=
+
+# Stripe secret API key used for subscription management
+STRIPE_SECRET_KEY=
+
+# Optional Cloudflare DDoS mitigation webhook URL; fired on DDoS pattern detection
+CLOUDFLARE_WEBHOOK_URL=
+
 # ── Docker Compose Overrides ───────────────────────────────────────────────────
 # Point these to the dev Dockerfiles for hot-reloading:
 #   INDEXER_DOCKERFILE=Dockerfile.dev

--- a/.kiro/specs/api-auth-rate-limiting/.config.kiro
+++ b/.kiro/specs/api-auth-rate-limiting/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "01cc9336-024c-4679-8b57-7160769eb2a4", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/api-auth-rate-limiting/design.md
+++ b/.kiro/specs/api-auth-rate-limiting/design.md
@@ -1,0 +1,324 @@
+# Design Document: API Authentication and Distributed Rate Limiting
+
+## Overview
+
+This feature adds API authentication, distributed rate limiting, and a supporting management layer to the Soroban Smart Block Explorer REST API. The backend is a Node.js/Express application (the `indexer` service) that already has Redis and PostgreSQL available via Docker Compose.
+
+The design inserts an authentication/rate-limiting middleware stack at the Express router level, adds PostgreSQL tables for API key management and audit logging, adds Redis key namespaces for token buckets and abuse detection state, integrates with Stripe for billing, adds a GraphQL complexity limiter, and delivers a React/TypeScript analytics dashboard to the frontend.
+
+All existing endpoints remain functional for unauthenticated clients subject to the Unauthenticated tier limits, preserving backward compatibility.
+
+---
+
+## Architecture
+
+### System Context
+
+```mermaid
+flowchart TD
+    Client -->|x-api-key optional| Express[Express Middleware Stack]
+    Express --> AuthN[API Key Authenticator]
+    AuthN --> GeoCheck[GeoIP Region Check]
+    GeoCheck --> ConcLimit[Concurrent Request Limiter]
+    ConcLimit --> RateLimiter[Token Bucket Rate Limiter]
+    RateLimiter --> ComplexityLimiter[GraphQL Complexity Limiter]
+    ComplexityLimiter --> AbuseDetector[Abuse Detector]
+    AbuseDetector --> Router[Existing Route Handlers]
+    Router -->|async| AuditLogger[Audit Logger]
+
+    RateLimiter <-->|CL.THROTTLE| Redis[(Redis)]
+    AbuseDetector <-->|state| Redis
+    ConcLimit <-->|counters| Redis
+    AuthN -->|key lookup + cache| PG[(PostgreSQL)]
+    AuditLogger -->|async INSERT| PG
+    UsageTracker[Usage Tracker] -->|aggregates| PG
+    BillingService[Billing Service] <-->|webhooks| Stripe[(Stripe)]
+    BillingService --> PG
+```
+
+### Middleware Execution Order
+
+Each inbound HTTP request passes through this ordered middleware chain before reaching the existing route handlers:
+
+1. `apiKeyAuthenticator` — resolves client identity and tier
+2. `geoIpRateLimiter` — blocks or multiplies limits by region
+3. `concurrentRequestLimiter` — enforces in-flight cap per key
+4. `tokenBucketRateLimiter` — applies per-tier, per-endpoint token bucket
+5. `graphqlComplexityLimiter` — rejects expensive GraphQL queries (GraphQL routes only)
+6. `abuseDetector` — pattern analysis and automatic penalties
+7. `rateLimitHeaderWriter` — attaches `X-RateLimit-*` headers on every response
+8. Existing route handlers (unmodified)
+9. `auditLogger` (response-finish hook, async, non-blocking)
+
+---
+
+## Components and Interfaces
+
+### 1. API Key Authenticator (`src/auth/apiKeyAuth.js`)
+
+Responsibilities:
+- Extract `x-api-key` header or fall back to client IP identity.
+- Look up key record in PostgreSQL; use a short-lived in-memory LRU cache (TTL 30 s, max 1 000 entries) to avoid per-request DB hits.
+- Validate: not revoked, not expired, IP CIDR whitelist, endpoint whitelist.
+- Attach a `req.rateContext` object consumed by downstream middleware.
+
+```js
+// req.rateContext shape
+{
+  clientId: string,       // key prefix or hashed IP
+  tier: 'unauthenticated' | 'free' | 'pro' | 'enterprise',
+  rateLimit: number | null,  // per-key override if set
+  keyId: string | null,
+  keyName: string | null,
+}
+```
+
+Error responses:
+- `401 { "error": "Invalid API key" }` — unrecognised key
+- `401 { "error": "API key expired" }` — past `expires_at`
+- `401 { "error": "API key revoked" }` — `revoked = true`
+- `403 { "error": "IP not permitted" }` — CIDR mismatch
+- `403 { "error": "Endpoint not permitted" }` — endpoint mismatch
+
+### 2. Token Bucket Rate Limiter (`src/rateLimit/tokenBucket.js`)
+
+Uses the Redis `CL.THROTTLE` command (RedisBloom / redis-cell module) which implements the GCRA (Generic Cell Rate Algorithm), a leaky-bucket variant compatible with token-bucket semantics.
+
+Fallback: if Redis is unreachable, falls back to an in-process `Map<clientId, {tokens, lastRefill}>` limiter and emits a `warn` log.
+
+```
+CL.THROTTLE <key> <max_burst> <count_per_period> <period_seconds> [<quantity>]
+Key format: rl:{clientId}:{endpointGroup}
+```
+
+Tier configuration (sourced from `RATE_LIMIT_CONFIG` env / default constants):
+
+| Tier            | Sustained (rpm) | Burst | TTL    |
+|-----------------|-----------------|-------|--------|
+| Unauthenticated | 60              | 10    | 1 h    |
+| Free            | 1 000           | 50    | 24 h   |
+| Pro             | 10 000          | 200   | 1 month|
+| Enterprise      | configurable    | configurable | configurable |
+
+Endpoint group rate limits are enforced via separate buckets per endpoint group. Groups and their limits are defined in `src/rateLimit/endpointGroups.js`.
+
+Response on exhaustion: `429` with `Retry-After: <seconds>` and the full `X-RateLimit-*` header set.
+
+### 3. Rate Limit Header Writer (`src/rateLimit/headers.js`)
+
+Attaches these headers to every response (success or error):
+
+| Header | Value |
+|--------|-------|
+| `X-RateLimit-Limit` | max rpm for active tier + endpoint group |
+| `X-RateLimit-Remaining` | remaining tokens in current window |
+| `X-RateLimit-Reset` | Unix timestamp of next window reset |
+| `X-RateLimit-Tier` | tier name string |
+| `Retry-After` | seconds until next token (429 only) |
+
+### 4. Concurrent Request Limiter (`src/rateLimit/concurrentLimiter.js`)
+
+Uses Redis `INCR` / `DECR` on keys `conc:{clientId}` with a short TTL safety net. On request start: INCR and check against tier cap. On response finish (including errors): DECR.
+
+Limits by tier: Unauthenticated 5, Free 20, Pro 100, Enterprise configurable.
+
+WebSocket connections are tracked separately under `conc:ws:{clientId}` with limits: Unauthenticated 1, Free 5, Pro 25.
+
+Returns `503 { "error": "Too many concurrent requests" }` with `Retry-After: 1` when cap exceeded.
+
+### 5. GraphQL Complexity Limiter (`src/rateLimit/graphqlComplexity.js`)
+
+Applied only to GraphQL endpoints. Parses the query body, walks the AST, and calculates total cost as the sum of field costs multiplied by list multipliers.
+
+Cost budgets by tier: Unauthenticated 100, Free 500, Pro 2 000, Enterprise configurable.
+
+On rejection: `400 { "error": "Query complexity exceeded", "cost": N, "limit": M }`.
+
+Headers added: `X-GraphQL-Cost`, `X-GraphQL-Cost-Remaining`.
+
+### 6. GeoIP Rate Limiter (`src/rateLimit/geoIpLimiter.js`)
+
+Resolves client IP to a country/region code using the `maxmind` npm package with the GeoLite2-Country database file (path from `GEOIP_DB_PATH` env).
+
+- If region in `GEO_BLOCK_LIST` (comma-separated env): return `403 { "error": "Region not permitted" }`.
+- If region in `GEO_RATE_MULTIPLIERS` (JSON env): multiply the tier's base limit by the configured factor before passing to the token bucket.
+
+### 7. Abuse Detector (`src/rateLimit/abuseDetector.js`)
+
+Implements five detection patterns, all persisting state in Redis for cross-instance consistency:
+
+| Pattern | Detection | Action |
+|---------|-----------|--------|
+| Auth brute-force | >10 auth failures per IP in 60 s | Block IP 15 min, set `captcha_required` flag |
+| Scraping | >200 rpm + URL similarity >0.9 | Reduce effective limit to 10% for 10 min |
+| DDoS | >50 distinct IPs to same endpoint in 10 s | Trigger alert + Cloudflare webhook |
+| Aggressive pagination | >20 consecutive pages in 60 s | Penalty: 5 rpm on endpoint for 5 min |
+| Repeat offender | >5 rate limit breaches in 10 min | Flag key as suspicious, emit structured warning log |
+
+URL similarity scoring uses Jaccard similarity on URL path token sets.
+
+### 8. Key Manager (`src/admin/keyManager.js`)
+
+CRUD service for `api_keys` table. Admin authentication via `ADMIN_SECRET` environment variable checked in `src/admin/adminAuth.js` middleware.
+
+Admin routes mounted at `/api/admin/`:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/admin/api-keys` | Paginated list (excludes `key_hash`) |
+| POST | `/api/admin/api-keys` | Create key, return raw key once |
+| PATCH | `/api/admin/api-keys/:id` | Update metadata/tier/revoked |
+| DELETE | `/api/admin/api-keys/:id` | Soft delete (set revoked=true) |
+| POST | `/api/admin/api-keys/:id/rotate` | Re-generate key, return new raw key once |
+| GET | `/api/admin/api-keys/:id/usage` | Daily usage history |
+| GET | `/api/admin/audit-log` | Filtered, paginated audit search |
+| GET | `/api/admin/audit-log/export` | CSV or JSON export |
+
+Key generation uses `crypto.randomBytes(32)` encoded as URL-safe base64. The raw key is hashed with `bcrypt` (cost factor 12) before storage.
+
+### 9. Usage Tracker (`src/usage/usageTracker.js`)
+
+Aggregates per-key metrics in Redis counters and flushes to `api_key_usage_daily` PostgreSQL table every minute via a cron job.
+
+Tracked per key per day:
+- `total_requests`
+- `endpoint_distribution` (JSONB map of endpoint group → count)
+- `data_transfer_mb`
+- `rate_limit_hits`
+- `peak_concurrent`
+
+Retention: 7 days (Free), 90 days (Pro), 3 years (Enterprise). A nightly cron job runs `DELETE ... WHERE created_at < NOW() - INTERVAL '<retention>'`.
+
+### 10. Billing Service (`src/billing/stripeWebhook.js`)
+
+Webhook endpoint at `POST /api/billing/stripe-webhook`. Verifies Stripe signature using `stripe.webhooks.constructEvent(body, sig, STRIPE_WEBHOOK_SECRET)`.
+
+- `customer.subscription.updated` → update `api_keys.tier` to match plan product metadata.
+- `customer.subscription.deleted` → downgrade `api_keys.tier` to `'free'`.
+
+Returns `400` on signature failure; `200` on success.
+
+### 11. Audit Logger (`src/audit/auditLogger.js`)
+
+Writes to `api_audit_log` via a non-blocking async queue (an in-process `AsyncQueue` that batches inserts). The HTTP response is sent before the audit write completes.
+
+### 12. Analytics Dashboard (`frontend/src/pages/RateLimitDashboard.tsx`)
+
+A new page in the React frontend, following the same pattern as `RpcMetricsDashboard.tsx`. Polled at 5-second intervals. Admin-gated: shows a login prompt if `ADMIN_SECRET` is not provided.
+
+Components:
+- `RateLimitHitsChart` — real-time line chart (rate limit hits/min)
+- `TopUsersTable` — top 20 keys by volume with configurable time window
+- `ViolationHeatmap` — hour-of-day × day-of-week violation density
+- `UpgradeRecommendations` — keys where 7-day avg > 80% of tier limit
+
+---
+
+## Data Models
+
+### PostgreSQL: `api_keys` table
+
+```sql
+CREATE TABLE api_keys (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name              TEXT NOT NULL,
+  key_hash          TEXT NOT NULL,
+  key_prefix        CHAR(8) NOT NULL,
+  tier              TEXT NOT NULL DEFAULT 'free'
+                    CHECK (tier IN ('unauthenticated','free','pro','enterprise')),
+  rate_limit        INTEGER,                    -- per-key override, nullable
+  allowed_ips       JSONB,                      -- CIDR array, nullable
+  allowed_endpoints JSONB,                      -- endpoint pattern array, nullable
+  expires_at        TIMESTAMPTZ,
+  revoked           BOOLEAN NOT NULL DEFAULT FALSE,
+  last_used_at      TIMESTAMPTZ,
+  usage_count       BIGINT NOT NULL DEFAULT 0,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_api_keys_prefix ON api_keys (key_prefix);
+CREATE INDEX idx_api_keys_tier ON api_keys (tier);
+```
+
+### PostgreSQL: `api_key_usage_daily` table
+
+```sql
+CREATE TABLE api_key_usage_daily (
+  id                    BIGSERIAL PRIMARY KEY,
+  api_key_id            UUID NOT NULL REFERENCES api_keys(id) ON DELETE CASCADE,
+  date                  DATE NOT NULL,
+  total_requests        BIGINT NOT NULL DEFAULT 0,
+  endpoint_distribution JSONB,
+  data_transfer_mb      NUMERIC(12,3) NOT NULL DEFAULT 0,
+  rate_limit_hits       BIGINT NOT NULL DEFAULT 0,
+  peak_concurrent       INTEGER NOT NULL DEFAULT 0,
+  UNIQUE (api_key_id, date)
+);
+
+CREATE INDEX idx_usage_daily_key_date ON api_key_usage_daily (api_key_id, date DESC);
+```
+
+### PostgreSQL: `api_audit_log` table (monthly partitioned)
+
+```sql
+CREATE TABLE api_audit_log (
+  id                    BIGSERIAL,
+  timestamp             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  api_key_id            UUID,
+  key_name              TEXT,
+  tier                  TEXT NOT NULL,
+  ip                    INET NOT NULL,
+  method                TEXT NOT NULL,
+  endpoint              TEXT NOT NULL,
+  status_code           SMALLINT NOT NULL,
+  response_time_ms      INTEGER NOT NULL,
+  rate_limit_remaining  INTEGER,
+  user_agent            TEXT,
+  PRIMARY KEY (id, timestamp)
+) PARTITION BY RANGE (timestamp);
+
+-- Initial partitions created by migration; monthly partitions created by cron
+CREATE TABLE api_audit_log_y2025m01
+  PARTITION OF api_audit_log
+  FOR VALUES FROM ('2025-01-01') TO ('2025-02-01');
+-- ... additional partitions added monthly by a scheduled cron job
+```
+
+A monthly cron job creates the next month's partition and drops partitions older than the configured retention period.
+
+### Redis Key Namespaces
+
+| Namespace | Type | Purpose |
+|-----------|------|---------|
+| `rl:{clientId}:{endpointGroup}` | CL.THROTTLE | Per-client, per-group token bucket |
+| `conc:{clientId}` | String (counter) | Concurrent HTTP request count |
+| `conc:ws:{clientId}` | String (counter) | Concurrent WebSocket count |
+| `abuse:authfail:{ip}` | String (counter, TTL 60s) | Auth failure count |
+| `abuse:block:{ip}` | String (TTL 15min) | IP temporary block flag |
+| `abuse:scrape:{clientId}` | Sorted Set | URL path sliding window |
+| `abuse:ddos:{endpoint}:{window}` | HyperLogLog | Distinct IPs per endpoint |
+| `abuse:paginate:{clientId}:{endpoint}` | String (counter, TTL 60s) | Consecutive page count |
+| `abuse:ratelimitcount:{clientId}` | String (counter, TTL 10min) | Repeat breach count |
+| `abuse:penalty:{clientId}:{endpoint}` | String (TTL duration) | Penalty flag |
+| `usage:{keyId}:{date}:{metric}` | String (counter) | Intra-day usage buffers |
+
+### Environment Variables (new)
+
+| Variable | Description |
+|----------|-------------|
+| `ADMIN_SECRET` | Bearer token for admin endpoint authentication |
+| `RATE_LIMIT_CONFIG` | JSON blob overriding default tier limits |
+| `GEO_BLOCK_LIST` | Comma-separated ISO-3166 country codes to block |
+| `GEO_RATE_MULTIPLIERS` | JSON map of country code → float multiplier |
+| `GEOIP_DB_PATH` | Path to MaxMind GeoLite2-Country.mmdb file |
+| `STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret |
+| `STRIPE_SECRET_KEY` | Stripe API key for subscription management |
+| `CLOUDFLARE_WEBHOOK_URL` | Optional Cloudflare DDoS mitigation webhook |
+
+---
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+

--- a/.kiro/specs/api-auth-rate-limiting/requirements.md
+++ b/.kiro/specs/api-auth-rate-limiting/requirements.md
@@ -1,0 +1,248 @@
+# Requirements Document
+
+## Introduction
+
+This document defines requirements for adding API authentication and distributed rate limiting to the Soroban Smart Block Explorer REST API. Currently the API has no authentication or rate limiting, making it vulnerable to abuse, DDoS, and unauthorized access. The solution introduces a Redis-backed token bucket rate limiter, a tiered API key system, per-endpoint granular limits, Stripe billing integration, GraphQL query complexity limiting, ML-based abuse detection, a comprehensive audit log, and a rate limit analytics dashboard. All existing endpoints must continue to function without an API key (subject to the Unauthenticated tier limits).
+
+---
+
+## Glossary
+
+- **Rate_Limiter**: The middleware component that enforces request rate limits using the token bucket algorithm in Redis.
+- **Token_Bucket**: A rate limiting algorithm that grants tokens at a fixed rate and allows burst consumption up to a maximum bucket size.
+- **API_Key**: A secret credential issued to a client that identifies its tier and controls access permissions.
+- **Key_Manager**: The admin service that creates, updates, rotates, and revokes API keys.
+- **Tier**: A named configuration level (Unauthenticated, Free, Pro, Enterprise) that defines rate limit values for a client.
+- **Audit_Logger**: The component that records every API access to the `api_audit_log` PostgreSQL table.
+- **Abuse_Detector**: The component that analyses request patterns to identify and respond to malicious behaviour.
+- **Usage_Tracker**: The component that aggregates per-key request counts, data transfer, and rate limit hit metrics.
+- **Billing_Service**: The component that integrates with Stripe to manage Pro and Enterprise subscription billing.
+- **Complexity_Limiter**: The component that analyses incoming GraphQL queries and rejects those exceeding the per-tier cost budget.
+- **Analytics_Dashboard**: The frontend page that visualises rate limit hits, top users, violations, and tier upgrade recommendations.
+- **CIDR_Whitelist**: A list of IP address ranges in CIDR notation that are permitted to use a given API key.
+- **Admin**: An operator authenticated with the `ADMIN_SECRET` environment variable who has access to key management and audit log search endpoints.
+
+---
+
+## Requirements
+
+### Requirement 1: Distributed Token Bucket Rate Limiting
+
+**User Story:** As an API operator, I want Redis-backed distributed rate limiting, so that request quotas are enforced consistently across all server instances.
+
+#### Acceptance Criteria
+
+1. WHEN a request arrives, THE Rate_Limiter SHALL identify the client by API key if the `x-api-key` header is present, or by client IP address otherwise.
+2. WHEN a request arrives, THE Rate_Limiter SHALL apply the token bucket algorithm using Redis to enforce the per-tier rate limit.
+3. WHEN the token bucket for a client is empty, THE Rate_Limiter SHALL return HTTP 429 with a `Retry-After` header specifying the number of seconds until the next token is available.
+4. THE Rate_Limiter SHALL support burst allowances above the sustained rate up to the per-tier burst limit without triggering a 429 response.
+5. THE Rate_Limiter SHALL set the following headers on every response: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, `X-RateLimit-Tier`, and `Retry-After` (when applicable).
+6. WHILE the Redis connection is unavailable, THE Rate_Limiter SHALL fall back to an in-process rate limiter and SHALL log a warning, ensuring requests are not unconditionally rejected due to Redis failure.
+7. THE Rate_Limiter SHALL store token bucket state in Redis keys with TTLs matching the per-tier values: 1 hour for Unauthenticated, 24 hours for Free, 1 month for Pro, and a configurable TTL for Enterprise.
+
+---
+
+### Requirement 2: API Key Tiers
+
+**User Story:** As an API operator, I want four distinct API key tiers with different rate limits, so that I can offer differentiated access levels to clients.
+
+#### Acceptance Criteria
+
+1. THE Rate_Limiter SHALL enforce the following sustained rate limits by tier: Unauthenticated at 60 requests per minute, Free at 1000 requests per minute, Pro at 10000 requests per minute, and Enterprise at a custom operator-configured value.
+2. THE Rate_Limiter SHALL enforce the following burst limits by tier: Unauthenticated at 10 additional requests, Free at 50 additional requests, Pro at 200 additional requests, and Enterprise at a custom operator-configured value.
+3. WHERE an API key includes a `rate_limit` override field, THE Rate_Limiter SHALL apply the override value in place of the tier default.
+4. THE Rate_Limiter SHALL include the active tier name in the `X-RateLimit-Tier` response header.
+
+---
+
+### Requirement 3: Per-Endpoint Granular Rate Limits
+
+**User Story:** As an API operator, I want stricter rate limits on expensive endpoints, so that high-cost operations cannot exhaust quota shared with cheap read endpoints.
+
+#### Acceptance Criteria
+
+1. WHEN a request matches the `GET /api/events` endpoint group, THE Rate_Limiter SHALL apply limits of 60/min (Unauthenticated), 1000/min (Free), and 10000/min (Pro).
+2. WHEN a request matches the `GET /api/search` endpoint group, THE Rate_Limiter SHALL apply limits of 30/min (Unauthenticated), 500/min (Free), and 5000/min (Pro).
+3. WHEN a request matches the `POST /api/contracts` endpoint group, THE Rate_Limiter SHALL apply limits of 10/min (Unauthenticated), 100/min (Free), and 1000/min (Pro).
+4. WHEN a request matches the `POST /api/simulate` endpoint group, THE Rate_Limiter SHALL apply limits of 5/min (Unauthenticated), 50/min (Free), and 500/min (Pro).
+5. WHEN a WebSocket connection is initiated, THE Rate_Limiter SHALL apply limits of 3/min (Unauthenticated), 30/min (Free), and 300/min (Pro).
+6. THE Rate_Limiter SHALL maintain separate token buckets per client per endpoint group, so that consuming quota on one group does not reduce quota on another group.
+
+---
+
+### Requirement 4: API Key Data Model
+
+**User Story:** As an API operator, I want a well-defined API key record stored in PostgreSQL, so that key metadata, permissions, and usage can be reliably persisted and queried.
+
+#### Acceptance Criteria
+
+1. THE Key_Manager SHALL store each API key with the following fields: `id` (UUID primary key), `name` (human-readable label), `key_hash` (bcrypt hash of the raw key), `key_prefix` (first 8 characters of the raw key for identification), `tier` (one of: unauthenticated, free, pro, enterprise), `rate_limit` (optional integer override), `allowed_ips` (optional JSONB array of CIDR strings), `allowed_endpoints` (optional JSONB array of endpoint patterns), `expires_at` (optional timestamp), `revoked` (boolean, default false), `last_used_at` (timestamp, nullable), and `usage_count` (integer, default 0).
+2. WHEN an API key is used, THE Key_Manager SHALL update `last_used_at` to the current timestamp and increment `usage_count` by 1.
+3. WHEN an API key has `expires_at` set to a past timestamp, THE Rate_Limiter SHALL treat the key as revoked and return HTTP 401.
+4. WHEN an API key has `revoked` set to true, THE Rate_Limiter SHALL return HTTP 401.
+5. WHERE an API key specifies `allowed_ips`, THE Rate_Limiter SHALL return HTTP 403 if the client IP does not match any entry in the CIDR whitelist.
+6. WHERE an API key specifies `allowed_endpoints`, THE Rate_Limiter SHALL return HTTP 403 if the requested endpoint does not match any entry in the whitelist.
+
+---
+
+### Requirement 5: API Key Management Endpoints
+
+**User Story:** As an admin, I want REST endpoints to create, list, update, rotate, and delete API keys, so that I can manage client access without direct database access.
+
+#### Acceptance Criteria
+
+1. THE Key_Manager SHALL expose `GET /api/admin/api-keys` requiring Admin authentication and returning a paginated list of all non-revoked API key records excluding the `key_hash` field.
+2. THE Key_Manager SHALL expose `POST /api/admin/api-keys` requiring Admin authentication, accepting `name`, `tier`, `rate_limit`, `allowed_ips`, `allowed_endpoints`, and `expires_at`, and returning the generated raw API key exactly once in the response body.
+3. THE Key_Manager SHALL expose `PATCH /api/admin/api-keys/:id` requiring Admin authentication and allowing updates to `name`, `tier`, `rate_limit`, `allowed_ips`, `allowed_endpoints`, `expires_at`, and `revoked`.
+4. THE Key_Manager SHALL expose `DELETE /api/admin/api-keys/:id` requiring Admin authentication and setting `revoked` to true (soft delete).
+5. THE Key_Manager SHALL expose `POST /api/admin/api-keys/:id/rotate` requiring Admin authentication, generating a new raw key, replacing `key_hash` and `key_prefix`, and returning the new raw key exactly once.
+6. IF an Admin request is made without a valid `ADMIN_SECRET` credential, THEN THE Key_Manager SHALL return HTTP 401.
+7. THE Key_Manager SHALL generate API keys as cryptographically random strings of at least 32 bytes encoded in URL-safe base64.
+
+---
+
+### Requirement 6: Usage Tracking
+
+**User Story:** As an API operator, I want per-key usage metrics tracked over time, so that I can monitor consumption, detect anomalies, and support billing.
+
+#### Acceptance Criteria
+
+1. THE Usage_Tracker SHALL record the following metrics per API key per day: total request count, endpoint distribution (request counts per endpoint group), data transfer in megabytes, rate limit hit count, and peak concurrent connection count.
+2. WHEN a rate limit is exceeded, THE Usage_Tracker SHALL increment the `rate_limit_hits` counter for the associated key.
+3. THE Usage_Tracker SHALL retain daily usage data for 7 days for Free tier keys, 90 days for Pro tier keys, and 3 years for Enterprise tier keys.
+4. THE Key_Manager SHALL expose `GET /api/admin/api-keys/:id/usage` requiring Admin authentication and returning the retained daily usage history for the specified key.
+
+---
+
+### Requirement 7: Stripe Billing Integration
+
+**User Story:** As a product owner, I want Pro and Enterprise API subscriptions managed through Stripe, so that billing is automated and tier upgrades are self-service.
+
+#### Acceptance Criteria
+
+1. THE Billing_Service SHALL integrate with the Stripe API to create, update, and cancel subscriptions for Pro ($29/month) and Enterprise (custom) tiers.
+2. WHEN a Stripe webhook event of type `customer.subscription.updated` is received, THE Billing_Service SHALL update the associated API key's `tier` field to match the new subscription plan.
+3. WHEN a Stripe webhook event of type `customer.subscription.deleted` is received, THE Billing_Service SHALL downgrade the associated API key's `tier` to `free`.
+4. THE Billing_Service SHALL verify the Stripe webhook signature using the `STRIPE_WEBHOOK_SECRET` environment variable before processing any webhook payload.
+5. IF the Stripe webhook signature verification fails, THEN THE Billing_Service SHALL return HTTP 400 and discard the payload.
+
+---
+
+### Requirement 8: GraphQL Query Complexity Limiting
+
+**User Story:** As an API operator, I want GraphQL queries to be rejected when they exceed a per-tier cost budget, so that complex queries cannot bypass rate limits by consuming disproportionate server resources.
+
+#### Acceptance Criteria
+
+1. THE Complexity_Limiter SHALL assign a cost value to each GraphQL field based on a configurable cost map.
+2. WHEN a GraphQL query is received, THE Complexity_Limiter SHALL calculate the total cost by summing field costs, multiplied by list multipliers where applicable.
+3. WHEN the calculated query cost exceeds the tier budget, THE Complexity_Limiter SHALL reject the request with HTTP 400 and an error body containing `{"error": "Query complexity exceeded", "cost": <calculated>, "limit": <budget>}`.
+4. THE Complexity_Limiter SHALL enforce the following default cost budgets: 100 for Unauthenticated, 500 for Free, 2000 for Pro, and a configurable value for Enterprise.
+5. THE Complexity_Limiter SHALL include the calculated cost and remaining budget in the response headers `X-GraphQL-Cost` and `X-GraphQL-Cost-Remaining`.
+
+---
+
+### Requirement 9: Concurrent Request Limiting
+
+**User Story:** As an API operator, I want to cap the number of simultaneous in-flight requests per API key, so that a single client cannot exhaust server thread capacity.
+
+#### Acceptance Criteria
+
+1. THE Rate_Limiter SHALL enforce the following maximum concurrent in-flight request limits per key: 5 for Unauthenticated, 20 for Free, 100 for Pro, and a configurable value for Enterprise.
+2. WHEN the concurrent request limit for a key is reached and an additional request arrives, THE Rate_Limiter SHALL return HTTP 503 with a `Retry-After` header indicating 1 second.
+3. THE Rate_Limiter SHALL enforce a maximum of 1 concurrent WebSocket connection per key for Unauthenticated, 5 for Free, 25 for Pro, and a configurable value for Enterprise.
+
+---
+
+### Requirement 10: Geographic Rate Limiting
+
+**User Story:** As an API operator, I want the ability to apply different rate limits or blocks per geographic region, so that high-risk regions can be restricted without affecting legitimate users.
+
+#### Acceptance Criteria
+
+1. THE Rate_Limiter SHALL derive the client's geographic region from the client IP address using a configurable GeoIP database.
+2. WHERE a region is configured as blocked in the operator's `GEO_BLOCK_LIST` environment variable, THE Rate_Limiter SHALL return HTTP 403 with body `{"error": "Region not permitted"}`.
+3. WHERE a region has a configured rate limit multiplier in `GEO_RATE_MULTIPLIERS`, THE Rate_Limiter SHALL scale the tier's base rate limit by that multiplier.
+
+---
+
+### Requirement 11: ML-Based Abuse Detection
+
+**User Story:** As an API operator, I want automated detection of abusive request patterns, so that attacks and scrapers are identified and blocked without manual intervention.
+
+#### Acceptance Criteria
+
+1. WHEN more than 10 authentication failures from the same IP address occur within 60 seconds, THE Abuse_Detector SHALL temporarily block that IP for 15 minutes and increment a `captcha_required` flag in the client's session.
+2. WHEN a client issues more than 200 requests per minute with a URL path similarity score above 0.9 (indicating a scraping pattern), THE Abuse_Detector SHALL reduce the client's effective rate limit to 10% of the tier default for 10 minutes.
+3. WHEN requests to the same endpoint from more than 50 distinct IP addresses within 10 seconds are detected, THE Abuse_Detector SHALL trigger a DDoS alert and invoke the configured Cloudflare integration webhook if `CLOUDFLARE_WEBHOOK_URL` is set.
+4. WHEN a client sequentially paginates through more than 20 consecutive pages on the same endpoint within 60 seconds, THE Abuse_Detector SHALL apply a penalty rate limit of 5 requests per minute on that endpoint for that client for 5 minutes.
+5. WHEN a client exceeds its rate limit more than 5 times within 10 minutes, THE Abuse_Detector SHALL flag the key as suspicious and emit a structured warning log entry containing the key prefix, IP, and pattern description.
+6. THE Abuse_Detector SHALL persist detection state in Redis to ensure detection works correctly across multiple server instances.
+
+---
+
+### Requirement 12: Audit Logging
+
+**User Story:** As an API operator, I want every API access logged to a searchable audit table, so that I have a complete record of who accessed what and when.
+
+#### Acceptance Criteria
+
+1. THE Audit_Logger SHALL record the following fields for every API request: `timestamp`, `api_key_id` (nullable), `key_name` (nullable), `tier`, `ip`, `method`, `endpoint`, `status_code`, `response_time_ms`, `rate_limit_remaining`, and `user_agent`.
+2. THE Audit_Logger SHALL store records in a PostgreSQL table named `api_audit_log` that is automatically partitioned by month using PostgreSQL declarative partitioning.
+3. THE Audit_Logger SHALL automatically drop partitions older than the retention period: 90 days for Free, 1 year for Pro, and 3 years for Enterprise.
+4. THE Key_Manager SHALL expose `GET /api/admin/audit-log` requiring Admin authentication and accepting filter parameters `api_key_id`, `ip`, `endpoint`, `status_code`, `from`, and `to` (ISO 8601 timestamps), with pagination via `limit` and `offset`.
+5. THE Key_Manager SHALL expose `GET /api/admin/audit-log/export` requiring Admin authentication, accepting the same filter parameters, and returning the matching records as either CSV or JSON based on the `format` query parameter.
+6. THE Audit_Logger SHALL write log entries asynchronously and SHALL NOT block the HTTP response while persisting the audit record.
+
+---
+
+### Requirement 13: Rate Limit Headers
+
+**User Story:** As an API consumer, I want standardised rate limit headers on every response, so that my client can implement proactive backoff without guessing limits.
+
+#### Acceptance Criteria
+
+1. THE Rate_Limiter SHALL include `X-RateLimit-Limit` on every response, set to the maximum requests per minute for the client's active tier and endpoint group.
+2. THE Rate_Limiter SHALL include `X-RateLimit-Remaining` on every response, set to the number of requests remaining in the current window.
+3. THE Rate_Limiter SHALL include `X-RateLimit-Reset` on every response, set to the Unix timestamp (seconds) at which the current window resets.
+4. THE Rate_Limiter SHALL include `X-RateLimit-Tier` on every response, set to the name of the client's current tier.
+5. WHEN the Rate_Limiter returns HTTP 429, THE Rate_Limiter SHALL include `Retry-After` set to the number of whole seconds until a token becomes available.
+
+---
+
+### Requirement 14: Rate Limit Analytics Dashboard
+
+**User Story:** As an API operator, I want a frontend dashboard visualising rate limit activity, so that I can identify usage trends and recommend tier upgrades to heavy users.
+
+#### Acceptance Criteria
+
+1. THE Analytics_Dashboard SHALL display a real-time chart of rate limit hits per minute, updated at most every 5 seconds.
+2. THE Analytics_Dashboard SHALL display a ranked table of the top 20 API keys by total request volume over a configurable time window (1 hour, 24 hours, 7 days).
+3. THE Analytics_Dashboard SHALL display a heat map of rate limit violations by hour of day and day of week.
+4. THE Analytics_Dashboard SHALL display a list of API keys whose 7-day average request rate exceeds 80% of their tier limit, flagged as candidates for a tier upgrade.
+5. THE Analytics_Dashboard SHALL require Admin authentication before displaying any data.
+
+---
+
+### Requirement 15: Backward Compatibility
+
+**User Story:** As an existing API consumer, I want all existing endpoints to continue working without an API key, so that my integration is not broken by this feature.
+
+#### Acceptance Criteria
+
+1. THE Rate_Limiter SHALL allow requests without an `x-api-key` header to proceed, applying Unauthenticated tier limits.
+2. WHEN an unrecognised API key is provided in the `x-api-key` header, THE Rate_Limiter SHALL return HTTP 401 with body `{"error": "Invalid API key"}`.
+3. THE Rate_Limiter SHALL preserve all existing response body structures and HTTP status codes on successful requests.
+4. THE Rate_Limiter SHALL add rate limit headers to existing endpoint responses without altering any other existing headers.
+
+---
+
+### Requirement 16: Round-Trip API Key Serialization
+
+**User Story:** As a developer, I want API key records to serialize and deserialize correctly, so that keys stored in and retrieved from the database are equivalent.
+
+#### Acceptance Criteria
+
+1. THE Key_Manager SHALL serialize API key records to and from JSON without data loss.
+2. FOR ALL valid ApiKey objects, serializing then deserializing SHALL produce an object equal to the original (round-trip property).
+3. IF an invalid or malformed API key JSON payload is provided to a management endpoint, THEN THE Key_Manager SHALL return HTTP 400 with a descriptive validation error.

--- a/.kiro/specs/api-auth-rate-limiting/tasks.md
+++ b/.kiro/specs/api-auth-rate-limiting/tasks.md
@@ -1,0 +1,289 @@
+# Implementation Plan: API Authentication and Distributed Rate Limiting
+
+## Overview
+
+Implement the auth/rate-limiting middleware stack for the `indexer` Node.js/Express service. Tasks proceed in dependency order: database schema first, then core middleware components, then admin/billing/dashboard layers, wiring everything into the existing `api.js` entry point last.
+
+## Tasks
+
+- [x] 1. Set up database migrations and Redis namespaces
+  - Create `indexer/migrations/005_api_auth_rate_limiting.sql` with `api_keys`, `api_key_usage_daily`, and `api_audit_log` (monthly-partitioned) table definitions, all indexes, and initial 2025-01 / 2025-02 partitions
+  - Define the Redis key namespace constants in `indexer/src/rateLimit/constants.js` (all `rl:`, `conc:`, `abuse:`, `usage:` prefixes and TTL values)
+  - Add environment variable documentation block to `.env.example` for `ADMIN_SECRET`, `RATE_LIMIT_CONFIG`, `GEO_BLOCK_LIST`, `GEO_RATE_MULTIPLIERS`, `GEOIP_DB_PATH`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_SECRET_KEY`, `CLOUDFLARE_WEBHOOK_URL`
+  - _Requirements: 1.7, 4.1, 12.2_
+
+- [x] 2. Implement API Key Authenticator
+  - [x] 2.1 Create `indexer/src/auth/apiKeyAuth.js`
+    - Extract `x-api-key` header; fall back to hashed client IP for unauthenticated identity
+    - Look up key in PostgreSQL by `key_prefix` (first 8 chars), verify bcrypt hash
+    - Maintain an in-memory LRU cache (TTL 30 s, max 1 000 entries) to avoid per-request DB hits
+    - Validate: not revoked, not expired, IP CIDR whitelist, endpoint whitelist
+    - Attach `req.rateContext` with `{ clientId, tier, rateLimit, keyId, keyName }`
+    - Return `401` / `403` error responses as specified in the design
+    - Update `last_used_at` and increment `usage_count` on every authenticated request
+    - _Requirements: 1.1, 4.2, 4.3, 4.4, 4.5, 4.6, 15.1, 15.2_
+
+  - [ ]* 2.2 Write property test for API Key Authenticator
+    - **Property 1: Valid keys always resolve to a rateContext with a recognised tier**
+    - **Validates: Requirements 1.1, 2.1**
+
+  - [ ]* 2.3 Write unit tests for apiKeyAuth
+    - Test all 401/403 branches (unrecognised key, expired, revoked, IP mismatch, endpoint mismatch)
+    - Test LRU cache hit path does not call DB
+    - Test unauthenticated fallback assigns `unauthenticated` tier
+    - _Requirements: 4.3, 4.4, 4.5, 4.6, 15.1, 15.2_
+
+- [x] 3. Implement Token Bucket Rate Limiter
+  - [x] 3.1 Create `indexer/src/rateLimit/endpointGroups.js`
+    - Define endpoint group patterns and per-tier limits for `events`, `search`, `contracts`, `simulate`, `websocket`, and a `default` group
+    - Export a `resolveEndpointGroup(path)` helper
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6_
+
+  - [x] 3.2 Create `indexer/src/rateLimit/tokenBucket.js`
+    - Implement `tokenBucketMiddleware` using Redis `CL.THROTTLE` on keys `rl:{clientId}:{endpointGroup}`
+    - On Redis failure, fall back to an in-process `Map<clientId, {tokens, lastRefill}>` limiter and emit a `warn` log
+    - Return `429` with `Retry-After` when bucket is exhausted
+    - Per-key `rate_limit` override respected when present on `req.rateContext`
+    - _Requirements: 1.2, 1.3, 1.4, 1.6, 2.1, 2.2, 2.3, 3.6_
+
+  - [ ]* 3.3 Write property test for token bucket
+    - **Property 2: Requests within burst never receive 429; requests beyond sustained rate eventually receive 429**
+    - **Validates: Requirements 1.3, 1.4, 2.1, 2.2**
+
+  - [ ]* 3.4 Write unit tests for tokenBucket
+    - Test Redis fallback path logs warning and continues
+    - Test per-key override overrides tier default
+    - Test separate bucket per endpoint group (req 3.6)
+    - _Requirements: 1.6, 2.3, 3.6_
+
+- [x] 4. Implement Rate Limit Header Writer
+  - Create `indexer/src/rateLimit/headers.js` exporting `rateLimitHeaderWriter` middleware
+  - Attach `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, `X-RateLimit-Tier` on every response; attach `Retry-After` only on 429
+  - Read values from `req.rateLimitState` populated by `tokenBucketMiddleware`
+  - _Requirements: 1.5, 13.1, 13.2, 13.3, 13.4, 13.5_
+
+  - [ ]* 4.1 Write unit tests for rateLimitHeaderWriter
+    - Test all five headers are present on 200 responses
+    - Test `Retry-After` is set on 429 and absent on 200
+    - _Requirements: 13.1, 13.2, 13.3, 13.4, 13.5_
+
+- [x] 5. Implement Concurrent Request Limiter
+  - Create `indexer/src/rateLimit/concurrentLimiter.js`
+  - Use Redis `INCR` / `DECR` on `conc:{clientId}` (HTTP) and `conc:ws:{clientId}` (WebSocket)
+  - Set a short TTL safety net on the counter key to avoid leaks on crashed connections
+  - DECR on response `finish` event (including errors)
+  - Return `503` with `Retry-After: 1` when cap exceeded
+  - Tier limits: HTTP 5 / 20 / 100; WebSocket 1 / 5 / 25
+  - _Requirements: 9.1, 9.2, 9.3_
+
+  - [ ]* 5.1 Write unit tests for concurrentLimiter
+    - Test that the counter decrements on response finish even when an error is thrown
+    - Test 503 with `Retry-After: 1` is returned at cap
+    - _Requirements: 9.1, 9.2_
+
+- [x] 6. Implement GeoIP Rate Limiter
+  - Create `indexer/src/rateLimit/geoIpLimiter.js`
+  - Load MaxMind GeoLite2-Country database from `GEOIP_DB_PATH` using the `maxmind` npm package
+  - Block IPs in `GEO_BLOCK_LIST` with `403 { "error": "Region not permitted" }`
+  - Apply multiplier from `GEO_RATE_MULTIPLIERS` to base tier limit before passing to token bucket
+  - Gracefully degrade (pass through) when database file is absent
+  - _Requirements: 10.1, 10.2, 10.3_
+
+  - [ ]* 6.1 Write unit tests for geoIpLimiter
+    - Test blocked region returns 403
+    - Test multiplier is applied to rateContext before downstream middleware
+    - Test pass-through when GEOIP_DB_PATH is unset
+    - _Requirements: 10.2, 10.3_
+
+- [x] 7. Implement GraphQL Complexity Limiter
+  - Create `indexer/src/rateLimit/graphqlComplexity.js`
+  - Parse GraphQL query AST from request body; walk the AST summing field costs × list multipliers using a configurable cost map
+  - Reject with `400 { "error": "Query complexity exceeded", "cost": N, "limit": M }` when budget exceeded
+  - Add `X-GraphQL-Cost` and `X-GraphQL-Cost-Remaining` headers
+  - Cost budgets: 100 / 500 / 2000 / configurable by tier
+  - Apply only to GraphQL routes
+  - _Requirements: 8.1, 8.2, 8.3, 8.4, 8.5_
+
+  - [ ]* 7.1 Write property test for GraphQL Complexity Limiter
+    - **Property 3: Calculated complexity is always non-negative and monotonically increases with additional fields**
+    - **Validates: Requirements 8.2**
+
+  - [ ]* 7.2 Write unit tests for graphqlComplexity
+    - Test query at exactly budget limit is allowed; budget + 1 is rejected
+    - Test list multiplier correctly scales cost
+    - Test both headers are set on allowed requests
+    - _Requirements: 8.3, 8.4, 8.5_
+
+- [x] 8. Implement Abuse Detector
+  - Create `indexer/src/rateLimit/abuseDetector.js`
+  - Implement all five detection patterns using Redis keys per design (auth brute-force, scraping, DDoS, aggressive pagination, repeat offender)
+  - URL similarity uses Jaccard similarity on URL path token sets
+  - DDoS detection uses HyperLogLog (`PFADD` / `PFCOUNT`) per endpoint × 10 s window
+  - Cloudflare webhook fire is conditional on `CLOUDFLARE_WEBHOOK_URL`
+  - All state persisted in Redis for cross-instance consistency
+  - _Requirements: 11.1, 11.2, 11.3, 11.4, 11.5, 11.6_
+
+  - [ ]* 8.1 Write property test for Abuse Detector
+    - **Property 4: The Jaccard similarity score is always in [0, 1] for any two non-empty URL path sets**
+    - **Validates: Requirements 11.2**
+
+  - [ ]* 8.2 Write unit tests for abuseDetector
+    - Test auth brute-force threshold triggers 15-min block after 11th failure in 60 s
+    - Test repeat offender flag is emitted as structured warning log after 6th breach in 10 min
+    - Test scraping penalty reduces effective limit to 10%
+    - _Requirements: 11.1, 11.2, 11.5_
+
+- [x] 9. Checkpoint — Ensure all middleware unit tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 10. Implement Admin Auth Middleware and Key Manager
+  - [x] 10.1 Create `indexer/src/admin/adminAuth.js`
+    - Check `Authorization: Bearer <ADMIN_SECRET>` header; return `401` if missing or wrong
+    - _Requirements: 5.6_
+
+  - [x] 10.2 Create `indexer/src/admin/keyManager.js`
+    - Implement CRUD service functions: `listKeys`, `createKey`, `updateKey`, `deleteKey` (soft), `rotateKey`, `getKeyUsage`
+    - `createKey` / `rotateKey` use `crypto.randomBytes(32)` → URL-safe base64; store bcrypt hash (cost 12)
+    - Raw key returned exactly once in response; `key_hash` excluded from list/get responses
+    - Validate request body on `createKey` and `updateKey`; return `400` with descriptive error on invalid payload
+    - _Requirements: 4.1, 5.1, 5.2, 5.3, 5.4, 5.5, 5.7, 16.1, 16.3_
+
+  - [ ]* 10.3 Write property test for Key Manager serialization round-trip
+    - **Property 5: For all valid ApiKey objects, serialize → deserialize → serialize produces identical JSON**
+    - **Validates: Requirements 16.1, 16.2**
+
+  - [ ]* 10.4 Write unit tests for keyManager
+    - Test `createKey` returns raw key once and stores hash (not raw key)
+    - Test `deleteKey` sets `revoked = true` without removing the row
+    - Test `rotateKey` replaces `key_hash` and `key_prefix`
+    - Test `400` response on malformed JSON payload
+    - _Requirements: 5.1, 5.2, 5.4, 5.5, 16.3_
+
+- [x] 11. Add Admin API Routes
+  - Create `indexer/src/routes/admin.js` mounting all admin routes under `/api/admin/`
+  - Wire `adminAuth` middleware on all routes
+  - Implement paginated `GET /api/admin/api-keys`, `POST`, `PATCH /:id`, `DELETE /:id`, `POST /:id/rotate`, `GET /:id/usage`
+  - Implement `GET /api/admin/audit-log` and `GET /api/admin/audit-log/export` (CSV and JSON via `format` param)
+  - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5, 6.4, 12.4, 12.5_
+
+  - [ ]* 11.1 Write unit tests for admin routes
+    - Test all routes return `401` when `ADMIN_SECRET` header is absent
+    - Test `GET /api/admin/api-keys` excludes `key_hash` from response
+    - Test `GET /api/admin/audit-log/export?format=csv` returns `Content-Type: text/csv`
+    - _Requirements: 5.1, 5.6, 12.5_
+
+- [x] 12. Implement Usage Tracker
+  - Create `indexer/src/usage/usageTracker.js`
+  - Increment Redis counters `usage:{keyId}:{date}:{metric}` on each request
+  - Schedule a `node-cron` job running every minute to flush Redis counters to `api_key_usage_daily` via upsert
+  - Track: `total_requests`, `endpoint_distribution` (JSONB), `data_transfer_mb`, `rate_limit_hits`, `peak_concurrent`
+  - Schedule a nightly `node-cron` job to `DELETE` rows older than retention period per tier (7d / 90d / 3y)
+  - _Requirements: 6.1, 6.2, 6.3_
+
+  - [ ]* 12.1 Write unit tests for usageTracker
+    - Test `rate_limit_hits` is incremented when a 429 is issued
+    - Test retention delete targets correct interval per tier
+    - _Requirements: 6.2, 6.3_
+
+- [x] 13. Implement Audit Logger
+  - Create `indexer/src/audit/auditLogger.js`
+  - Implement an in-process async queue that batches INSERT statements into `api_audit_log`
+  - Fire-and-forget via response `finish` hook so HTTP response is never blocked
+  - Fields logged: `timestamp`, `api_key_id`, `key_name`, `tier`, `ip`, `method`, `endpoint`, `status_code`, `response_time_ms`, `rate_limit_remaining`, `user_agent`
+  - Schedule a monthly `node-cron` job to CREATE the next month's partition and DROP partitions beyond retention
+  - _Requirements: 12.1, 12.2, 12.3, 12.6_
+
+  - [ ]* 13.1 Write unit tests for auditLogger
+    - Test that the HTTP response `finish` callback queues the record without awaiting DB write
+    - Test all required fields are present in the enqueued payload
+    - _Requirements: 12.1, 12.6_
+
+- [x] 14. Implement Billing Service
+  - Create `indexer/src/billing/stripeWebhook.js`
+  - Verify Stripe webhook signature with `stripe.webhooks.constructEvent(body, sig, STRIPE_WEBHOOK_SECRET)`
+  - Handle `customer.subscription.updated` → update `api_keys.tier`
+  - Handle `customer.subscription.deleted` → downgrade `api_keys.tier` to `'free'`
+  - Return `400` on signature failure; `200` on success
+  - Mount at `POST /api/billing/stripe-webhook` (raw body parser required)
+  - _Requirements: 7.1, 7.2, 7.3, 7.4, 7.5_
+
+  - [ ]* 14.1 Write unit tests for stripeWebhook
+    - Test `400` response when signature verification throws
+    - Test `customer.subscription.deleted` downgrades tier to `free`
+    - _Requirements: 7.4, 7.5, 7.3_
+
+- [x] 15. Wire Middleware Stack into Express App
+  - In `indexer/src/api.js`, import and mount the full ordered middleware chain immediately after the existing `helmet` / `cors` / `express.json()` block:
+    1. `apiKeyAuthenticator`
+    2. `geoIpRateLimiter`
+    3. `concurrentRequestLimiter`
+    4. `tokenBucketRateLimiter`
+    5. `graphqlComplexityLimiter` (GraphQL routes only)
+    6. `abuseDetector`
+    7. `rateLimitHeaderWriter`
+  - Register the `auditLogger` response-finish hook globally
+  - Import and mount the admin router and billing webhook route
+  - Start the `usageTracker` cron jobs alongside existing startup jobs in `index.js`
+  - Remove (or deprecate) the existing `generalLimiter` and `writeLimiter` express-rate-limit instances now superseded by the new middleware
+  - _Requirements: 1.1, 1.2, 1.5, 15.3, 15.4_
+
+  - [ ]* 15.1 Write integration tests for the full middleware chain
+    - Test unauthenticated request flows through chain and receives correct tier headers
+    - Test a revoked key is rejected with `401` before reaching any route handler
+    - Test backward compatibility: existing `/api/events` response body is unchanged
+    - _Requirements: 15.1, 15.2, 15.3, 15.4_
+
+- [x] 16. Checkpoint — Ensure all middleware and integration tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [-] 17. Implement Rate Limit Analytics Dashboard
+  - [x] 17.1 Add analytics data endpoints to the admin router
+    - `GET /api/admin/analytics/rate-limit-hits` — per-minute hit counts for the last N minutes from Redis/DB
+    - `GET /api/admin/analytics/top-users?window=1h|24h|7d` — top 20 keys by request volume from `api_key_usage_daily`
+    - `GET /api/admin/analytics/violation-heatmap` — hour × day-of-week aggregation from `api_audit_log`
+    - `GET /api/admin/analytics/upgrade-recommendations` — keys where 7-day avg > 80% of tier limit
+    - All endpoints require admin auth
+    - _Requirements: 14.1, 14.2, 14.3, 14.4, 14.5_
+
+  - [x] 17.2 Create `frontend/src/pages/RateLimitDashboard.tsx`
+    - Admin login prompt when `ADMIN_SECRET` is not present in context
+    - Polls analytics endpoints every 5 seconds
+    - Renders `RateLimitHitsChart`, `TopUsersTable`, `ViolationHeatmap`, `UpgradeRecommendations` sub-components
+    - Follow the same pattern as the existing `RpcMetricsDashboard.tsx`
+    - _Requirements: 14.1, 14.2, 14.3, 14.4, 14.5_
+
+  - [x] 17.3 Create `frontend/src/components/RateLimitHitsChart.tsx`
+    - Real-time line chart of rate limit hits per minute
+    - _Requirements: 14.1_
+
+  - [x] 17.4 Create `frontend/src/components/TopUsersTable.tsx`
+    - Ranked table of top 20 keys with configurable time window selector (1h / 24h / 7d)
+    - _Requirements: 14.2_
+
+  - [ ] 17.5 Create `frontend/src/components/ViolationHeatmap.tsx`
+    - Hour-of-day × day-of-week heat map of rate limit violations
+    - _Requirements: 14.3_
+
+  - [ ] 17.6 Create `frontend/src/components/UpgradeRecommendations.tsx`
+    - List of keys whose 7-day avg exceeds 80% of tier limit
+    - _Requirements: 14.4_
+
+  - [ ] 17.7 Register `RateLimitDashboard` route in `frontend/src/App.tsx`
+    - Add route entry (e.g. `/admin/rate-limits`) following the existing routing pattern
+    - _Requirements: 14.5_
+
+  - [ ]* 17.8 Write unit tests for dashboard components
+    - Test `RateLimitDashboard` renders login prompt when no admin token is present
+    - Test `TopUsersTable` renders correct number of rows from mock data
+    - _Requirements: 14.5_
+
+- [ ] 18. Final Checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for a faster MVP
+- All JavaScript follows the ESM (`import`/`export`) convention used throughout the `indexer` service
+- Property tests use the existing `node --test` runner with a fast-check or similar property library
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation before adding the next layer

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ const DeveloperWorkspace = lazy(() => import("./pages/DeveloperWorkspace"));
 const SetupPage = lazy(() => import("./pages/SetupPage"));
 const BatchMultiCall = lazy(() => import("./pages/BatchMultiCall"));
 const SubInvocationPage = lazy(() => import("./pages/SubInvocationPage"));
+const RateLimitDashboard = lazy(() => import("./pages/RateLimitDashboard"));
 
 function Fallback() {
   return <p style={{ padding: 32, textAlign: "center", color: "var(--muted)" }}>Loading…</p>;
@@ -43,6 +44,7 @@ export default function App() {
             <Route path="/setup" element={<SetupPage />} />
             <Route path="/batch" element={<BatchMultiCall />} />
             <Route path="/sub-invocations" element={<SubInvocationPage />} />
+            <Route path="/admin/rate-limits" element={<RateLimitDashboard />} />
           </Routes>
         </Suspense>
       </main>

--- a/frontend/src/components/RateLimitHitsChart.tsx
+++ b/frontend/src/components/RateLimitHitsChart.tsx
@@ -1,0 +1,61 @@
+/**
+ * Real-time line chart of rate limit hits per minute.
+ */
+interface HitDataPoint {
+  minute: string;
+  hits: number;
+}
+
+export default function RateLimitHitsChart({ data }: { data: HitDataPoint[] }) {
+  if (!data.length) {
+    return <p style={{ color: "#9ca3af", fontSize: 13 }}>No rate limit hits in the selected window.</p>;
+  }
+
+  const maxHits = Math.max(...data.map((d) => Number(d.hits)), 1);
+  const w = 600;
+  const h = 80;
+  const pts = data
+    .map((d, i) => {
+      const x = (i / (data.length - 1 || 1)) * w;
+      const y = h - (Number(d.hits) / maxHits) * h;
+      return `${x},${y}`;
+    })
+    .join(" ");
+
+  return (
+    <div>
+      <svg
+        width="100%"
+        viewBox={`0 0 ${w} ${h}`}
+        style={{ display: "block", overflow: "visible" }}
+        aria-label="Rate limit hits per minute chart"
+      >
+        <polyline points={pts} fill="none" stroke="#dc2626" strokeWidth={2} />
+        {data.map((d, i) => {
+          const x = (i / (data.length - 1 || 1)) * w;
+          const y = h - (Number(d.hits) / maxHits) * h;
+          return (
+            <circle key={i} cx={x} cy={y} r={3} fill="#dc2626">
+              <title>
+                {new Date(d.minute).toLocaleTimeString()}: {d.hits} hits
+              </title>
+            </circle>
+          );
+        })}
+      </svg>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          fontSize: 11,
+          color: "#9ca3af",
+          marginTop: 4,
+        }}
+      >
+        <span>{data[0] ? new Date(data[0].minute).toLocaleTimeString() : ""}</span>
+        <span>Peak: {maxHits} hits/min</span>
+        <span>{data[data.length - 1] ? new Date(data[data.length - 1].minute).toLocaleTimeString() : ""}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TopUsersTable.tsx
+++ b/frontend/src/components/TopUsersTable.tsx
@@ -1,0 +1,73 @@
+/**
+ * Ranked table of top 20 API keys by request volume.
+ */
+interface TopUser {
+  api_key_id: string;
+  key_name: string;
+  total_requests: number;
+}
+
+type Window = "1h" | "24h" | "7d";
+
+interface Props {
+  data: TopUser[];
+  window: Window;
+  onWindowChange: (w: Window) => void;
+}
+
+export default function TopUsersTable({ data, window, onWindowChange }: Props) {
+  return (
+    <div>
+      <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
+        {(["1h", "24h", "7d"] as Window[]).map((w) => (
+          <button
+            key={w}
+            onClick={() => onWindowChange(w)}
+            style={{
+              padding: "4px 12px",
+              borderRadius: 4,
+              border: "1px solid #e5e7eb",
+              background: window === w ? "#7c3aed" : "#f9fafb",
+              color: window === w ? "#fff" : "#374151",
+              cursor: "pointer",
+              fontSize: 12,
+              fontWeight: 600,
+            }}
+            aria-pressed={window === w}
+          >
+            {w}
+          </button>
+        ))}
+      </div>
+
+      {data.length === 0 ? (
+        <p style={{ color: "#9ca3af", fontSize: 13 }}>No data for this window.</p>
+      ) : (
+        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+          <thead>
+            <tr style={{ borderBottom: "2px solid #e5e7eb" }}>
+              <th style={{ textAlign: "left", padding: "6px 8px", color: "#6b7280" }}>#</th>
+              <th style={{ textAlign: "left", padding: "6px 8px", color: "#6b7280" }}>Key Name</th>
+              <th style={{ textAlign: "left", padding: "6px 8px", color: "#6b7280" }}>Key ID</th>
+              <th style={{ textAlign: "right", padding: "6px 8px", color: "#6b7280" }}>Requests</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((row, i) => (
+              <tr key={row.api_key_id} style={{ borderBottom: "1px solid #f3f4f6" }}>
+                <td style={{ padding: "6px 8px", color: "#9ca3af" }}>{i + 1}</td>
+                <td style={{ padding: "6px 8px", fontWeight: 500 }}>{row.key_name ?? "—"}</td>
+                <td style={{ padding: "6px 8px" }}>
+                  <code style={{ fontSize: 11, color: "#6b7280" }}>{row.api_key_id?.slice(0, 8)}…</code>
+                </td>
+                <td style={{ padding: "6px 8px", textAlign: "right", fontWeight: 600 }}>
+                  {Number(row.total_requests).toLocaleString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/UpgradeRecommendations.tsx
+++ b/frontend/src/components/UpgradeRecommendations.tsx
@@ -1,0 +1,72 @@
+/**
+ * List of API keys whose 7-day average request rate exceeds 80% of their tier limit.
+ */
+interface Recommendation {
+  id: string;
+  name: string;
+  tier: string;
+  avg_daily_requests: number;
+  daily_tier_limit: number;
+}
+
+const NEXT_TIER: Record<string, string> = {
+  unauthenticated: "free",
+  free: "pro",
+  pro: "enterprise",
+};
+
+export default function UpgradeRecommendations({ data }: { data: Recommendation[] }) {
+  if (!data.length) {
+    return (
+      <p style={{ color: "#9ca3af", fontSize: 13 }}>
+        No keys are approaching their tier limit.
+      </p>
+    );
+  }
+
+  return (
+    <div style={{ display: "grid", gap: 10 }}>
+      {data.map((rec) => {
+        const pct = rec.daily_tier_limit
+          ? Math.round((Number(rec.avg_daily_requests) / Number(rec.daily_tier_limit)) * 100)
+          : 0;
+        const next = NEXT_TIER[rec.tier] ?? "custom";
+
+        return (
+          <div
+            key={rec.id}
+            style={{
+              border: "1px solid #fde68a",
+              borderRadius: 8,
+              padding: "12px 16px",
+              background: "#fffbeb",
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+            }}
+          >
+            <div>
+              <div style={{ fontWeight: 600, fontSize: 14 }}>{rec.name}</div>
+              <div style={{ fontSize: 12, color: "#6b7280", marginTop: 2 }}>
+                Tier: <strong>{rec.tier}</strong> · Avg {Number(rec.avg_daily_requests).toLocaleString()} req/day ·{" "}
+                <span style={{ color: "#d97706" }}>{pct}% of limit</span>
+              </div>
+            </div>
+            <div
+              style={{
+                fontSize: 12,
+                fontWeight: 600,
+                color: "#92400e",
+                background: "#fde68a",
+                padding: "4px 10px",
+                borderRadius: 4,
+              }}
+            >
+              Consider upgrading to {next}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/ViolationHeatmap.tsx
+++ b/frontend/src/components/ViolationHeatmap.tsx
@@ -1,0 +1,94 @@
+/**
+ * Hour-of-day × day-of-week heat map of rate limit violations.
+ */
+interface HeatmapCell {
+  hour: number;
+  day_of_week: number;
+  violations: number;
+}
+
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+export default function ViolationHeatmap({ data }: { data: HeatmapCell[] }) {
+  if (!data.length) {
+    return <p style={{ color: "#9ca3af", fontSize: 13 }}>No violation data available.</p>;
+  }
+
+  // Build a lookup map: [day][hour] → violations
+  const grid: number[][] = Array.from({ length: 7 }, () => new Array(24).fill(0));
+  let maxVal = 1;
+  for (const cell of data) {
+    const v = Number(cell.violations);
+    grid[cell.day_of_week][cell.hour] = v;
+    if (v > maxVal) maxVal = v;
+  }
+
+  const cellSize = 18;
+  const labelW = 32;
+  const headerH = 20;
+
+  return (
+    <div style={{ overflowX: "auto" }}>
+      <svg
+        width={labelW + 24 * cellSize}
+        height={headerH + 7 * cellSize}
+        aria-label="Rate limit violation heatmap by hour and day of week"
+      >
+        {/* Hour labels */}
+        {Array.from({ length: 24 }, (_, h) => (
+          <text
+            key={h}
+            x={labelW + h * cellSize + cellSize / 2}
+            y={headerH - 4}
+            textAnchor="middle"
+            fontSize={9}
+            fill="#9ca3af"
+          >
+            {h % 6 === 0 ? h : ""}
+          </text>
+        ))}
+
+        {/* Day labels + cells */}
+        {Array.from({ length: 7 }, (_, day) => (
+          <g key={day}>
+            <text
+              x={labelW - 4}
+              y={headerH + day * cellSize + cellSize / 2 + 4}
+              textAnchor="end"
+              fontSize={10}
+              fill="#6b7280"
+            >
+              {DAY_LABELS[day]}
+            </text>
+            {Array.from({ length: 24 }, (_, hour) => {
+              const v = grid[day][hour];
+              const intensity = v / maxVal;
+              const r = Math.round(220 + (220 - 220) * intensity);
+              const g = Math.round(220 - 160 * intensity);
+              const b = Math.round(220 - 200 * intensity);
+              const fill = v === 0 ? "#f3f4f6" : `rgb(${r},${g},${b})`;
+              return (
+                <rect
+                  key={hour}
+                  x={labelW + hour * cellSize + 1}
+                  y={headerH + day * cellSize + 1}
+                  width={cellSize - 2}
+                  height={cellSize - 2}
+                  fill={fill}
+                  rx={2}
+                >
+                  <title>
+                    {DAY_LABELS[day]} {hour}:00 — {v} violations
+                  </title>
+                </rect>
+              );
+            })}
+          </g>
+        ))}
+      </svg>
+      <div style={{ fontSize: 11, color: "#9ca3af", marginTop: 4 }}>
+        Darker = more violations · Last 30 days
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/RateLimitDashboard.tsx
+++ b/frontend/src/pages/RateLimitDashboard.tsx
@@ -1,0 +1,236 @@
+/**
+ * Rate Limit Analytics Dashboard
+ * Polls analytics endpoints every 5 seconds. Requires admin authentication.
+ */
+import { useEffect, useState, useCallback } from "react";
+import RateLimitHitsChart from "../components/RateLimitHitsChart";
+import TopUsersTable from "../components/TopUsersTable";
+import ViolationHeatmap from "../components/ViolationHeatmap";
+import UpgradeRecommendations from "../components/UpgradeRecommendations";
+
+type Window = "1h" | "24h" | "7d";
+
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        border: "1px solid #e5e7eb",
+        borderRadius: 8,
+        padding: 20,
+        background: "#fff",
+        marginBottom: 20,
+      }}
+    >
+      <h3 style={{ margin: "0 0 16px", fontSize: 15, fontWeight: 600, color: "#111827" }}>
+        {title}
+      </h3>
+      {children}
+    </div>
+  );
+}
+
+export default function RateLimitDashboard() {
+  const [adminToken, setAdminToken] = useState(() => sessionStorage.getItem("admin_token") ?? "");
+  const [tokenInput, setTokenInput] = useState("");
+  const [authed, setAuthed] = useState(false);
+
+  const [hitsData, setHitsData] = useState([]);
+  const [topUsers, setTopUsers] = useState([]);
+  const [heatmap, setHeatmap] = useState([]);
+  const [recommendations, setRecommendations] = useState([]);
+  const [topWindow, setTopWindow] = useState<Window>("24h");
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const headers = { Authorization: `Bearer ${adminToken}` };
+
+  const fetchAll = useCallback(async () => {
+    if (!adminToken) return;
+    try {
+      const [hitsRes, topRes, heatmapRes, recsRes] = await Promise.all([
+        fetch("/api/admin/analytics/rate-limit-hits?minutes=60", { headers }),
+        fetch(`/api/admin/analytics/top-users?window=${topWindow}`, { headers }),
+        fetch("/api/admin/analytics/violation-heatmap", { headers }),
+        fetch("/api/admin/analytics/upgrade-recommendations", { headers }),
+      ]);
+
+      if (hitsRes.status === 401) {
+        setAuthed(false);
+        setError("Invalid or expired admin token.");
+        return;
+      }
+
+      setHitsData(await hitsRes.json());
+      setTopUsers(await topRes.json());
+      setHeatmap(await heatmapRes.json());
+      setRecommendations(await recsRes.json());
+      setLastUpdated(new Date());
+      setAuthed(true);
+      setError(null);
+    } catch (e: any) {
+      setError(e.message);
+    }
+  }, [adminToken, topWindow]);
+
+  useEffect(() => {
+    if (!adminToken) return;
+    fetchAll();
+    const id = setInterval(fetchAll, 5_000);
+    return () => clearInterval(id);
+  }, [fetchAll]);
+
+  // Re-fetch top users when window changes
+  useEffect(() => {
+    if (!authed) return;
+    fetch(`/api/admin/analytics/top-users?window=${topWindow}`, { headers })
+      .then((r) => r.json())
+      .then(setTopUsers)
+      .catch(() => {});
+  }, [topWindow]);
+
+  // Login screen
+  if (!adminToken || !authed) {
+    return (
+      <div
+        style={{
+          maxWidth: 400,
+          margin: "80px auto",
+          border: "1px solid #e5e7eb",
+          borderRadius: 8,
+          padding: 32,
+          background: "#fff",
+        }}
+      >
+        <h2 style={{ margin: "0 0 8px", fontSize: 18 }}>Admin Login</h2>
+        <p style={{ color: "#6b7280", fontSize: 13, marginBottom: 20 }}>
+          Enter your ADMIN_SECRET to access the Rate Limit Dashboard.
+        </p>
+        {error && (
+          <div
+            style={{
+              padding: "8px 12px",
+              background: "#fee2e2",
+              borderRadius: 4,
+              color: "#991b1b",
+              fontSize: 13,
+              marginBottom: 12,
+            }}
+          >
+            {error}
+          </div>
+        )}
+        <input
+          type="password"
+          placeholder="Admin token"
+          value={tokenInput}
+          onChange={(e) => setTokenInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              sessionStorage.setItem("admin_token", tokenInput);
+              setAdminToken(tokenInput);
+            }
+          }}
+          style={{
+            width: "100%",
+            padding: "8px 12px",
+            borderRadius: 4,
+            border: "1px solid #d1d5db",
+            fontSize: 14,
+            boxSizing: "border-box",
+            marginBottom: 12,
+          }}
+          aria-label="Admin token"
+        />
+        <button
+          onClick={() => {
+            sessionStorage.setItem("admin_token", tokenInput);
+            setAdminToken(tokenInput);
+          }}
+          style={{
+            width: "100%",
+            padding: "8px 12px",
+            background: "#7c3aed",
+            color: "#fff",
+            border: "none",
+            borderRadius: 4,
+            fontSize: 14,
+            fontWeight: 600,
+            cursor: "pointer",
+          }}
+        >
+          Sign in
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 24,
+        }}
+      >
+        <h2 style={{ margin: 0 }}>Rate Limit Analytics</h2>
+        <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
+          {lastUpdated && (
+            <span style={{ fontSize: 12, color: "#9ca3af" }}>
+              Updated {lastUpdated.toLocaleTimeString()}
+            </span>
+          )}
+          <button
+            onClick={() => {
+              sessionStorage.removeItem("admin_token");
+              setAdminToken("");
+              setAuthed(false);
+            }}
+            style={{
+              padding: "4px 12px",
+              fontSize: 12,
+              borderRadius: 4,
+              border: "1px solid #e5e7eb",
+              background: "#f9fafb",
+              cursor: "pointer",
+            }}
+          >
+            Sign out
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div
+          style={{
+            padding: 12,
+            background: "#fee2e2",
+            borderRadius: 6,
+            marginBottom: 16,
+            color: "#991b1b",
+            fontSize: 13,
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      <Card title="Rate Limit Hits / Minute (last 60 min)">
+        <RateLimitHitsChart data={hitsData} />
+      </Card>
+
+      <Card title="Top Users by Request Volume">
+        <TopUsersTable data={topUsers} window={topWindow} onWindowChange={setTopWindow} />
+      </Card>
+
+      <Card title="Violation Heat Map (last 30 days)">
+        <ViolationHeatmap data={heatmap} />
+      </Card>
+
+      <Card title="Tier Upgrade Recommendations">
+        <UpgradeRecommendations data={recommendations} />
+      </Card>
+    </div>
+  );
+}

--- a/indexer/migrations/005_api_auth_rate_limiting.sql
+++ b/indexer/migrations/005_api_auth_rate_limiting.sql
@@ -1,0 +1,144 @@
+-- Migration 005: API authentication, rate limiting keys, usage tracking, and audit logging
+
+-- ── API Keys ──────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS api_keys (
+  id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  name              TEXT        NOT NULL,
+  key_hash          TEXT        NOT NULL,
+  key_prefix        CHAR(8)     NOT NULL,
+  tier              TEXT        NOT NULL DEFAULT 'free'
+                                CHECK (tier IN ('unauthenticated','free','pro','enterprise')),
+  rate_limit        INTEGER,                    -- per-key override, nullable
+  allowed_ips       JSONB,                      -- CIDR array, nullable
+  allowed_endpoints JSONB,                      -- endpoint pattern array, nullable
+  expires_at        TIMESTAMPTZ,
+  revoked           BOOLEAN     NOT NULL DEFAULT FALSE,
+  last_used_at      TIMESTAMPTZ,
+  usage_count       BIGINT      NOT NULL DEFAULT 0,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_prefix ON api_keys (key_prefix);
+CREATE INDEX IF NOT EXISTS idx_api_keys_tier   ON api_keys (tier);
+
+-- ── Daily Usage Aggregates ────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS api_key_usage_daily (
+  id                    BIGSERIAL   PRIMARY KEY,
+  api_key_id            UUID        NOT NULL REFERENCES api_keys(id) ON DELETE CASCADE,
+  date                  DATE        NOT NULL,
+  total_requests        BIGINT      NOT NULL DEFAULT 0,
+  endpoint_distribution JSONB,
+  data_transfer_mb      NUMERIC(12,3) NOT NULL DEFAULT 0,
+  rate_limit_hits       BIGINT      NOT NULL DEFAULT 0,
+  peak_concurrent       INTEGER     NOT NULL DEFAULT 0,
+  UNIQUE (api_key_id, date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_usage_daily_key_date
+  ON api_key_usage_daily (api_key_id, date DESC);
+
+-- ── Audit Log (monthly partitioned) ──────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS api_audit_log (
+  id                   BIGSERIAL,
+  timestamp            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  api_key_id           UUID,
+  key_name             TEXT,
+  tier                 TEXT        NOT NULL,
+  ip                   INET        NOT NULL,
+  method               TEXT        NOT NULL,
+  endpoint             TEXT        NOT NULL,
+  status_code          SMALLINT    NOT NULL,
+  response_time_ms     INTEGER     NOT NULL,
+  rate_limit_remaining INTEGER,
+  user_agent           TEXT,
+  PRIMARY KEY (id, timestamp)
+) PARTITION BY RANGE (timestamp);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_timestamp
+  ON api_audit_log (timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_log_api_key_id
+  ON api_audit_log (api_key_id);
+CREATE INDEX IF NOT EXISTS idx_audit_log_ip
+  ON api_audit_log (ip);
+CREATE INDEX IF NOT EXISTS idx_audit_log_status_code
+  ON api_audit_log (status_code);
+CREATE INDEX IF NOT EXISTS idx_audit_log_endpoint
+  ON api_audit_log (endpoint);
+
+-- ── Initial monthly partitions: 2025-01 through 2026-06 ──────────────────────
+
+CREATE TABLE IF NOT EXISTS api_audit_log_y2025m01
+  PARTITION OF api_audit_log
+  FOR VALUES FROM ('2025-01-01') TO ('2025-02-01');
+
+CREATE TABLE IF NOT EXISTS api_audit_log_y2025m02
+  PARTITION OF api_audit_log
+  FOR VALUES FROM ('2025-02-01') TO ('2025-03-01');
+
+CREATE TABLE IF NOT EXISTS api_audit_log_y2025m03
+  PARTITION OF api_audit_log
+  FOR VALUES FROM ('2025-03-01') TO ('2025-04-01');
+
+CREATE TABLE IF NOT EXISTS api_audit_log_y2025m04
+  PARTITION OF api_audit_log
+  FOR VALUES FROM ('2025-04-01') TO ('2025-05-01');
+
+CREATE TABLE IF NOT EXISTS api_audit_log_y2025m05
+  PARTITION OF api_audit_log
+  FOR VALUES FROM ('2025-05-01') TO ('2025-06-01');
+
+CREATE TABLE IF NOT EXISTS api_audit_log_y2025m06
+  PARTITION OF api_audit_log
+  FOR VALUES FROM ('2025-06-01') TO ('2025-07-01');
+
+CREATE TABLE IF NOT EXISTS api_audit_log_y2025m07
+  PARTITION OF api_audit_log
+  FOR VALUES FROM ('2025-07-01') TO ('2025-08-01');
+
+CREATE TABLE IF NOT EXISTS api_audit_log_y2025m08
+  PARTITION OF api_audit_log
+  FOR VALUES FROM ('2025-08-01') TO ('2025-09-01');
+
+CREATE TABLE IF NOT EXISTS api_audit_log_y2025m09
+  PARTITION OF api_audit_log
+  FOR VALUES FROM ('2025-09-01') TO ('2025-10-01');
+
+CREATE TABLE IF NOT EXISTS api_audit_log_y2025m10
+  PARTITION OF api_audit_log
+  FOR VALUES FROM ('2025-10-01') TO ('2025-11-01');
+
+CREATE TABLE IF NOT EXISTS api_audit_log_y2025m11
+  PARTITION OF api_audit_log
+  FOR VALUES FROM ('2025-11-01') TO ('2025-12-01');
+
+CREATE TABLE IF NOT EXISTS api_audit_log_y2025m12
+  PARTITION OF api_audit_log
+  FOR VALUES FROM ('2025-12-01') TO ('2026-01-01');
+
+CREATE TABLE IF NOT EXISTS api_audit_log_y2026m01
+  PARTITION OF api_audit_log
+  FOR VALUES FROM ('2026-01-01') TO ('2026-02-01');
+
+CREATE TABLE IF NOT EXISTS api_audit_log_y2026m02
+  PARTITION OF api_audit_log
+  FOR VALUES FROM ('2026-02-01') TO ('2026-03-01');
+
+CREATE TABLE IF NOT EXISTS api_audit_log_y2026m03
+  PARTITION OF api_audit_log
+  FOR VALUES FROM ('2026-03-01') TO ('2026-04-01');
+
+CREATE TABLE IF NOT EXISTS api_audit_log_y2026m04
+  PARTITION OF api_audit_log
+  FOR VALUES FROM ('2026-04-01') TO ('2026-05-01');
+
+CREATE TABLE IF NOT EXISTS api_audit_log_y2026m05
+  PARTITION OF api_audit_log
+  FOR VALUES FROM ('2026-05-01') TO ('2026-06-01');
+
+CREATE TABLE IF NOT EXISTS api_audit_log_y2026m06
+  PARTITION OF api_audit_log
+  FOR VALUES FROM ('2026-06-01') TO ('2026-07-01');

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -9,18 +9,23 @@
   },
   "dependencies": {
     "@stellar/stellar-sdk": "12.3.0",
+    "bcryptjs": "^2.4.3",
     "cors": "^2.8.6",
     "dotenv": "16.4.5",
     "express": "^4.22.2",
     "express-rate-limit": "^8.5.2",
+    "graphql": "^16.8.2",
     "helmet": "^8.2.0",
+    "lru-cache": "^10.4.3",
+    "maxmind": "^4.3.22",
     "node-cron": "^3.0.3",
     "pg": "8.12.0",
     "redis": "^4.7.0",
     "swagger-ui-express": "^5.0.1",
     "ws": "^8.21.0",
     "yaml": "^2.9.0",
-    "prom-client": "15.1.3"
+    "prom-client": "15.1.3",
+    "stripe": "^14.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",

--- a/indexer/src/admin/adminAuth.js
+++ b/indexer/src/admin/adminAuth.js
@@ -1,0 +1,60 @@
+/**
+ * Admin Authentication Middleware
+ *
+ * Checks the `Authorization: Bearer <token>` header against `ADMIN_SECRET`.
+ * Uses crypto.timingSafeEqual to prevent timing-based secret enumeration.
+ *
+ * Returns 401 `{ error: "Unauthorized" }` if the header is missing, malformed,
+ * or the token does not match. Calls next() if the token is valid.
+ */
+
+import crypto from 'crypto';
+
+/**
+ * Express middleware that enforces admin authentication via a Bearer token.
+ *
+ * Reads `process.env.ADMIN_SECRET` at request time so that tests can set
+ * the variable after module load.
+ *
+ * @type {import('express').RequestHandler}
+ */
+function adminAuthMiddleware(req, res, next) {
+  const adminSecret = process.env.ADMIN_SECRET;
+
+  // If ADMIN_SECRET is not configured, block all admin access.
+  if (!adminSecret) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const authHeader = req.headers['authorization'];
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const token = authHeader.slice('Bearer '.length);
+
+  // Use timingSafeEqual to avoid timing attacks.
+  // Both buffers must be the same byte length for the comparison to work.
+  try {
+    const tokenBuf = Buffer.from(token);
+    const secretBuf = Buffer.from(adminSecret);
+
+    // If lengths differ the key is clearly wrong, but we still do the
+    // comparison on equal-length buffers to avoid early exit leaking info.
+    if (tokenBuf.length !== secretBuf.length) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    const match = crypto.timingSafeEqual(tokenBuf, secretBuf);
+    if (!match) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+  } catch {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  return next();
+}
+
+export { adminAuthMiddleware };

--- a/indexer/src/admin/keyManager.js
+++ b/indexer/src/admin/keyManager.js
@@ -1,0 +1,302 @@
+/**
+ * Key Manager — Admin Service Layer
+ *
+ * Business-logic functions for managing api_keys records.
+ * These are pure service functions (not Express route handlers).
+ *
+ * All functions throw on validation failure or unexpected DB errors.
+ * Callers (route handlers) are responsible for mapping errors to HTTP responses.
+ */
+
+import crypto from 'crypto';
+import bcrypt from 'bcryptjs';
+import { pool } from '../db.js';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const BCRYPT_COST = 12;
+const VALID_TIERS = ['unauthenticated', 'free', 'pro', 'enterprise'];
+const UPDATABLE_FIELDS = [
+  'name',
+  'tier',
+  'rate_limit',
+  'allowed_ips',
+  'allowed_endpoints',
+  'expires_at',
+  'revoked',
+];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Generate a cryptographically random API key as URL-safe base64.
+ * 32 bytes → 43 characters (no padding).
+ * @returns {string}
+ */
+function generateRawKey() {
+  return crypto
+    .randomBytes(32)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+}
+
+/**
+ * Strip `key_hash` from a database row before returning it to callers.
+ * @param {object} row
+ * @returns {object}
+ */
+function stripKeyHash(row) {
+  if (!row) return row;
+  const { key_hash, ...rest } = row; // eslint-disable-line no-unused-vars
+  return rest;
+}
+
+// ── listKeys ──────────────────────────────────────────────────────────────────
+
+/**
+ * Return a paginated list of API keys (excluding `key_hash`).
+ *
+ * @param {number} [page=1]
+ * @param {number} [limit=50]
+ * @returns {Promise<{ data: object[], total: number, page: number, limit: number }>}
+ */
+async function listKeys(page = 1, limit = 50) {
+  const safePage = Math.max(1, Number(page) || 1);
+  const safeLimit = Math.min(Math.max(1, Number(limit) || 50), 200);
+  const offset = (safePage - 1) * safeLimit;
+
+  const [{ rows }, { rows: countRows }] = await Promise.all([
+    pool.query(
+      `SELECT id, name, key_prefix, tier, rate_limit,
+              allowed_ips, allowed_endpoints, expires_at,
+              revoked, last_used_at, usage_count, created_at, updated_at
+       FROM api_keys
+       ORDER BY created_at DESC
+       LIMIT $1 OFFSET $2`,
+      [safeLimit, offset],
+    ),
+    pool.query('SELECT COUNT(*)::INT AS total FROM api_keys'),
+  ]);
+
+  return {
+    data: rows,
+    total: countRows[0].total,
+    page: safePage,
+    limit: safeLimit,
+  };
+}
+
+// ── createKey ─────────────────────────────────────────────────────────────────
+
+/**
+ * Create a new API key.
+ *
+ * @param {object} data
+ * @param {string} data.name            — required, non-empty
+ * @param {string} [data.tier='free']
+ * @param {number} [data.rate_limit]
+ * @param {string[]} [data.allowed_ips]
+ * @param {string[]} [data.allowed_endpoints]
+ * @param {string} [data.expires_at]   — ISO-8601 timestamp
+ * @returns {Promise<{ key: string, record: object }>}
+ */
+async function createKey(data) {
+  const { name, tier = 'free', rate_limit, allowed_ips, allowed_endpoints, expires_at } = data ?? {};
+
+  // Validate required fields.
+  if (!name || typeof name !== 'string' || name.trim() === '') {
+    throw new Error('name is required and must be a non-empty string');
+  }
+
+  if (!VALID_TIERS.includes(tier)) {
+    throw new Error(`tier must be one of: ${VALID_TIERS.join(', ')}`);
+  }
+
+  if (rate_limit !== undefined && rate_limit !== null) {
+    const rateNum = Number(rate_limit);
+    if (!Number.isInteger(rateNum) || rateNum <= 0) {
+      throw new Error('rate_limit must be a positive integer');
+    }
+  }
+
+  // Generate key material.
+  const rawKey = generateRawKey();
+  const keyPrefix = rawKey.slice(0, 8);
+  const keyHash = await bcrypt.hash(rawKey, BCRYPT_COST);
+
+  const { rows } = await pool.query(
+    `INSERT INTO api_keys
+       (name, key_hash, key_prefix, tier, rate_limit, allowed_ips, allowed_endpoints, expires_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     RETURNING id, name, key_prefix, tier, rate_limit,
+               allowed_ips, allowed_endpoints, expires_at,
+               revoked, last_used_at, usage_count, created_at, updated_at`,
+    [
+      name.trim(),
+      keyHash,
+      keyPrefix,
+      tier,
+      rate_limit ?? null,
+      allowed_ips ? JSON.stringify(allowed_ips) : null,
+      allowed_endpoints ? JSON.stringify(allowed_endpoints) : null,
+      expires_at ?? null,
+    ],
+  );
+
+  return { key: rawKey, record: rows[0] };
+}
+
+// ── updateKey ─────────────────────────────────────────────────────────────────
+
+/**
+ * Update allowed metadata fields on an existing key.
+ *
+ * @param {string} id   — UUID
+ * @param {object} updates — subset of updatable fields
+ * @returns {Promise<object>} updated record (without key_hash)
+ */
+async function updateKey(id, updates) {
+  if (!id) throw new Error('id is required');
+  if (!updates || typeof updates !== 'object' || Array.isArray(updates)) {
+    throw new Error('updates must be a non-null object');
+  }
+
+  // Filter to only allowed fields to prevent injection.
+  const filtered = {};
+  for (const field of UPDATABLE_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(updates, field)) {
+      filtered[field] = updates[field];
+    }
+  }
+
+  if (Object.keys(filtered).length === 0) {
+    throw new Error(`No updatable fields provided. Allowed fields: ${UPDATABLE_FIELDS.join(', ')}`);
+  }
+
+  // Validate tier if provided.
+  if (filtered.tier !== undefined && !VALID_TIERS.includes(filtered.tier)) {
+    throw new Error(`tier must be one of: ${VALID_TIERS.join(', ')}`);
+  }
+
+  // Build SET clause dynamically.
+  const setClauses = [];
+  const params = [];
+
+  for (const [field, value] of Object.entries(filtered)) {
+    params.push(value);
+    setClauses.push(`${field} = $${params.length}`);
+  }
+
+  // Always bump updated_at.
+  setClauses.push(`updated_at = NOW()`);
+
+  params.push(id);
+  const idParam = params.length;
+
+  const { rows } = await pool.query(
+    `UPDATE api_keys
+     SET ${setClauses.join(', ')}
+     WHERE id = $${idParam}
+     RETURNING id, name, key_prefix, tier, rate_limit,
+               allowed_ips, allowed_endpoints, expires_at,
+               revoked, last_used_at, usage_count, created_at, updated_at`,
+    params,
+  );
+
+  if (rows.length === 0) {
+    throw new Error(`API key not found: ${id}`);
+  }
+
+  return stripKeyHash(rows[0]);
+}
+
+// ── deleteKey ─────────────────────────────────────────────────────────────────
+
+/**
+ * Soft-delete a key by setting revoked = true.
+ *
+ * @param {string} id — UUID
+ * @returns {Promise<object>} updated record (without key_hash)
+ */
+async function deleteKey(id) {
+  if (!id) throw new Error('id is required');
+
+  const { rows } = await pool.query(
+    `UPDATE api_keys
+     SET revoked = TRUE, updated_at = NOW()
+     WHERE id = $1
+     RETURNING id, name, key_prefix, tier, rate_limit,
+               allowed_ips, allowed_endpoints, expires_at,
+               revoked, last_used_at, usage_count, created_at, updated_at`,
+    [id],
+  );
+
+  if (rows.length === 0) {
+    throw new Error(`API key not found: ${id}`);
+  }
+
+  return stripKeyHash(rows[0]);
+}
+
+// ── rotateKey ─────────────────────────────────────────────────────────────────
+
+/**
+ * Generate a new raw key for an existing record, replacing key_hash and key_prefix.
+ *
+ * @param {string} id — UUID
+ * @returns {Promise<{ key: string, record: object }>}
+ */
+async function rotateKey(id) {
+  if (!id) throw new Error('id is required');
+
+  const rawKey = generateRawKey();
+  const keyPrefix = rawKey.slice(0, 8);
+  const keyHash = await bcrypt.hash(rawKey, BCRYPT_COST);
+
+  const { rows } = await pool.query(
+    `UPDATE api_keys
+     SET key_hash = $1, key_prefix = $2, updated_at = NOW()
+     WHERE id = $3
+     RETURNING id, name, key_prefix, tier, rate_limit,
+               allowed_ips, allowed_endpoints, expires_at,
+               revoked, last_used_at, usage_count, created_at, updated_at`,
+    [keyHash, keyPrefix, id],
+  );
+
+  if (rows.length === 0) {
+    throw new Error(`API key not found: ${id}`);
+  }
+
+  return { key: rawKey, record: stripKeyHash(rows[0]) };
+}
+
+// ── getKeyUsage ───────────────────────────────────────────────────────────────
+
+/**
+ * Return daily usage history for a key.
+ *
+ * @param {string} id  — UUID
+ * @param {number} [days=30]
+ * @returns {Promise<object[]>}
+ */
+async function getKeyUsage(id, days = 30) {
+  if (!id) throw new Error('id is required');
+
+  const safeDays = Math.min(Math.max(1, Number(days) || 30), 365);
+
+  const { rows } = await pool.query(
+    `SELECT date, total_requests, endpoint_distribution,
+            data_transfer_mb, rate_limit_hits, peak_concurrent
+     FROM api_key_usage_daily
+     WHERE api_key_id = $1
+     ORDER BY date DESC
+     LIMIT $2`,
+    [id, safeDays],
+  );
+
+  return rows;
+}
+
+export { listKeys, createKey, updateKey, deleteKey, rotateKey, getKeyUsage };

--- a/indexer/src/api.js
+++ b/indexer/src/api.js
@@ -14,6 +14,17 @@ import { attachWebSocketServer, publishTransactionStatus, getTransactionStatus, 
 import { verifyAbi } from "./verify_abi.js";
 import { getMetrics } from "./rpcMetrics.js";
 import { getRpcNodeStatus } from "./rpcMultiNode.js";
+// ── Auth & Rate Limiting ──────────────────────────────────────────────────────
+import { apiKeyAuthenticator } from "./auth/apiKeyAuth.js";
+import { geoIpRateLimiter } from "./rateLimit/geoIpLimiter.js";
+import { concurrentRequestLimiter } from "./rateLimit/concurrentLimiter.js";
+import { tokenBucketMiddleware } from "./rateLimit/tokenBucket.js";
+import { graphqlComplexityLimiter } from "./rateLimit/graphqlComplexity.js";
+import { abuseDetector } from "./rateLimit/abuseDetector.js";
+import { rateLimitHeaderWriter } from "./rateLimit/headers.js";
+import { auditLoggerMiddleware } from "./audit/auditLogger.js";
+import registerAdminRoutes from "./routes/admin.js";
+import { stripeWebhookRouter } from "./billing/stripeWebhook.js";
 import {
   cacheInvalidate,
   cacheGet,
@@ -31,6 +42,16 @@ import { registry } from "./metrics.js";
 import pg from "pg";
 import { getBurnAlerts } from "./burnDetector.js";
 import { formatAmount } from "./formatAmount.js";
+import { auditLoggerMiddleware } from "./audit/auditLogger.js";
+import { apiKeyAuthenticator } from "./auth/apiKeyAuth.js";
+import { geoIpRateLimiter } from "./rateLimit/geoIpLimiter.js";
+import { concurrentRequestLimiter } from "./rateLimit/concurrentLimiter.js";
+import { tokenBucketMiddleware } from "./rateLimit/tokenBucket.js";
+import { graphqlComplexityLimiter } from "./rateLimit/graphqlComplexity.js";
+import { abuseDetector } from "./rateLimit/abuseDetector.js";
+import { rateLimitHeaderWriter } from "./rateLimit/headers.js";
+import registerAdminRoutes from "./routes/admin.js";
+import { stripeWebhookRouter } from "./billing/stripeWebhook.js";
 
 const PORT = process.env.PORT || 3001;
 const VERIFY_ON_UPLOAD = process.env.VERIFY_ABI !== "false";
@@ -126,8 +147,30 @@ export function startApi() {
   const app = express();
   app.use(helmet());
   app.use(cors({ origin: process.env.CORS_ORIGIN || "*" }));
+
+  // Stripe webhook requires raw body — mount BEFORE express.json()
+  app.use("/api/billing", stripeWebhookRouter);
+
   app.use(express.json());
-  app.use(generalLimiter);
+
+  // ── Auth & Rate Limiting Middleware Stack ─────────────────────────────────
+  // Order matters: audit logger sets _startTime first, then auth resolves tier,
+  // then geo/concurrent/bucket limiters enforce quotas, then headers are set.
+  app.use(auditLoggerMiddleware);
+  app.use(apiKeyAuthenticator);
+  app.use(geoIpRateLimiter);
+  app.use(concurrentRequestLimiter);
+  app.use(tokenBucketMiddleware);
+  app.use(graphqlComplexityLimiter);
+  app.use(abuseDetector);
+  app.use(rateLimitHeaderWriter);
+
+  // NOTE: generalLimiter superseded by tokenBucketMiddleware above.
+  // Kept as fallback only if Redis is unavailable (tokenBucket fails open).
+  // app.use(generalLimiter);
+
+  // ── Admin routes (auth-gated) ─────────────────────────────────────────────
+  registerAdminRoutes(app);
 
   // ── API Documentation ────────────────────────────────────────────────────────
   const openApiPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../openapi.yaml");

--- a/indexer/src/audit/auditLogger.js
+++ b/indexer/src/audit/auditLogger.js
@@ -1,0 +1,226 @@
+/**
+ * Audit Logger
+ *
+ * Provides non-blocking, batched audit logging to the `api_audit_log` table.
+ *
+ * Architecture:
+ *   - auditLoggerMiddleware: Express middleware that records req/res metadata
+ *     into an in-process queue on `res.on('finish')`. The HTTP response is
+ *     sent before any DB write occurs.
+ *   - createAuditLogEntry: Enqueues a single entry into the async queue.
+ *   - A setInterval flush loop drains the queue every 500 ms, batching up to
+ *     MAX_BATCH_SIZE rows per INSERT for efficiency.
+ *   - startAuditPartitionCron: Monthly cron job that pre-creates the next
+ *     month's partition and drops partitions older than 90 days.
+ */
+
+import cron from 'node-cron';
+import { pool } from '../db.js';
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+const FLUSH_INTERVAL_MS = 500;
+const MAX_BATCH_SIZE = 100;
+
+// ── In-process queue ──────────────────────────────────────────────────────────
+/** @type {object[]} */
+const _queue = [];
+
+// ── createAuditLogEntry ───────────────────────────────────────────────────────
+
+/**
+ * Add one audit log entry to the in-process async queue.
+ * Returns immediately — does not await any DB write.
+ *
+ * @param {object} entry
+ */
+function createAuditLogEntry(entry) {
+  _queue.push(entry);
+}
+
+// ── Flush loop ────────────────────────────────────────────────────────────────
+
+/**
+ * Drain up to MAX_BATCH_SIZE entries from the queue and INSERT them into
+ * api_audit_log. Called by setInterval every FLUSH_INTERVAL_MS ms.
+ */
+async function _flushQueue() {
+  if (_queue.length === 0) return;
+
+  const batch = _queue.splice(0, MAX_BATCH_SIZE);
+  if (batch.length === 0) return;
+
+  try {
+    // Build a multi-row VALUES clause.
+    const valuePlaceholders = batch.map((_, i) => {
+      const base = i * 11;
+      return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}::INET, $${base + 6}, $${base + 7}, $${base + 8}, $${base + 9}, $${base + 10}, $${base + 11})`;
+    });
+
+    const params = batch.flatMap((e) => [
+      e.timestamp ?? new Date(),
+      e.api_key_id ?? null,
+      e.key_name ?? null,
+      e.tier ?? 'unauthenticated',
+      e.ip ?? '0.0.0.0',
+      e.method ?? 'GET',
+      e.endpoint ?? '/',
+      e.status_code ?? 200,
+      e.response_time_ms ?? 0,
+      e.rate_limit_remaining ?? null,
+      e.user_agent ?? null,
+    ]);
+
+    await pool.query(
+      `INSERT INTO api_audit_log
+         (timestamp, api_key_id, key_name, tier, ip, method, endpoint,
+          status_code, response_time_ms, rate_limit_remaining, user_agent)
+       VALUES ${valuePlaceholders.join(', ')}`,
+      params,
+    );
+  } catch (err) {
+    console.error('[auditLogger] Batch INSERT failed:', err.message);
+    // Re-queue the batch so it is retried on the next flush cycle.
+    // Prepend so ordering is roughly preserved.
+    _queue.unshift(...batch);
+  }
+}
+
+// Start the flush loop immediately on module load.
+setInterval(() => {
+  _flushQueue().catch((err) => {
+    console.error('[auditLogger] Flush interval error:', err.message);
+  });
+}, FLUSH_INTERVAL_MS);
+
+// ── auditLoggerMiddleware ─────────────────────────────────────────────────────
+
+/**
+ * Express middleware that queues an audit log entry when the response finishes.
+ *
+ * Reads:
+ *   - req.rateContext   — { keyId, keyName, tier }  (set by apiKeyAuthenticator)
+ *   - req.rateLimitState — { remaining }             (set by tokenBucketMiddleware)
+ *   - req._startTime    — set by this middleware at request start
+ *
+ * @type {import('express').RequestHandler}
+ */
+function auditLoggerMiddleware(req, res, next) {
+  req._startTime = Date.now();
+
+  res.on('finish', () => {
+    try {
+      const forwarded = req.headers['x-forwarded-for'];
+      const ip = forwarded
+        ? String(forwarded).split(',')[0].trim()
+        : req.socket?.remoteAddress ?? '0.0.0.0';
+
+      createAuditLogEntry({
+        timestamp: new Date(),
+        api_key_id: req.rateContext?.keyId ?? null,
+        key_name: req.rateContext?.keyName ?? null,
+        tier: req.rateContext?.tier ?? 'unauthenticated',
+        ip,
+        method: req.method,
+        endpoint: req.path,
+        status_code: res.statusCode,
+        response_time_ms: Date.now() - req._startTime,
+        rate_limit_remaining: req.rateLimitState?.remaining ?? null,
+        user_agent: req.headers['user-agent'] ?? null,
+      });
+    } catch (err) {
+      // Never let audit logging affect the request lifecycle.
+      console.error('[auditLogger] Failed to enqueue entry:', err.message);
+    }
+  });
+
+  return next();
+}
+
+// ── startAuditPartitionCron ───────────────────────────────────────────────────
+
+/**
+ * Start a monthly cron job (runs on the 1st of each month at 01:00 UTC) that:
+ *   1. Creates the next month's partition if it does not already exist.
+ *   2. Drops partitions older than 90 days (free tier retention window).
+ *
+ * @returns {cron.ScheduledTask}
+ */
+function startAuditPartitionCron() {
+  return cron.schedule('0 1 1 * *', async () => {
+    try {
+      const now = new Date();
+
+      // Create partition for next month.
+      const nextMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
+      const afterNextMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 2, 1));
+
+      const partitionName = _partitionName(nextMonth);
+      const fromStr = nextMonth.toISOString().slice(0, 10);
+      const toStr = afterNextMonth.toISOString().slice(0, 10);
+
+      try {
+        await pool.query(
+          `CREATE TABLE IF NOT EXISTS ${partitionName}
+           PARTITION OF api_audit_log
+           FOR VALUES FROM ('${fromStr}') TO ('${toStr}')`,
+        );
+        console.log(`[auditLogger] Created partition ${partitionName} (${fromStr} – ${toStr})`);
+      } catch (createErr) {
+        console.error(`[auditLogger] Failed to create partition ${partitionName}:`, createErr.message);
+      }
+
+      // Drop partitions older than 90 days.
+      const cutoff = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 90));
+
+      // List existing partitions by querying pg_inherits.
+      const { rows } = await pool.query(
+        `SELECT c.relname AS partition_name
+         FROM pg_inherits i
+         JOIN pg_class p ON p.oid = i.inhparent
+         JOIN pg_class c ON c.oid = i.inhrelid
+         WHERE p.relname = 'api_audit_log'`,
+      );
+
+      for (const { partition_name } of rows) {
+        const partDate = _parsePartitionDate(partition_name);
+        if (partDate && partDate < cutoff) {
+          try {
+            await pool.query(`DROP TABLE IF EXISTS ${partition_name}`);
+            console.log(`[auditLogger] Dropped old partition ${partition_name}`);
+          } catch (dropErr) {
+            console.error(`[auditLogger] Failed to drop partition ${partition_name}:`, dropErr.message);
+          }
+        }
+      }
+    } catch (err) {
+      console.error('[auditLogger] Partition cron error:', err.message);
+    }
+  });
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Build a partition table name like `api_audit_log_y2025m06` from a Date.
+ * @param {Date} date
+ * @returns {string}
+ */
+function _partitionName(date) {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  return `api_audit_log_y${year}m${month}`;
+}
+
+/**
+ * Parse the year+month from a partition name like `api_audit_log_y2025m06`.
+ * Returns the first day of that month as a Date, or null if unparseable.
+ * @param {string} name
+ * @returns {Date|null}
+ */
+function _parsePartitionDate(name) {
+  const match = name.match(/y(\d{4})m(\d{2})$/);
+  if (!match) return null;
+  return new Date(Date.UTC(Number(match[1]), Number(match[2]) - 1, 1));
+}
+
+export { createAuditLogEntry, auditLoggerMiddleware, startAuditPartitionCron };

--- a/indexer/src/auth/apiKeyAuth.js
+++ b/indexer/src/auth/apiKeyAuth.js
@@ -1,0 +1,287 @@
+/**
+ * API Key Authenticator Middleware
+ *
+ * Responsibilities:
+ * - Extract the `x-api-key` header; fall back to a hashed client IP for
+ *   unauthenticated identity.
+ * - Look up the key record in PostgreSQL by `key_prefix` (first 8 chars),
+ *   then verify the full key against the stored bcrypt hash.
+ * - Maintain an in-memory LRU cache (TTL 30 s, max 1 000 entries) to avoid
+ *   per-request DB hits.
+ * - Validate: not revoked, not expired, IP CIDR whitelist, endpoint whitelist.
+ * - Attach `req.rateContext` consumed by downstream middleware.
+ * - Return 401/403 error responses as specified in the design.
+ * - Asynchronously update `last_used_at` and `usage_count` on every
+ *   authenticated request.
+ */
+
+import crypto from 'crypto';
+import bcrypt from 'bcryptjs';
+import { LRUCache } from 'lru-cache';
+import { pool } from '../db.js';
+
+// ── In-memory LRU cache ───────────────────────────────────────────────────────
+// Caches resolved key records keyed by the raw API key string.
+// TTL: 30 seconds, max: 1 000 entries.
+const KEY_CACHE_TTL_MS = 30_000;
+const KEY_CACHE_MAX = 1_000;
+
+const keyCache = new LRUCache({
+  max: KEY_CACHE_MAX,
+  ttl: KEY_CACHE_TTL_MS,
+});
+
+// ── CIDR helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Convert an IPv4 address string to a 32-bit integer.
+ * @param {string} ip
+ * @returns {number}
+ */
+function ipv4ToInt(ip) {
+  return ip
+    .split('.')
+    .reduce((acc, octet) => (acc << 8) | parseInt(octet, 10), 0) >>> 0;
+}
+
+/**
+ * Check whether an IPv4 address matches a CIDR block.
+ * @param {string} ip     e.g. "192.168.1.5"
+ * @param {string} cidr   e.g. "192.168.1.0/24"
+ * @returns {boolean}
+ */
+function ipMatchesCidr(ip, cidr) {
+  // Handle plain IP (no prefix length) as /32.
+  const [range, prefixStr] = cidr.includes('/') ? cidr.split('/') : [cidr, '32'];
+  const prefix = parseInt(prefixStr, 10);
+  const mask = prefix === 0 ? 0 : ~((1 << (32 - prefix)) - 1) >>> 0;
+  try {
+    return (ipv4ToInt(ip) & mask) === (ipv4ToInt(range) & mask);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Return true if `ip` matches any entry in the CIDR list.
+ * @param {string}   ip
+ * @param {string[]} cidrList
+ * @returns {boolean}
+ */
+function ipInCidrList(ip, cidrList) {
+  if (!Array.isArray(cidrList) || cidrList.length === 0) return true;
+  return cidrList.some((cidr) => ipMatchesCidr(ip, cidr));
+}
+
+// ── Endpoint whitelist helper ─────────────────────────────────────────────────
+
+/**
+ * Return true if `endpoint` matches any pattern in the whitelist.
+ * Patterns support a trailing `*` wildcard.
+ * @param {string}   endpoint  e.g. "/api/events"
+ * @param {string[]} patterns  e.g. ["/api/events*", "/api/contracts"]
+ * @returns {boolean}
+ */
+function endpointAllowed(endpoint, patterns) {
+  if (!Array.isArray(patterns) || patterns.length === 0) return true;
+  return patterns.some((pattern) => {
+    if (pattern.endsWith('*')) {
+      return endpoint.startsWith(pattern.slice(0, -1));
+    }
+    return endpoint === pattern;
+  });
+}
+
+// ── Client IP extraction ──────────────────────────────────────────────────────
+
+/**
+ * Extract the real client IP from the request, respecting common proxy headers.
+ * @param {import('express').Request} req
+ * @returns {string}
+ */
+function getClientIp(req) {
+  const forwarded = req.headers['x-forwarded-for'];
+  if (forwarded) {
+    // x-forwarded-for can be a comma-separated list; take the first (client) IP.
+    return String(forwarded).split(',')[0].trim();
+  }
+  return req.socket?.remoteAddress ?? '0.0.0.0';
+}
+
+/**
+ * Produce a stable, opaque clientId from an IP address by SHA-256 hashing.
+ * This avoids storing raw IPs in rateContext for unauthenticated clients.
+ * @param {string} ip
+ * @returns {string}  hex string prefixed with "ip:"
+ */
+function hashIp(ip) {
+  return 'ip:' + crypto.createHash('sha256').update(ip).digest('hex').slice(0, 16);
+}
+
+// ── Database lookup ───────────────────────────────────────────────────────────
+
+/**
+ * Fetch the api_keys row whose key_prefix matches the first 8 characters of
+ * the raw key, then verify the full key against the stored bcrypt hash.
+ *
+ * Returns the row on success, `null` if no row found or the hash does not
+ * match.
+ *
+ * @param {string} rawKey
+ * @returns {Promise<object|null>}
+ */
+async function lookupKeyInDb(rawKey) {
+  const prefix = rawKey.slice(0, 8);
+
+  const { rows } = await pool.query(
+    `SELECT id, name, key_hash, tier, rate_limit,
+            allowed_ips, allowed_endpoints, expires_at,
+            revoked, last_used_at, usage_count
+     FROM   api_keys
+     WHERE  key_prefix = $1`,
+    [prefix],
+  );
+
+  if (rows.length === 0) return null;
+
+  // There may be multiple rows for the same prefix (extremely unlikely but
+  // possible). Test each until one matches.
+  for (const row of rows) {
+    const match = await bcrypt.compare(rawKey, row.key_hash);
+    if (match) return row;
+  }
+
+  return null;
+}
+
+/**
+ * Asynchronously update `last_used_at` and increment `usage_count` for the
+ * given key id. Fire-and-forget — errors are swallowed to avoid affecting the
+ * request lifecycle.
+ *
+ * @param {string} keyId  UUID
+ */
+function updateUsageAsync(keyId) {
+  pool
+    .query(
+      `UPDATE api_keys
+       SET    last_used_at = NOW(),
+              usage_count  = usage_count + 1
+       WHERE  id = $1`,
+      [keyId],
+    )
+    .catch((err) => {
+      console.error('[apiKeyAuth] Failed to update usage stats for key', keyId, err.message);
+    });
+}
+
+// ── Middleware factory ────────────────────────────────────────────────────────
+
+/**
+ * Express middleware that authenticates the incoming request via the
+ * `x-api-key` header and attaches `req.rateContext`.
+ *
+ * For unauthenticated requests (no header), the client is assigned the
+ * `unauthenticated` tier using a hashed IP as the clientId.
+ *
+ * Error responses (per design):
+ *   401 { "error": "Invalid API key" }    — unrecognised key
+ *   401 { "error": "API key expired" }    — past `expires_at`
+ *   401 { "error": "API key revoked" }    — `revoked = true`
+ *   403 { "error": "IP not permitted" }   — CIDR mismatch
+ *   403 { "error": "Endpoint not permitted" } — endpoint mismatch
+ *
+ * @type {import('express').RequestHandler}
+ */
+async function apiKeyAuthenticator(req, res, next) {
+  try {
+    const rawKey = req.headers['x-api-key'];
+
+    // ── Unauthenticated path ────────────────────────────────────────────────
+    if (!rawKey) {
+      req.rateContext = {
+        clientId: hashIp(getClientIp(req)),
+        tier: 'unauthenticated',
+        rateLimit: null,
+        keyId: null,
+        keyName: null,
+      };
+      return next();
+    }
+
+    // ── Authenticated path ──────────────────────────────────────────────────
+
+    // 1. Try LRU cache first.
+    let keyRecord = keyCache.get(rawKey);
+
+    if (keyRecord === undefined) {
+      // 2. Cache miss → query the database.
+      const dbRecord = await lookupKeyInDb(rawKey);
+
+      if (!dbRecord) {
+        return res.status(401).json({ error: 'Invalid API key' });
+      }
+
+      keyRecord = dbRecord;
+
+      // Normalise JSONB fields that may come back as strings in some drivers.
+      keyRecord.allowed_ips =
+        typeof keyRecord.allowed_ips === 'string'
+          ? JSON.parse(keyRecord.allowed_ips)
+          : keyRecord.allowed_ips;
+      keyRecord.allowed_endpoints =
+        typeof keyRecord.allowed_endpoints === 'string'
+          ? JSON.parse(keyRecord.allowed_endpoints)
+          : keyRecord.allowed_endpoints;
+
+      keyCache.set(rawKey, keyRecord);
+    }
+
+    // 3. Validate the cached record.
+
+    // Revoked check.
+    if (keyRecord.revoked) {
+      return res.status(401).json({ error: 'API key revoked' });
+    }
+
+    // Expiry check.
+    if (keyRecord.expires_at && new Date(keyRecord.expires_at) < new Date()) {
+      return res.status(401).json({ error: 'API key expired' });
+    }
+
+    // IP CIDR whitelist check.
+    if (keyRecord.allowed_ips && keyRecord.allowed_ips.length > 0) {
+      const clientIp = getClientIp(req);
+      if (!ipInCidrList(clientIp, keyRecord.allowed_ips)) {
+        return res.status(403).json({ error: 'IP not permitted' });
+      }
+    }
+
+    // Endpoint whitelist check.
+    if (keyRecord.allowed_endpoints && keyRecord.allowed_endpoints.length > 0) {
+      const endpoint = req.path;
+      if (!endpointAllowed(endpoint, keyRecord.allowed_endpoints)) {
+        return res.status(403).json({ error: 'Endpoint not permitted' });
+      }
+    }
+
+    // 4. Attach rateContext.
+    req.rateContext = {
+      clientId: keyRecord.id,
+      tier: keyRecord.tier,
+      rateLimit: keyRecord.rate_limit ?? null,
+      keyId: keyRecord.id,
+      keyName: keyRecord.name,
+    };
+
+    // 5. Update usage stats asynchronously (fire-and-forget).
+    updateUsageAsync(keyRecord.id);
+
+    return next();
+  } catch (err) {
+    console.error('[apiKeyAuth] Unexpected error:', err);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+}
+
+export { apiKeyAuthenticator, keyCache, ipMatchesCidr, ipInCidrList, endpointAllowed, hashIp };

--- a/indexer/src/billing/stripeWebhook.js
+++ b/indexer/src/billing/stripeWebhook.js
@@ -1,0 +1,185 @@
+/**
+ * Stripe Webhook Handler
+ *
+ * Verifies incoming Stripe webhook signatures and handles subscription lifecycle
+ * events to update api_keys.tier accordingly.
+ *
+ * Handled events:
+ *   customer.subscription.updated  → update tier from product metadata
+ *   customer.subscription.deleted  → downgrade tier to 'free'
+ *
+ * Security:
+ *   - express.raw() is applied on this route so Stripe signature verification
+ *     can operate on the raw request body (JSON parsing would invalidate the sig).
+ *   - Returns 400 { error: "Invalid signature" } if verification fails.
+ *   - Returns 200 { received: true } on success.
+ *
+ * Environment variables:
+ *   STRIPE_WEBHOOK_SECRET  — Stripe webhook signing secret (whsec_...)
+ *   STRIPE_SECRET_KEY      — Stripe API key (sk_...)
+ */
+
+import express from 'express';
+import Stripe from 'stripe';
+import { pool } from '../db.js';
+
+const stripeWebhookRouter = express.Router();
+
+// ── Route ─────────────────────────────────────────────────────────────────────
+
+/**
+ * POST /stripe-webhook
+ *
+ * express.raw() is applied inline so only this route receives an unparsed body.
+ * The parent app must NOT apply express.json() before this route for the path
+ * /api/billing/stripe-webhook, or the raw body will be consumed.
+ */
+stripeWebhookRouter.post(
+  '/stripe-webhook',
+  express.raw({ type: 'application/json' }),
+  async (req, res) => {
+    const sig = req.headers['stripe-signature'];
+    const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+
+    if (!webhookSecret) {
+      console.error('[stripeWebhook] STRIPE_WEBHOOK_SECRET is not set');
+      return res.status(500).json({ error: 'Webhook secret not configured' });
+    }
+
+    // Lazily instantiate Stripe client so the module can be imported without
+    // STRIPE_SECRET_KEY being set (e.g. in tests that mock the client).
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY ?? '', {
+      apiVersion: '2023-10-16',
+    });
+
+    let event;
+    try {
+      event = stripe.webhooks.constructEvent(req.body, sig, webhookSecret);
+    } catch (err) {
+      console.warn('[stripeWebhook] Signature verification failed:', err.message);
+      return res.status(400).json({ error: 'Invalid signature' });
+    }
+
+    try {
+      await _handleEvent(event);
+      return res.status(200).json({ received: true });
+    } catch (err) {
+      console.error('[stripeWebhook] Event handling error:', err.message);
+      // Return 200 to prevent Stripe retrying an event we cannot process.
+      // The error is logged for investigation.
+      return res.status(200).json({ received: true, warning: err.message });
+    }
+  },
+);
+
+// ── Event handler ─────────────────────────────────────────────────────────────
+
+/**
+ * Dispatch a verified Stripe event to the appropriate handler.
+ *
+ * @param {import('stripe').Stripe.Event} event
+ */
+async function _handleEvent(event) {
+  switch (event.type) {
+    case 'customer.subscription.updated':
+      await _handleSubscriptionUpdated(event.data.object);
+      break;
+
+    case 'customer.subscription.deleted':
+      await _handleSubscriptionDeleted(event.data.object);
+      break;
+
+    default:
+      // Silently ignore unhandled event types.
+      console.log(`[stripeWebhook] Unhandled event type: ${event.type}`);
+  }
+}
+
+// ── customer.subscription.updated ─────────────────────────────────────────────
+
+/**
+ * Update the API key's tier to match the subscription's product metadata.
+ *
+ * The Stripe product should have metadata:
+ *   tier: 'free' | 'pro' | 'enterprise'
+ *
+ * The subscription (or its metadata) should identify the API key via:
+ *   api_key_id: '<uuid>'
+ *
+ * @param {import('stripe').Stripe.Subscription} subscription
+ */
+async function _handleSubscriptionUpdated(subscription) {
+  const apiKeyId = subscription.metadata?.api_key_id;
+
+  if (!apiKeyId) {
+    console.warn('[stripeWebhook] subscription.updated: no api_key_id in metadata, skipping');
+    return;
+  }
+
+  // Derive tier from the first subscription item's product metadata.
+  const tier = _extractTierFromSubscription(subscription);
+
+  if (!tier) {
+    console.warn('[stripeWebhook] subscription.updated: could not determine tier from product metadata');
+    return;
+  }
+
+  await pool.query(
+    `UPDATE api_keys SET tier = $1, updated_at = NOW() WHERE id = $2`,
+    [tier, apiKeyId],
+  );
+
+  console.log(`[stripeWebhook] Updated api_keys.tier → ${tier} for key ${apiKeyId}`);
+}
+
+// ── customer.subscription.deleted ─────────────────────────────────────────────
+
+/**
+ * Downgrade the API key tier to 'free' when a subscription is cancelled.
+ *
+ * @param {import('stripe').Stripe.Subscription} subscription
+ */
+async function _handleSubscriptionDeleted(subscription) {
+  const apiKeyId = subscription.metadata?.api_key_id;
+
+  if (!apiKeyId) {
+    console.warn('[stripeWebhook] subscription.deleted: no api_key_id in metadata, skipping');
+    return;
+  }
+
+  await pool.query(
+    `UPDATE api_keys SET tier = 'free', updated_at = NOW() WHERE id = $1`,
+    [apiKeyId],
+  );
+
+  console.log(`[stripeWebhook] Downgraded api_keys.tier → free for key ${apiKeyId}`);
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Extract a tier string from the subscription's product metadata.
+ * Returns null if the tier cannot be determined or is not a known value.
+ *
+ * @param {import('stripe').Stripe.Subscription} subscription
+ * @returns {string|null}
+ */
+function _extractTierFromSubscription(subscription) {
+  const VALID_TIERS = ['free', 'pro', 'enterprise'];
+
+  // Try subscription-level metadata first.
+  const subTier = subscription.metadata?.tier;
+  if (subTier && VALID_TIERS.includes(subTier)) return subTier;
+
+  // Fall back to first subscription item's price/product metadata.
+  const items = subscription.items?.data ?? [];
+  for (const item of items) {
+    const productMeta = item.price?.product?.metadata ?? item.plan?.metadata ?? {};
+    const productTier = productMeta.tier;
+    if (productTier && VALID_TIERS.includes(productTier)) return productTier;
+  }
+
+  return null;
+}
+
+export { stripeWebhookRouter };

--- a/indexer/src/index.js
+++ b/indexer/src/index.js
@@ -25,6 +25,8 @@ import { recordLedgerHash } from "./reorgWorker.js";
 import { warmCache } from "./cacheWarming.js";
 import { cacheInvalidate } from "./cacheLayer.js";
 import { eventsIngested, decodeLatency, rpcErrors, updateDbPoolMetrics } from "./metrics.js";
+import { startUsageFlushCron, startRetentionCleanupCron } from "./usage/usageTracker.js";
+import { startAuditPartitionCron } from "./audit/auditLogger.js";
 
 const RPC_URL = process.env.SOROBAN_RPC_URL || "https://soroban-testnet.stellar.org";
 const START_LEDGER = Number(process.env.START_LEDGER || 0);
@@ -213,9 +215,14 @@ async function run() {
   warmCache().catch((e) => console.warn("[daemon] cache warm failed:", e.message));
   startAbiSync();
   startBurnDetector();
-  startMetricsCollector(); RPC latency probes
-  startPruner(); daily temporary-storage cleanup
-  startGasGuzzlersWorker(); daily gas consumption leaderboard
+  startMetricsCollector(); // RPC latency probes
+  startPruner(); // daily temporary-storage cleanup
+  startGasGuzzlersWorker(); // daily gas consumption leaderboard
+
+  // ── Auth & Rate Limiting cron jobs ─────────────────────────────────────────
+  startUsageFlushCron();       // flush Redis usage counters → DB every minute
+  startRetentionCleanupCron(); // nightly usage data retention cleanup
+  startAuditPartitionCron();   // monthly audit log partition management
 
   // Bootstrap vault indexer: initial ratio snapshot for all registered vaults
   refreshAllVaults().catch(() => {});

--- a/indexer/src/rateLimit/abuseDetector.js
+++ b/indexer/src/rateLimit/abuseDetector.js
@@ -1,0 +1,511 @@
+/**
+ * Abuse Detector Middleware
+ *
+ * Implements five detection patterns using Redis for cross-instance consistency:
+ *
+ *   1. Auth brute-force  – checks abuse:block:{ip} key on every request
+ *   2. Scraping          – URL similarity (Jaccard) > 0.9 over recent requests
+ *   3. DDoS              – HyperLogLog PFCOUNT > 50 distinct IPs per endpoint in 10 s
+ *   4. Aggressive pagination – > 20 consecutive page params in 60 s
+ *   5. Repeat offender   – > 5 rate-limit breaches in 10 min
+ *
+ * Also exports:
+ *   recordAuthFailure(ip, redis)         – INCR authfail counter; block IP at > 10
+ *   recordRateLimitBreach(clientId, redis) – INCR breach counter; warn at > 5
+ *
+ * All Redis operations are wrapped in try/catch — the request is passed through
+ * on any Redis failure.
+ */
+
+import {
+  ABUSE_AUTHFAIL_PREFIX,
+  ABUSE_BLOCK_PREFIX,
+  ABUSE_SCRAPE_PREFIX,
+  ABUSE_DDOS_PREFIX,
+  ABUSE_PAGINATE_PREFIX,
+  ABUSE_RATELIMITCOUNT_PREFIX,
+  ABUSE_PENALTY_PREFIX,
+} from './constants.js';
+import { getRedisClient } from './tokenBucket.js';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/** Auth failure window (seconds). */
+const AUTH_FAIL_WINDOW = 60;
+/** Auth failure threshold before IP block. */
+const AUTH_FAIL_THRESHOLD = 10;
+/** IP block duration (seconds) — 15 min. */
+const IP_BLOCK_TTL = 900;
+
+/** Number of recent URLs to track per client for scraping detection. */
+const SCRAPE_WINDOW_SIZE = 10;
+/** Scraping URL similarity threshold. */
+const SCRAPE_SIMILARITY_THRESHOLD = 0.9;
+/** Scraping penalty TTL (seconds) — 10 min. */
+const SCRAPE_PENALTY_TTL = 600;
+/** Effective rpm when scraping penalty applies (10% of original, minimum 1). */
+const SCRAPE_PENALTY_FACTOR = 0.1;
+
+/** DDoS detection window in seconds. */
+const DDOS_WINDOW = 10;
+/** Distinct IP threshold for DDoS detection. */
+const DDOS_THRESHOLD = 50;
+
+/** Aggressive pagination threshold. */
+const PAGINATION_THRESHOLD = 20;
+/** Aggressive pagination counter TTL (seconds). */
+const PAGINATION_WINDOW = 60;
+/** Pagination penalty TTL (seconds) — 5 min. */
+const PAGINATION_PENALTY_TTL = 300;
+/** Effective rpm applied as pagination penalty. */
+const PAGINATION_PENALTY_RATE = 5;
+
+/** Rate limit breach threshold for repeat offender detection. */
+const BREACH_THRESHOLD = 5;
+/** Rate limit breach counter TTL (seconds) — 10 min. */
+const BREACH_WINDOW = 600;
+
+// ── IP extraction ─────────────────────────────────────────────────────────────
+
+/**
+ * @param {import('express').Request} req
+ * @returns {string}
+ */
+function extractIp(req) {
+  const forwarded = req.headers['x-forwarded-for'];
+  if (forwarded) return String(forwarded).split(',')[0].trim();
+  return req.socket?.remoteAddress ?? '0.0.0.0';
+}
+
+// ── Jaccard similarity ────────────────────────────────────────────────────────
+
+/**
+ * Tokenise a URL path into a set of non-empty path segments.
+ *
+ * @param {string} urlPath
+ * @returns {Set<string>}
+ */
+function tokenisePath(urlPath) {
+  const parts = urlPath.split('/').filter(Boolean);
+  return new Set(parts);
+}
+
+/**
+ * Compute Jaccard similarity between two token sets.
+ * Returns a value in [0, 1].
+ *
+ * @param {Set<string>} a
+ * @param {Set<string>} b
+ * @returns {number}
+ */
+function jaccardSimilarity(a, b) {
+  if (a.size === 0 && b.size === 0) return 1;
+  if (a.size === 0 || b.size === 0) return 0;
+
+  let intersection = 0;
+  for (const token of a) {
+    if (b.has(token)) intersection++;
+  }
+
+  const union = a.size + b.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+/**
+ * Compute the average Jaccard similarity between a candidate token set and
+ * each set in a list of historical token sets.
+ *
+ * @param {Set<string>}   candidate
+ * @param {Set<string>[]} history
+ * @returns {number}
+ */
+function averageJaccard(candidate, history) {
+  if (history.length === 0) return 0;
+  const total = history.reduce((sum, h) => sum + jaccardSimilarity(candidate, h), 0);
+  return total / history.length;
+}
+
+// ── Exported helper functions ─────────────────────────────────────────────────
+
+/**
+ * Record an authentication failure for an IP address.
+ * If failures exceed AUTH_FAIL_THRESHOLD within AUTH_FAIL_WINDOW, the IP is
+ * blocked for IP_BLOCK_TTL seconds.
+ *
+ * @param {string} ip
+ * @param {import('redis').RedisClientType} redis
+ * @returns {Promise<void>}
+ */
+async function recordAuthFailure(ip, redis) {
+  try {
+    const failKey = `${ABUSE_AUTHFAIL_PREFIX}:${ip}`;
+    const count = await redis.incr(failKey);
+    if (count === 1) {
+      await redis.expire(failKey, AUTH_FAIL_WINDOW);
+    }
+
+    if (count > AUTH_FAIL_THRESHOLD) {
+      const blockKey = `${ABUSE_BLOCK_PREFIX}:${ip}`;
+      await redis.set(blockKey, '1', { EX: IP_BLOCK_TTL });
+      console.warn('[abuseDetector] IP blocked for auth brute-force:', ip);
+    }
+  } catch (err) {
+    // Redis unavailable — log and continue.
+    console.warn('[abuseDetector] recordAuthFailure Redis error:', err.message);
+  }
+}
+
+/**
+ * Record a rate-limit breach for a client.
+ * Emits a structured warning log if the client has breached > BREACH_THRESHOLD
+ * times within BREACH_WINDOW seconds.
+ *
+ * @param {string} clientId
+ * @param {import('redis').RedisClientType} redis
+ * @returns {Promise<void>}
+ */
+async function recordRateLimitBreach(clientId, redis) {
+  try {
+    const key = `${ABUSE_RATELIMITCOUNT_PREFIX}:${clientId}`;
+    const count = await redis.incr(key);
+    if (count === 1) {
+      await redis.expire(key, BREACH_WINDOW);
+    }
+
+    if (count > BREACH_THRESHOLD) {
+      console.warn(
+        JSON.stringify({
+          level: 'warn',
+          event: 'repeat_offender',
+          clientId,
+          breachCount: count,
+          windowSeconds: BREACH_WINDOW,
+          message: 'Client has exceeded the rate limit repeatedly — flagging as suspicious',
+        }),
+      );
+    }
+  } catch (err) {
+    console.warn('[abuseDetector] recordRateLimitBreach Redis error:', err.message);
+  }
+}
+
+// ── Detection helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Check whether the client IP is currently blocked.
+ *
+ * @param {string}                           ip
+ * @param {import('redis').RedisClientType}  redis
+ * @returns {Promise<boolean>}
+ */
+async function isBlocked(ip, redis) {
+  try {
+    const val = await redis.get(`${ABUSE_BLOCK_PREFIX}:${ip}`);
+    return val !== null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check for an active penalty on the client for the given endpoint.
+ *
+ * @param {string}                           clientId
+ * @param {string}                           endpoint
+ * @param {import('redis').RedisClientType}  redis
+ * @returns {Promise<boolean>}
+ */
+async function hasPenalty(clientId, endpoint, redis) {
+  try {
+    // Check both the specific endpoint penalty and a wildcard penalty.
+    const specificKey = `${ABUSE_PENALTY_PREFIX}:${clientId}:${endpoint}`;
+    const wildcardKey = `${ABUSE_PENALTY_PREFIX}:${clientId}:*`;
+    const [specific, wildcard] = await Promise.all([
+      redis.get(specificKey),
+      redis.get(wildcardKey),
+    ]);
+    return specific !== null || wildcard !== null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Apply scraping detection: track the last N URLs for the client in a Redis
+ * list and compute average Jaccard similarity. If similarity exceeds the
+ * threshold, apply a penalty.
+ *
+ * @param {string}                           clientId
+ * @param {string}                           path
+ * @param {number}                           originalLimit
+ * @param {import('redis').RedisClientType}  redis
+ * @returns {Promise<number>}  effective rate limit (may be reduced)
+ */
+async function checkScrapingPattern(clientId, path, originalLimit, redis) {
+  try {
+    const scrapeKey = `${ABUSE_SCRAPE_PREFIX}:${clientId}`;
+
+    // Push the current path to the list and trim to the last N entries.
+    await redis.rPush(scrapeKey, path);
+    await redis.lTrim(scrapeKey, -SCRAPE_WINDOW_SIZE, -1);
+    await redis.expire(scrapeKey, SCRAPE_PENALTY_TTL);
+
+    const recent = await redis.lRange(scrapeKey, 0, -1);
+    if (recent.length < 3) {
+      // Not enough data to compute meaningful similarity.
+      return originalLimit;
+    }
+
+    const candidateTokens = tokenisePath(path);
+    const historyTokenSets = recent
+      .slice(0, -1) // exclude the current path we just added
+      .map(tokenisePath);
+
+    const similarity = averageJaccard(candidateTokens, historyTokenSets);
+
+    if (similarity > SCRAPE_SIMILARITY_THRESHOLD) {
+      // Apply scraping penalty.
+      const reducedLimit = Math.max(1, Math.floor(originalLimit * SCRAPE_PENALTY_FACTOR));
+
+      const penaltyKey = `${ABUSE_PENALTY_PREFIX}:${clientId}:*`;
+      await redis.set(penaltyKey, '1', { EX: SCRAPE_PENALTY_TTL });
+
+      console.warn(
+        JSON.stringify({
+          level: 'warn',
+          event: 'scraping_detected',
+          clientId,
+          similarity: similarity.toFixed(3),
+          reducedLimit,
+          message: 'Scraping pattern detected — applying rate limit penalty',
+        }),
+      );
+
+      return reducedLimit;
+    }
+
+    return originalLimit;
+  } catch {
+    return originalLimit;
+  }
+}
+
+/**
+ * Update DDoS HyperLogLog for the endpoint and check threshold.
+ *
+ * @param {string}                           endpoint
+ * @param {string}                           ip
+ * @param {import('redis').RedisClientType}  redis
+ * @returns {Promise<boolean>}  true if DDoS threshold exceeded
+ */
+async function checkDDoSPattern(endpoint, ip, redis) {
+  try {
+    const window = Math.floor(Date.now() / (DDOS_WINDOW * 1000));
+    const ddosKey = `${ABUSE_DDOS_PREFIX}:${endpoint}:${window}`;
+
+    await redis.pfAdd(ddosKey, ip);
+    // Set TTL slightly longer than the window to allow natural expiry.
+    await redis.expire(ddosKey, DDOS_WINDOW * 3);
+
+    const distinctIps = await redis.pfCount(ddosKey);
+
+    return distinctIps > DDOS_THRESHOLD;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check for aggressive pagination behaviour.
+ *
+ * @param {string}                           clientId
+ * @param {string}                           endpoint
+ * @param {import('express').Request}        req
+ * @param {import('redis').RedisClientType}  redis
+ * @returns {Promise<boolean>}  true if pagination penalty should be applied
+ */
+async function checkPaginationPattern(clientId, endpoint, req, redis) {
+  try {
+    const hasPageParam =
+      req.query?.page !== undefined ||
+      req.query?.offset !== undefined ||
+      req.query?.cursor !== undefined;
+
+    if (!hasPageParam) return false;
+
+    const paginateKey = `${ABUSE_PAGINATE_PREFIX}:${clientId}:${endpoint}`;
+    const count = await redis.incr(paginateKey);
+    if (count === 1) {
+      await redis.expire(paginateKey, PAGINATION_WINDOW);
+    }
+
+    if (count > PAGINATION_THRESHOLD) {
+      const penaltyKey = `${ABUSE_PENALTY_PREFIX}:${clientId}:${endpoint}`;
+      await redis.set(penaltyKey, '1', { EX: PAGINATION_PENALTY_TTL });
+      return true;
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fire-and-forget POST to the Cloudflare DDoS mitigation webhook.
+ *
+ * @param {string} endpoint
+ * @param {number} distinctIps
+ */
+function notifyCloudflare(endpoint, distinctIps) {
+  const webhookUrl = process.env.CLOUDFLARE_WEBHOOK_URL;
+  if (!webhookUrl) return;
+
+  const payload = {
+    event: 'ddos_detected',
+    endpoint,
+    distinctIps,
+    timestamp: new Date().toISOString(),
+  };
+
+  // Fire-and-forget using built-in Node 18+ fetch.
+  fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  }).catch((err) => {
+    console.warn('[abuseDetector] Cloudflare webhook notification failed:', err.message);
+  });
+}
+
+// ── Middleware ─────────────────────────────────────────────────────────────────
+
+/**
+ * Express middleware that detects and mitigates request abuse patterns.
+ *
+ * Checks on every request:
+ *   1. IP block (auth brute-force) — return 403
+ *   2. Active penalty — reduce effective rate limit
+ *
+ * After response (res.on('finish')):
+ *   3. Record rate-limit breach on 429
+ *   4. DDoS detection via HyperLogLog
+ *
+ * Also runs:
+ *   5. Scraping detection (URL similarity)
+ *   6. Aggressive pagination detection
+ *
+ * @type {import('express').RequestHandler}
+ */
+async function abuseDetector(req, res, next) {
+  const ip = extractIp(req);
+  const rateContext = req.rateContext ?? {
+    clientId: 'unknown',
+    tier: 'unauthenticated',
+    rateLimit: null,
+  };
+  const { clientId } = rateContext;
+  const endpoint = req.path;
+
+  let redis = null;
+  try {
+    redis = await getRedisClient();
+  } catch {
+    // Redis unavailable — pass through.
+    return next();
+  }
+
+  if (!redis?.isReady) {
+    return next();
+  }
+
+  // ── 1. Check IP block ──────────────────────────────────────────────────────
+  try {
+    const blocked = await isBlocked(ip, redis);
+    if (blocked) {
+      return res.status(403).json({ error: 'Request blocked' });
+    }
+  } catch {
+    // Continue on Redis error.
+  }
+
+  // ── 2. Check active penalty ────────────────────────────────────────────────
+  try {
+    const penalised = await hasPenalty(clientId, endpoint, redis);
+    if (penalised) {
+      req.rateContext = { ...rateContext, rateLimit: 5 };
+    }
+  } catch {
+    // Continue on Redis error.
+  }
+
+  // ── 5. Scraping detection ──────────────────────────────────────────────────
+  try {
+    const originalLimit = req.rateContext.rateLimit ?? 60;
+    const effectiveLimit = await checkScrapingPattern(clientId, req.path, originalLimit, redis);
+    if (effectiveLimit < originalLimit) {
+      req.rateContext = { ...req.rateContext, rateLimit: effectiveLimit };
+    }
+  } catch {
+    // Continue.
+  }
+
+  // ── 6. Aggressive pagination ───────────────────────────────────────────────
+  try {
+    const paginationPenalty = await checkPaginationPattern(clientId, endpoint, req, redis);
+    if (paginationPenalty) {
+      req.rateContext = { ...req.rateContext, rateLimit: PAGINATION_PENALTY_RATE };
+    }
+  } catch {
+    // Continue.
+  }
+
+  // ── Post-response hooks ────────────────────────────────────────────────────
+  res.on('finish', () => {
+    // 3. Record rate-limit breach on 429.
+    if (res.statusCode === 429) {
+      getRedisClient()
+        .then((r) => {
+          if (r?.isReady) return recordRateLimitBreach(clientId, r);
+        })
+        .catch(() => {});
+    }
+
+    // 4. DDoS detection.
+    getRedisClient()
+      .then(async (r) => {
+        if (!r?.isReady) return;
+        const isDDoS = await checkDDoSPattern(endpoint, ip, r);
+        if (isDDoS) {
+          const window = Math.floor(Date.now() / (DDOS_WINDOW * 1000));
+          const ddosKey = `${ABUSE_DDOS_PREFIX}:${endpoint}:${window}`;
+          const distinctIps = await r.pfCount(ddosKey).catch(() => 0);
+
+          console.warn(
+            JSON.stringify({
+              level: 'warn',
+              event: 'ddos_detected',
+              endpoint,
+              distinctIps,
+              windowSeconds: DDOS_WINDOW,
+              message: 'DDoS threshold exceeded — consider activating mitigation',
+            }),
+          );
+
+          notifyCloudflare(endpoint, distinctIps);
+        }
+      })
+      .catch(() => {});
+  });
+
+  return next();
+}
+
+export {
+  abuseDetector,
+  recordAuthFailure,
+  recordRateLimitBreach,
+  jaccardSimilarity,
+  tokenisePath,
+  averageJaccard,
+};

--- a/indexer/src/rateLimit/concurrentLimiter.js
+++ b/indexer/src/rateLimit/concurrentLimiter.js
@@ -1,0 +1,154 @@
+/**
+ * Concurrent Request Limiter Middleware
+ *
+ * Enforces a per-client cap on the number of in-flight HTTP requests (and
+ * WebSocket connections handled separately) using Redis INCR / DECR counters.
+ *
+ * Key formats:
+ *   conc:{clientId}       – concurrent HTTP request counter
+ *   conc:ws:{clientId}    – concurrent WebSocket connection counter
+ *
+ * Tier limits (HTTP):
+ *   unauthenticated: 5
+ *   free:            20
+ *   pro:             100
+ *   enterprise:      200
+ *
+ * Tier limits (WebSocket):
+ *   unauthenticated: 1
+ *   free:            5
+ *   pro:             25
+ *   enterprise:      50
+ *
+ * Behaviour:
+ *   - On request start: INCR the counter; if counter > limit → 503 + Retry-After: 1
+ *   - On response finish: DECR the counter (even on errors)
+ *   - A TTL_CONC_SAFETY (300 s) safety net is re-applied after each INCR to
+ *     prevent permanent counter leaks if a connection dies without decrementing.
+ *   - If Redis is unavailable, the middleware passes through (graceful degradation).
+ */
+
+import { getRedisClient } from './tokenBucket.js';
+import { CONC_PREFIX, CONC_WS_PREFIX, TTL_CONC_SAFETY } from './constants.js';
+
+// ── Tier limit tables ─────────────────────────────────────────────────────────
+
+/** Maximum concurrent HTTP requests per tier. */
+const HTTP_TIER_LIMITS = {
+  unauthenticated: 5,
+  free: 20,
+  pro: 100,
+  enterprise: 200,
+};
+
+/** Maximum concurrent WebSocket connections per tier. */
+const WS_TIER_LIMITS = {
+  unauthenticated: 1,
+  free: 5,
+  pro: 25,
+  enterprise: 50,
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Determine whether the request is a WebSocket upgrade.
+ *
+ * @param {import('express').Request} req
+ * @returns {boolean}
+ */
+function isWebSocket(req) {
+  return (
+    typeof req.headers?.upgrade === 'string' &&
+    req.headers.upgrade.toLowerCase() === 'websocket'
+  );
+}
+
+/**
+ * Return the concurrent limit for the client given its tier and connection type.
+ *
+ * @param {string}  tier
+ * @param {boolean} ws
+ * @returns {number}
+ */
+function getConcLimit(tier, ws) {
+  const table = ws ? WS_TIER_LIMITS : HTTP_TIER_LIMITS;
+  return table[tier] ?? table.unauthenticated;
+}
+
+// ── Middleware ─────────────────────────────────────────────────────────────────
+
+/**
+ * Express middleware that limits concurrent in-flight requests per client.
+ *
+ * Reads req.rateContext (populated by apiKeyAuthenticator) for clientId and tier.
+ * Returns 503 with Retry-After: 1 when the concurrent limit is exceeded.
+ * Gracefully passes through if Redis is unavailable.
+ *
+ * @type {import('express').RequestHandler}
+ */
+async function concurrentRequestLimiter(req, res, next) {
+  const rateContext = req.rateContext ?? {
+    clientId: 'unknown',
+    tier: 'unauthenticated',
+  };
+
+  const { clientId, tier } = rateContext;
+  const ws = isWebSocket(req);
+  const prefix = ws ? CONC_WS_PREFIX : CONC_PREFIX;
+  const redisKey = `${prefix}:${clientId}`;
+  const limit = getConcLimit(tier, ws);
+
+  let redis = null;
+  try {
+    redis = await getRedisClient();
+  } catch {
+    // Redis unavailable — pass through.
+    return next();
+  }
+
+  if (!redis?.isReady) {
+    // Graceful degradation: allow the request through.
+    return next();
+  }
+
+  let count;
+  try {
+    // Atomically increment and read.
+    count = await redis.incr(redisKey);
+
+    // Refresh safety-net TTL on every increment to prevent key leaks.
+    await redis.expire(redisKey, TTL_CONC_SAFETY);
+  } catch {
+    // Redis error mid-operation — fail open.
+    return next();
+  }
+
+  if (count > limit) {
+    // Exceeded the concurrent cap. Decrement immediately since we are not
+    // going to process this request.
+    try {
+      await redis.decr(redisKey);
+    } catch {
+      // Ignore decr failure — TTL safety net will clean up eventually.
+    }
+
+    res.set('Retry-After', '1');
+    return res.status(503).json({ error: 'Too many concurrent requests' });
+  }
+
+  // Decrement when the response finishes (success or error).
+  res.on('finish', () => {
+    getRedisClient()
+      .then((r) => {
+        if (r?.isReady) return r.decr(redisKey);
+      })
+      .catch(() => {
+        // Ignore — safety TTL handles eventual cleanup.
+      });
+  });
+
+  return next();
+}
+
+export { concurrentRequestLimiter, HTTP_TIER_LIMITS, WS_TIER_LIMITS };

--- a/indexer/src/rateLimit/constants.js
+++ b/indexer/src/rateLimit/constants.js
@@ -1,0 +1,69 @@
+/**
+ * Redis key namespace constants for the rate limiting and abuse detection system.
+ *
+ * Key formats:
+ *   rl:{clientId}:{endpointGroup}           – token bucket (CL.THROTTLE)
+ *   conc:{clientId}                         – concurrent HTTP request counter
+ *   conc:ws:{clientId}                      – concurrent WebSocket counter
+ *   abuse:authfail:{ip}                     – auth failure count (TTL 60 s)
+ *   abuse:block:{ip}                        – temporary IP block flag (TTL 15 min)
+ *   abuse:scrape:{clientId}                 – scraping URL sliding window (sorted set)
+ *   abuse:ddos:{endpoint}:{window}          – distinct IP HyperLogLog per endpoint
+ *   abuse:paginate:{clientId}:{endpoint}    – consecutive page count (TTL 60 s)
+ *   abuse:ratelimitcount:{clientId}         – repeat breach count (TTL 10 min)
+ *   abuse:penalty:{clientId}:{endpoint}     – active penalty flag (TTL variable)
+ *   usage:{keyId}:{date}:{metric}           – intra-day usage buffer counter
+ */
+
+// ── Rate limit token bucket prefix ────────────────────────────────────────────
+/** Prefix for per-client, per-endpoint-group token bucket keys. */
+export const RL_PREFIX = 'rl';
+
+// ── Concurrent request counter prefixes ───────────────────────────────────────
+/** Prefix for per-client concurrent HTTP request counters. */
+export const CONC_PREFIX = 'conc';
+
+/** Prefix for per-client concurrent WebSocket connection counters. */
+export const CONC_WS_PREFIX = 'conc:ws';
+
+// ── Abuse detection prefixes ───────────────────────────────────────────────────
+/** Prefix for per-IP authentication failure counters (TTL: 60 s). */
+export const ABUSE_AUTHFAIL_PREFIX = 'abuse:authfail';
+
+/** Prefix for temporary IP block flags (TTL: 15 min). */
+export const ABUSE_BLOCK_PREFIX = 'abuse:block';
+
+/** Prefix for scraping URL-path sliding windows (sorted set). */
+export const ABUSE_SCRAPE_PREFIX = 'abuse:scrape';
+
+/** Prefix for per-endpoint DDoS detection HyperLogLog keys. */
+export const ABUSE_DDOS_PREFIX = 'abuse:ddos';
+
+/** Prefix for aggressive pagination counters per client per endpoint (TTL: 60 s). */
+export const ABUSE_PAGINATE_PREFIX = 'abuse:paginate';
+
+/** Prefix for repeat rate-limit breach counters (TTL: 10 min). */
+export const ABUSE_RATELIMITCOUNT_PREFIX = 'abuse:ratelimitcount';
+
+/** Prefix for active penalty flags per client per endpoint (TTL: variable). */
+export const ABUSE_PENALTY_PREFIX = 'abuse:penalty';
+
+// ── Usage tracking prefix ──────────────────────────────────────────────────────
+/** Prefix for intra-day per-key usage buffer counters. */
+export const USAGE_PREFIX = 'usage';
+
+// ── TTL constants (seconds) ────────────────────────────────────────────────────
+/** Token bucket TTL for Unauthenticated tier (1 hour). */
+export const TTL_UNAUTH = 3600;
+
+/** Token bucket TTL for Free tier (24 hours). */
+export const TTL_FREE = 86400;
+
+/** Token bucket TTL for Pro tier (1 month ≈ 30 days). */
+export const TTL_PRO = 2592000;
+
+/**
+ * Safety-net TTL applied to concurrent request counter keys to prevent
+ * permanent counter leaks if a connection drops without decrementing (5 min).
+ */
+export const TTL_CONC_SAFETY = 300;

--- a/indexer/src/rateLimit/endpointGroups.js
+++ b/indexer/src/rateLimit/endpointGroups.js
@@ -1,0 +1,185 @@
+/**
+ * Endpoint Groups and Per-Tier Rate Limits
+ *
+ * Defines URL path patterns for each endpoint group and the sustained rpm
+ * and burst limits per tier. Used by the token bucket middleware to select
+ * the appropriate rate limit for each request.
+ *
+ * Groups (in match priority order):
+ *   websocket  – WebSocket upgrade paths
+ *   simulate   – simulation / sandbox execution paths
+ *   contracts  – contract metadata, ABI, spec, upgrades, etc.
+ *   search     – search and wallet lookup
+ *   events     – event listing and single-event reads
+ *   default    – everything else
+ *
+ * Per-tier rpm values (sustained requests per minute):
+ *
+ *   Group      | unauth |  free  |  pro   | enterprise
+ *   -----------|--------|--------|--------|------------
+ *   events     |   60   |  1000  | 10000  | Infinity*
+ *   search     |   30   |   500  |  5000  | Infinity*
+ *   contracts  |   10   |   100  |  1000  | Infinity*
+ *   simulate   |    5   |    50  |   500  | Infinity*
+ *   websocket  |    3   |    30  |   300  | Infinity*
+ *   default    |   60   |  1000  | 10000  | Infinity*
+ *
+ * * Enterprise rpm is configurable; Infinity is used as a sentinel value
+ *   that callers should replace with the key-specific override.
+ *
+ * Default burst limits per tier:
+ *   unauthenticated: 10
+ *   free:            50
+ *   pro:             200
+ *   enterprise:      500
+ */
+
+// ── Endpoint group definitions ────────────────────────────────────────────────
+
+/**
+ * Each entry has:
+ *   name     {string}   – canonical group identifier
+ *   patterns {string[]} – path prefix strings to match (longest prefix wins
+ *                         implicitly through ordering)
+ */
+const ENDPOINT_GROUP_DEFINITIONS = [
+  {
+    name: 'websocket',
+    patterns: ['/ws', '/socket', '/api/ws', '/api/socket'],
+  },
+  {
+    name: 'simulate',
+    patterns: ['/api/simulate', '/api/sandbox/simulate'],
+  },
+  {
+    name: 'contracts',
+    patterns: [
+      '/api/contracts',
+      '/api/v1/contracts',
+      '/api/spec',
+      '/api/verify',
+    ],
+  },
+  {
+    name: 'search',
+    patterns: ['/api/search', '/api/wallet'],
+  },
+  {
+    name: 'events',
+    patterns: ['/api/events', '/api/v1/events'],
+  },
+];
+
+// ── Per-tier burst defaults ───────────────────────────────────────────────────
+
+/** Default burst token allocation per tier (tokens above the sustained rate). */
+export const TIER_BURST_DEFAULTS = {
+  unauthenticated: 10,
+  free: 50,
+  pro: 200,
+  enterprise: 500,
+};
+
+// ── Per-group, per-tier sustained rpm limits ──────────────────────────────────
+
+/**
+ * Sustained requests-per-minute for each (group, tier) combination.
+ * Enterprise is set to Infinity as a placeholder; callers should substitute
+ * the key-specific override when one is available.
+ *
+ * @type {Record<string, Record<string, number>>}
+ */
+export const GROUP_TIER_LIMITS = {
+  events: {
+    unauthenticated: 60,
+    free: 1000,
+    pro: 10000,
+    enterprise: Infinity,
+  },
+  search: {
+    unauthenticated: 30,
+    free: 500,
+    pro: 5000,
+    enterprise: Infinity,
+  },
+  contracts: {
+    unauthenticated: 10,
+    free: 100,
+    pro: 1000,
+    enterprise: Infinity,
+  },
+  simulate: {
+    unauthenticated: 5,
+    free: 50,
+    pro: 500,
+    enterprise: Infinity,
+  },
+  websocket: {
+    unauthenticated: 3,
+    free: 30,
+    pro: 300,
+    enterprise: Infinity,
+  },
+  default: {
+    unauthenticated: 60,
+    free: 1000,
+    pro: 10000,
+    enterprise: Infinity,
+  },
+};
+
+// ── resolveEndpointGroup ──────────────────────────────────────────────────────
+
+/**
+ * Resolve the endpoint group name for a given URL path.
+ *
+ * Iterates over ENDPOINT_GROUP_DEFINITIONS in order. The first group whose
+ * any pattern is a prefix of `path` (case-insensitive) is returned. Falls
+ * back to `"default"` if no pattern matches.
+ *
+ * @param {string} path  e.g. "/api/events/123"
+ * @returns {string}     group name, e.g. "events"
+ */
+export function resolveEndpointGroup(path) {
+  if (typeof path !== 'string') return 'default';
+
+  const normalised = path.toLowerCase();
+
+  for (const group of ENDPOINT_GROUP_DEFINITIONS) {
+    for (const pattern of group.patterns) {
+      if (normalised === pattern || normalised.startsWith(pattern + '/') || normalised.startsWith(pattern + '?')) {
+        return group.name;
+      }
+    }
+  }
+
+  return 'default';
+}
+
+// ── getTierLimits ─────────────────────────────────────────────────────────────
+
+/**
+ * Return the effective `{ rpm, burst }` for a given group + tier combination.
+ *
+ * If `overrideRpm` is a finite positive number it replaces the table value.
+ * For the enterprise tier the table value is Infinity; callers should always
+ * provide a meaningful `overrideRpm` for enterprise keys.
+ *
+ * @param {string}      group        – endpoint group name (e.g. "events")
+ * @param {string}      tier         – tier name (e.g. "pro")
+ * @param {number|null} [overrideRpm] – per-key override from api_keys.rate_limit
+ * @returns {{ rpm: number, burst: number }}
+ */
+export function getTierLimits(group, tier, overrideRpm = null) {
+  const baseLimits = GROUP_TIER_LIMITS[group] ?? GROUP_TIER_LIMITS.default;
+  const baseRpm = baseLimits[tier] ?? baseLimits.unauthenticated ?? 60;
+
+  const rpm =
+    typeof overrideRpm === 'number' && Number.isFinite(overrideRpm) && overrideRpm > 0
+      ? overrideRpm
+      : baseRpm;
+
+  const burst = TIER_BURST_DEFAULTS[tier] ?? TIER_BURST_DEFAULTS.unauthenticated;
+
+  return { rpm, burst };
+}

--- a/indexer/src/rateLimit/geoIpLimiter.js
+++ b/indexer/src/rateLimit/geoIpLimiter.js
@@ -1,0 +1,193 @@
+/**
+ * GeoIP Rate Limiter Middleware
+ *
+ * Uses the MaxMind GeoLite2-Country database (via the `maxmind` npm package)
+ * to resolve the client IP to a country/region code and then either:
+ *   - Blocks the request (403) if the region is in GEO_BLOCK_LIST
+ *   - Multiplies the effective rate limit if the region is in GEO_RATE_MULTIPLIERS
+ *   - Passes through unchanged otherwise
+ *
+ * Environment variables:
+ *   GEOIP_DB_PATH         – path to GeoLite2-Country.mmdb (optional)
+ *   GEO_BLOCK_LIST        – comma-separated ISO-3166 country codes to block
+ *   GEO_RATE_MULTIPLIERS  – JSON map of country code → float multiplier
+ *                           e.g. {"US": 1.5, "CN": 0.5}
+ *
+ * Gracefully passes through (calls next()) when:
+ *   - GEOIP_DB_PATH is unset
+ *   - The database file is missing or fails to load
+ *   - The IP lookup fails
+ */
+
+import { readFile } from 'fs/promises';
+import { existsSync } from 'fs';
+
+// ── Lazy-loaded MaxMind reader ────────────────────────────────────────────────
+
+let _maxmindReader = null;
+let _maxmindLoadAttempted = false;
+
+/**
+ * Lazily load the MaxMind GeoLite2-Country database.
+ * Returns the reader instance or null if unavailable.
+ *
+ * @returns {Promise<object|null>}
+ */
+async function getMaxmindReader() {
+  if (_maxmindLoadAttempted) return _maxmindReader;
+  _maxmindLoadAttempted = true;
+
+  const dbPath = process.env.GEOIP_DB_PATH;
+  if (!dbPath) return null;
+
+  if (!existsSync(dbPath)) {
+    console.warn('[geoIpLimiter] GeoLite2 database file not found at:', dbPath);
+    return null;
+  }
+
+  try {
+    // Dynamic import so the module is only loaded when actually needed.
+    const maxmind = await import('maxmind');
+    const open = maxmind.default?.open ?? maxmind.open;
+    _maxmindReader = await open(dbPath);
+    console.log('[geoIpLimiter] MaxMind GeoLite2-Country database loaded from:', dbPath);
+  } catch (err) {
+    console.warn('[geoIpLimiter] Failed to load MaxMind database:', err.message);
+    _maxmindReader = null;
+  }
+
+  return _maxmindReader;
+}
+
+// ── Config helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Parse GEO_BLOCK_LIST env into an uppercase Set of country codes.
+ * @returns {Set<string>}
+ */
+function getBlockList() {
+  const raw = process.env.GEO_BLOCK_LIST ?? '';
+  if (!raw.trim()) return new Set();
+  return new Set(
+    raw
+      .split(',')
+      .map((s) => s.trim().toUpperCase())
+      .filter(Boolean),
+  );
+}
+
+/**
+ * Parse GEO_RATE_MULTIPLIERS env into a map of uppercase country code → float.
+ * @returns {Record<string, number>}
+ */
+function getRateMultipliers() {
+  const raw = process.env.GEO_RATE_MULTIPLIERS;
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    // Normalise keys to uppercase.
+    const result = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      const multiplier = Number(v);
+      if (k && Number.isFinite(multiplier) && multiplier > 0) {
+        result[k.toUpperCase()] = multiplier;
+      }
+    }
+    return result;
+  } catch {
+    console.warn('[geoIpLimiter] Failed to parse GEO_RATE_MULTIPLIERS — using empty map');
+    return {};
+  }
+}
+
+// ── IP extraction ─────────────────────────────────────────────────────────────
+
+/**
+ * Extract the best-effort client IP from the request.
+ *
+ * @param {import('express').Request} req
+ * @returns {string}
+ */
+function extractClientIp(req) {
+  const forwarded = req.headers['x-forwarded-for'];
+  if (forwarded) {
+    return String(forwarded).split(',')[0].trim();
+  }
+  return req.socket?.remoteAddress ?? '0.0.0.0';
+}
+
+// ── Middleware ─────────────────────────────────────────────────────────────────
+
+/**
+ * Express middleware that applies GeoIP-based blocking and rate multipliers.
+ *
+ * Reads/modifies req.rateContext.rateLimit to apply the regional multiplier.
+ * Returns 403 for blocked regions.
+ * Passes through transparently if the GeoIP database is unavailable.
+ *
+ * @type {import('express').RequestHandler}
+ */
+async function geoIpRateLimiter(req, res, next) {
+  try {
+    const reader = await getMaxmindReader();
+    if (!reader) {
+      // No database available — pass through.
+      return next();
+    }
+
+    const ip = extractClientIp(req);
+    let countryCode = null;
+
+    try {
+      const result = reader.get(ip);
+      countryCode = result?.country?.iso_code?.toUpperCase() ?? null;
+    } catch {
+      // Lookup failure — pass through.
+      return next();
+    }
+
+    if (!countryCode) {
+      return next();
+    }
+
+    const blockList = getBlockList();
+    if (blockList.has(countryCode)) {
+      return res.status(403).json({ error: 'Region not permitted' });
+    }
+
+    const multipliers = getRateMultipliers();
+    if (multipliers[countryCode] !== undefined) {
+      const multiplier = multipliers[countryCode];
+
+      // Ensure rateContext exists.
+      if (!req.rateContext) {
+        req.rateContext = {
+          clientId: 'unknown',
+          tier: 'unauthenticated',
+          rateLimit: null,
+          keyId: null,
+          keyName: null,
+        };
+      }
+
+      // Apply multiplier to existing rateLimit override, or derive from tier default.
+      if (req.rateContext.rateLimit != null) {
+        req.rateContext.rateLimit = Math.round(req.rateContext.rateLimit * multiplier);
+      } else {
+        // Store the multiplier for downstream middleware (tokenBucket) to use.
+        // We attach it as a separate field so token bucket can compute
+        // the effective limit when no explicit override exists.
+        req.rateContext.geoMultiplier = multiplier;
+      }
+    }
+
+    return next();
+  } catch (err) {
+    console.error('[geoIpLimiter] Unexpected error:', err.message);
+    // Fail open — do not block requests on unexpected errors.
+    return next();
+  }
+}
+
+// Export for testing.
+export { geoIpRateLimiter, getMaxmindReader, extractClientIp, getBlockList, getRateMultipliers };

--- a/indexer/src/rateLimit/graphqlComplexity.js
+++ b/indexer/src/rateLimit/graphqlComplexity.js
@@ -1,0 +1,196 @@
+/**
+ * GraphQL Complexity Limiter Middleware
+ *
+ * Applied only to requests whose path includes '/graphql'.
+ * Parses req.body.query using the `graphql` package's parse() function,
+ * walks the DocumentNode AST to calculate total cost, and rejects queries
+ * that exceed the tier budget.
+ *
+ * Cost model:
+ *   - Default field cost: 1
+ *   - List fields (field name ends with 's' OR appears in LIST_FIELD_NAMES):
+ *     base cost × 10
+ *
+ * Cost budgets by tier:
+ *   unauthenticated:  100
+ *   free:             500
+ *   pro:            2 000
+ *   enterprise:    10 000
+ *
+ * On rejection: 400 { "error": "Query complexity exceeded", "cost": N, "limit": M }
+ *
+ * On success: sets X-GraphQL-Cost and X-GraphQL-Cost-Remaining headers and
+ * calls next().
+ *
+ * Parse errors are handled gracefully — the request is allowed through.
+ */
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/** Cost budget per tier. */
+const TIER_COMPLEXITY_BUDGETS = {
+  unauthenticated: 100,
+  free: 500,
+  pro: 2000,
+  enterprise: 10000,
+};
+
+/** Default cost for a single field selection. */
+const DEFAULT_FIELD_COST = 1;
+
+/** Multiplier applied to fields identified as list-returning. */
+const LIST_FIELD_MULTIPLIER = 10;
+
+/**
+ * Explicit set of field names that are known to return lists (in addition to
+ * the heuristic of names ending with 's').
+ */
+const LIST_FIELD_NAMES = new Set([
+  'edges',
+  'nodes',
+  'items',
+  'results',
+  'data',
+  'records',
+  'entries',
+  'list',
+  'feed',
+  'page',
+  'collection',
+]);
+
+// ── Cost calculation ──────────────────────────────────────────────────────────
+
+/**
+ * Determine whether a field selection is heuristically a list field.
+ *
+ * @param {string} fieldName
+ * @returns {boolean}
+ */
+function isListField(fieldName) {
+  if (LIST_FIELD_NAMES.has(fieldName.toLowerCase())) return true;
+  // Heuristic: plural names (ending in 's') are usually list-returning.
+  return fieldName.length > 1 && fieldName.endsWith('s');
+}
+
+/**
+ * Recursively walk a GraphQL SelectionSet and accumulate complexity cost.
+ *
+ * @param {object} selectionSet  – A GraphQL SelectionSetNode or undefined
+ * @returns {number}
+ */
+function calculateSelectionSetCost(selectionSet) {
+  if (!selectionSet || !Array.isArray(selectionSet.selections)) return 0;
+
+  let total = 0;
+
+  for (const selection of selectionSet.selections) {
+    if (selection.kind === 'Field') {
+      const fieldName = selection.name?.value ?? '';
+      const fieldCost = isListField(fieldName)
+        ? DEFAULT_FIELD_COST * LIST_FIELD_MULTIPLIER
+        : DEFAULT_FIELD_COST;
+
+      total += fieldCost;
+
+      // Recurse into nested selection sets.
+      if (selection.selectionSet) {
+        total += calculateSelectionSetCost(selection.selectionSet);
+      }
+    } else if (selection.kind === 'InlineFragment') {
+      total += calculateSelectionSetCost(selection.selectionSet);
+    } else if (selection.kind === 'FragmentSpread') {
+      // Fragment spreads cost 1 by default; the actual fragment body is not
+      // available without the full document context, so we apply a minimal cost.
+      total += DEFAULT_FIELD_COST;
+    }
+  }
+
+  return total;
+}
+
+/**
+ * Calculate the total complexity cost for a parsed GraphQL DocumentNode.
+ *
+ * @param {object} document – A GraphQL DocumentNode (result of parse())
+ * @returns {number}
+ */
+function calculateDocumentCost(document) {
+  if (!document || !Array.isArray(document.definitions)) return 0;
+
+  let total = 0;
+
+  for (const definition of document.definitions) {
+    if (
+      definition.kind === 'OperationDefinition' ||
+      definition.kind === 'FragmentDefinition'
+    ) {
+      total += calculateSelectionSetCost(definition.selectionSet);
+    }
+  }
+
+  return total;
+}
+
+// ── Middleware ─────────────────────────────────────────────────────────────────
+
+/**
+ * Express middleware that enforces GraphQL query complexity limits.
+ *
+ * Only runs on paths that include '/graphql'.
+ * Reads req.rateContext.tier for the budget; falls back to 'unauthenticated'.
+ * Sets X-GraphQL-Cost and X-GraphQL-Cost-Remaining on allowed requests.
+ *
+ * @type {import('express').RequestHandler}
+ */
+async function graphqlComplexityLimiter(req, res, next) {
+  // Only apply to GraphQL routes.
+  if (!req.path.includes('/graphql')) {
+    return next();
+  }
+
+  const query = req.body?.query;
+
+  // If there is no query, pass through (e.g. introspection over GET, health checks).
+  if (!query || typeof query !== 'string') {
+    return next();
+  }
+
+  let document;
+  try {
+    // Dynamically import graphql to keep startup fast and avoid hard dependency
+    // errors if the package is missing.
+    const { parse } = await import('graphql');
+    document = parse(query);
+  } catch {
+    // Parse failure — pass through gracefully.
+    return next();
+  }
+
+  const cost = calculateDocumentCost(document);
+  const tier = req.rateContext?.tier ?? 'unauthenticated';
+  const budget =
+    TIER_COMPLEXITY_BUDGETS[tier] ?? TIER_COMPLEXITY_BUDGETS.unauthenticated;
+
+  if (cost > budget) {
+    return res.status(400).json({
+      error: 'Query complexity exceeded',
+      cost,
+      limit: budget,
+    });
+  }
+
+  // Attach cost headers.
+  res.set('X-GraphQL-Cost', String(cost));
+  res.set('X-GraphQL-Cost-Remaining', String(Math.max(0, budget - cost)));
+
+  return next();
+}
+
+export {
+  graphqlComplexityLimiter,
+  calculateDocumentCost,
+  calculateSelectionSetCost,
+  isListField,
+  TIER_COMPLEXITY_BUDGETS,
+};

--- a/indexer/src/rateLimit/headers.js
+++ b/indexer/src/rateLimit/headers.js
@@ -1,0 +1,90 @@
+/**
+ * Rate Limit Header Writer Middleware
+ *
+ * Attaches X-RateLimit-* headers to every response and Retry-After only when
+ * the response status is 429.
+ *
+ * Reads from req.rateLimitState populated by tokenBucketMiddleware:
+ *   { limit, remaining, reset, tier }
+ *
+ * Headers set on every response:
+ *   X-RateLimit-Limit     – max rpm for active tier + endpoint group
+ *   X-RateLimit-Remaining – remaining tokens in current window
+ *   X-RateLimit-Reset     – Unix timestamp of next window reset
+ *   X-RateLimit-Tier      – tier name string
+ *
+ * Additional header on 429 responses:
+ *   Retry-After           – seconds until next token is available
+ */
+
+/**
+ * Express middleware that writes X-RateLimit-* headers on every response.
+ * Should be placed after tokenBucketMiddleware in the chain.
+ *
+ * @type {import('express').RequestHandler}
+ */
+function rateLimitHeaderWriter(req, res, next) {
+  // Intercept the response by wrapping the write/end cycle.
+  // We override res.writeHead so the headers are always set before the
+  // response is flushed, regardless of how the response is sent.
+  const originalWriteHead = res.writeHead.bind(res);
+
+  res.writeHead = function patchedWriteHead(statusCode, statusMessage, headers) {
+    _applyRateLimitHeaders(req, res, statusCode);
+
+    // Restore and delegate to the original.
+    res.writeHead = originalWriteHead;
+    if (typeof statusMessage === 'string') {
+      return originalWriteHead(statusCode, statusMessage, headers);
+    }
+    // statusMessage may be omitted; the second arg might be headers.
+    return originalWriteHead(statusCode, statusMessage);
+  };
+
+  // Also set them immediately so they are available to downstream middleware
+  // that reads res headers (e.g. tests that call res.get(...) before flush).
+  // This is a best-effort pre-population; writeHead override handles the
+  // actual flush-time guarantee.
+  const state = req.rateLimitState;
+  if (state) {
+    res.set('X-RateLimit-Limit', String(state.limit));
+    res.set('X-RateLimit-Remaining', String(Math.max(0, state.remaining)));
+    res.set('X-RateLimit-Reset', String(state.reset));
+    res.set('X-RateLimit-Tier', String(state.tier));
+  }
+
+  return next();
+}
+
+/**
+ * Apply X-RateLimit-* headers to the response object.
+ *
+ * @param {import('express').Request}  req
+ * @param {import('express').Response} res
+ * @param {number} statusCode
+ */
+function _applyRateLimitHeaders(req, res, statusCode) {
+  const state = req.rateLimitState;
+  if (!state) return;
+
+  try {
+    res.setHeader('X-RateLimit-Limit', String(state.limit));
+    res.setHeader('X-RateLimit-Remaining', String(Math.max(0, state.remaining)));
+    res.setHeader('X-RateLimit-Reset', String(state.reset));
+    res.setHeader('X-RateLimit-Tier', String(state.tier));
+
+    // Retry-After is only meaningful on 429 responses.
+    if (statusCode === 429) {
+      // retryAfter may be on the state if the token bucket populated it,
+      // or on the existing Retry-After header already set by tokenBucketMiddleware.
+      const existing = res.getHeader('Retry-After');
+      if (!existing && state.retryAfter !== undefined) {
+        res.setHeader('Retry-After', String(state.retryAfter));
+      }
+    }
+  } catch {
+    // Headers may already be sent in edge cases — ignore silently.
+  }
+}
+
+export { rateLimitHeaderWriter };

--- a/indexer/src/rateLimit/tokenBucket.js
+++ b/indexer/src/rateLimit/tokenBucket.js
@@ -1,0 +1,252 @@
+/**
+ * Token Bucket Rate Limiter Middleware
+ *
+ * Implements per-client, per-endpoint-group rate limiting using the Redis
+ * `CL.THROTTLE` command (redis-cell / RedisBloom GCRA implementation).
+ *
+ * Key format: rl:{clientId}:{endpointGroup}
+ *
+ * CL.THROTTLE syntax:
+ *   CL.THROTTLE <key> <max_burst> <count_per_period> <period_seconds> [<quantity>]
+ *
+ *   max_burst        = burst - 1  (extra tokens above the sustained rate)
+ *   count_per_period = rpm value from tier config
+ *   period_seconds   = 60
+ *   quantity         = 1  (each request consumes 1 token)
+ *
+ * CL.THROTTLE response array (indices):
+ *   [0] allowed   – 0 = allowed, 1 = rate limited
+ *   [1] limit     – total tokens (max_burst + 1)
+ *   [2] remaining – tokens remaining after this request
+ *   [3] retryAfter – seconds until next token (-1 if not limited)
+ *   [4] resetAfter – seconds until bucket is fully replenished
+ *
+ * On Redis failure the middleware falls back to an in-process token bucket
+ * implemented with a Map and emits a warn-level log. The fallback is
+ * intentionally simple (no persistence, no cross-instance sharing) and is
+ * only meant to keep the service functional when Redis is temporarily down.
+ *
+ * Attaches req.rateLimitState for the downstream header writer:
+ *   { limit, remaining, reset, tier }
+ */
+
+import { createClient } from 'redis';
+import { resolveEndpointGroup, getTierLimits } from './endpointGroups.js';
+import { RL_PREFIX } from './constants.js';
+
+// ── Redis client (lazy singleton) ─────────────────────────────────────────────
+
+let _redis = null;
+let _redisConnecting = false;
+
+/**
+ * Returns a connected Redis client or null if Redis is unavailable.
+ * Uses lazy initialisation so the module can be imported before REDIS_URL
+ * is set (e.g. during tests).
+ *
+ * @returns {Promise<import('redis').RedisClientType|null>}
+ */
+async function getRedisClient() {
+  if (_redis?.isReady) return _redis;
+
+  if (_redisConnecting) return null;
+
+  const url = process.env.REDIS_URL;
+  if (!url) return null;
+
+  _redisConnecting = true;
+  try {
+    const client = createClient({ url });
+    client.on('error', (err) => {
+      console.warn('[tokenBucket] Redis error:', err.message);
+      _redis = null;
+      _redisConnecting = false;
+    });
+    await client.connect();
+    _redis = client;
+    console.log('[tokenBucket] Redis connected:', url);
+  } catch (err) {
+    console.warn('[tokenBucket] Redis unavailable, using in-process fallback:', err.message);
+    _redis = null;
+  } finally {
+    _redisConnecting = false;
+  }
+
+  return _redis;
+}
+
+// ── In-process fallback limiter ────────────────────────────────────────────────
+
+/**
+ * Simple in-process token bucket used when Redis is unavailable.
+ * NOT shared across instances — only suitable as a temporary fallback.
+ *
+ * Map key: "{clientId}:{endpointGroup}"
+ * Map value: { tokens: number, lastRefill: number }
+ */
+const _fallbackBuckets = new Map();
+
+/**
+ * Consume one token from the in-process fallback bucket.
+ *
+ * @param {string} bucketKey    – "{clientId}:{endpointGroup}"
+ * @param {number} rpm          – sustained requests per minute
+ * @param {number} burst        – max burst size
+ * @returns {{ allowed: boolean, remaining: number, retryAfter: number, reset: number }}
+ */
+function fallbackConsume(bucketKey, rpm, burst) {
+  const now = Date.now();
+  const refillRateMs = 60_000 / rpm; // ms per token
+  const maxTokens = burst;
+
+  let bucket = _fallbackBuckets.get(bucketKey);
+
+  if (!bucket) {
+    bucket = { tokens: maxTokens, lastRefill: now };
+    _fallbackBuckets.set(bucketKey, bucket);
+  }
+
+  // Refill tokens proportional to elapsed time.
+  const elapsed = now - bucket.lastRefill;
+  const tokensToAdd = Math.floor(elapsed / refillRateMs);
+  if (tokensToAdd > 0) {
+    bucket.tokens = Math.min(maxTokens, bucket.tokens + tokensToAdd);
+    bucket.lastRefill = now + (tokensToAdd * refillRateMs - elapsed);
+    if (bucket.lastRefill > now) bucket.lastRefill = now;
+  }
+
+  const allowed = bucket.tokens >= 1;
+  if (allowed) {
+    bucket.tokens -= 1;
+  }
+
+  const remaining = bucket.tokens;
+  const retryAfter = allowed ? 0 : Math.ceil(refillRateMs / 1000);
+  const reset = Math.ceil((now + (maxTokens - remaining) * refillRateMs) / 1000);
+
+  return { allowed, remaining, retryAfter, reset };
+}
+
+// ── CL.THROTTLE via Redis ──────────────────────────────────────────────────────
+
+/**
+ * Issue a CL.THROTTLE command and return a normalised result object.
+ *
+ * @param {import('redis').RedisClientType} redis
+ * @param {string} key
+ * @param {number} maxBurst        – burst - 1
+ * @param {number} countPerPeriod  – rpm
+ * @param {number} periodSeconds   – 60
+ * @returns {Promise<{ allowed: boolean, limit: number, remaining: number, retryAfter: number, reset: number }>}
+ */
+async function clThrottle(redis, key, maxBurst, countPerPeriod, periodSeconds) {
+  // CL.THROTTLE key max_burst count_per_period period_seconds [quantity]
+  const result = await redis.sendCommand([
+    'CL.THROTTLE',
+    key,
+    String(maxBurst),
+    String(countPerPeriod),
+    String(periodSeconds),
+    '1',
+  ]);
+
+  // result: [allowed(0=yes,1=no), limit, remaining, retryAfter, resetAfter]
+  const [limitedFlag, limit, remaining, retryAfterSecs, resetAfterSecs] = result;
+
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    allowed: limitedFlag === 0,
+    limit: Number(limit),
+    remaining: Number(remaining),
+    retryAfter: Number(retryAfterSecs),
+    reset: now + Number(resetAfterSecs),
+  };
+}
+
+// ── Middleware ─────────────────────────────────────────────────────────────────
+
+/**
+ * Express middleware that enforces per-client, per-endpoint-group token bucket
+ * rate limiting.
+ *
+ * Reads `req.rateContext` (populated by apiKeyAuthenticator) for:
+ *   - clientId  {string}       – unique client identifier
+ *   - tier      {string}       – tier name
+ *   - rateLimit {number|null}  – per-key rpm override
+ *
+ * Sets `req.rateLimitState` for the downstream header writer:
+ *   { limit, remaining, reset, tier }
+ *
+ * Returns 429 with `Retry-After` header when the bucket is exhausted.
+ *
+ * @type {import('express').RequestHandler}
+ */
+async function tokenBucketMiddleware(req, res, next) {
+  try {
+    // Ensure rateContext is present (apiKeyAuthenticator should always set it,
+    // but guard defensively).
+    const rateContext = req.rateContext ?? {
+      clientId: 'unknown',
+      tier: 'unauthenticated',
+      rateLimit: null,
+    };
+
+    const { clientId, tier, rateLimit: overrideRpm } = rateContext;
+    const endpointGroup = resolveEndpointGroup(req.path);
+    const { rpm, burst } = getTierLimits(endpointGroup, tier, overrideRpm);
+
+    // Compose the Redis key.
+    const redisKey = `${RL_PREFIX}:${clientId}:${endpointGroup}`;
+
+    // ── Try Redis CL.THROTTLE ──────────────────────────────────────────────
+    let result = null;
+    let usedFallback = false;
+
+    try {
+      const redis = await getRedisClient();
+
+      if (redis?.isReady) {
+        const maxBurst = burst - 1; // CL.THROTTLE max_burst = total extra tokens
+        result = await clThrottle(redis, redisKey, maxBurst, rpm, 60);
+      } else {
+        usedFallback = true;
+      }
+    } catch (redisErr) {
+      console.warn('[tokenBucket] Redis CL.THROTTLE failed, using in-process fallback:', redisErr.message);
+      usedFallback = true;
+    }
+
+    if (usedFallback) {
+      const fallback = fallbackConsume(`${clientId}:${endpointGroup}`, rpm, burst);
+      result = {
+        allowed: fallback.allowed,
+        limit: burst,
+        remaining: fallback.remaining,
+        retryAfter: fallback.retryAfter,
+        reset: fallback.reset,
+      };
+    }
+
+    // ── Attach rateLimitState for header writer ────────────────────────────
+    req.rateLimitState = {
+      limit: result.limit,
+      remaining: result.remaining,
+      reset: result.reset,
+      tier,
+    };
+
+    // ── Enforce the limit ──────────────────────────────────────────────────
+    if (!result.allowed) {
+      res.set('Retry-After', String(result.retryAfter));
+      return res.status(429).json({ error: 'Too many requests' });
+    }
+
+    return next();
+  } catch (err) {
+    console.error('[tokenBucket] Unexpected error:', err);
+    // Fail open — do not block the request on an unexpected internal error.
+    return next();
+  }
+}
+
+export { tokenBucketMiddleware, getRedisClient, fallbackConsume, clThrottle };

--- a/indexer/src/routes/admin.js
+++ b/indexer/src/routes/admin.js
@@ -1,48 +1,109 @@
-import { db } from "../db.js";
-import { runAllChecks } from "../doctor-lib.js";
+/**
+ * Admin Routes
+ *
+ * Mounts all admin-gated routes under `/api/admin/` using adminAuthMiddleware.
+ * Also preserves the existing non-auth admin utility routes (health, doctor,
+ * db-init, export) that were previously registered directly on the app.
+ *
+ * Admin API key management routes:
+ *   GET    /api/admin/api-keys              — paginated list (no key_hash)
+ *   POST   /api/admin/api-keys              — create key, return raw key once
+ *   PATCH  /api/admin/api-keys/:id          — update metadata
+ *   DELETE /api/admin/api-keys/:id          — soft delete
+ *   POST   /api/admin/api-keys/:id/rotate   — rotate key
+ *   GET    /api/admin/api-keys/:id/usage    — usage history
+ *
+ * Audit log routes:
+ *   GET    /api/admin/audit-log             — filtered, paginated
+ *   GET    /api/admin/audit-log/export      — CSV or JSON export
+ */
+
+import { Router } from 'express';
+import { adminAuthMiddleware } from '../admin/adminAuth.js';
+import {
+  listKeys,
+  createKey,
+  updateKey,
+  deleteKey,
+  rotateKey,
+  getKeyUsage,
+} from '../admin/keyManager.js';
+import { getRedisClient } from '../rateLimit/tokenBucket.js';
+import { db, pool } from '../db.js';
+import { runAllChecks } from '../doctor-lib.js';
+
+// ── CSV helpers ───────────────────────────────────────────────────────────────
+
+const AUDIT_LOG_COLUMNS = [
+  'id',
+  'timestamp',
+  'api_key_id',
+  'key_name',
+  'tier',
+  'ip',
+  'method',
+  'endpoint',
+  'status_code',
+  'response_time_ms',
+  'rate_limit_remaining',
+  'user_agent',
+];
 
 const EVENT_COLUMNS = [
-  "seq",
-  "contract_id",
-  "function",
-  "ledger",
-  "tx_hash",
-  "description",
-  "cpu_instructions",
-  "mem_bytes",
-  "fee_charged",
-  "is_clawback",
-  "is_high_bloat_risk",
+  'seq',
+  'contract_id',
+  'function',
+  'ledger',
+  'tx_hash',
+  'description',
+  'cpu_instructions',
+  'mem_bytes',
+  'fee_charged',
+  'is_clawback',
+  'is_high_bloat_risk',
 ];
 
 const CONTRACT_COLUMNS = [
-  "id",
-  "name",
-  "description",
-  "registered_by",
-  "has_circuit_breaker",
-  "is_paused",
-  "is_rwa",
-  "rwa_type",
-  "created_at",
+  'id',
+  'name',
+  'description',
+  'registered_by',
+  'has_circuit_breaker',
+  'is_paused',
+  'is_rwa',
+  'rwa_type',
+  'created_at',
 ];
 
 function rowsToCsv(rows, columns) {
-  if (!rows.length) return columns.join(",") + "\n";
+  if (!rows.length) return columns.join(',') + '\n';
   const escape = (v) => {
-    if (v == null) return "";
+    if (v == null) return '';
     const s = String(v);
-    return s.includes(",") || s.includes('"') || s.includes("\n") ? `"${s.replace(/"/g, '""')}"` : s;
+    return s.includes(',') || s.includes('"') || s.includes('\n')
+      ? `"${s.replace(/"/g, '""')}"`
+      : s;
   };
-  const header = columns.join(",");
-  const body = rows.map((r) => columns.map((c) => escape(r[c])).join(",")).join("\n");
-  return header + "\n" + body + "\n";
+  const header = columns.join(',');
+  const body = rows.map((r) => columns.map((c) => escape(r[c])).join(',')).join('\n');
+  return header + '\n' + body + '\n';
 }
 
-export default function (app) {
-  app.get("/health", (_req, res) => res.json({ status: "ok" }));
+// ── Router factory ────────────────────────────────────────────────────────────
 
-  app.get("/api/doctor", async (_req, res) => {
+/**
+ * Returns an Express Router with all admin routes.
+ * Also registers legacy utility routes on `app` directly (backwards compat).
+ *
+ * @param {import('express').Express} app  — the Express app instance
+ * @returns {import('express').Router}
+ */
+export default function registerAdminRoutes(app) {
+  // ── Legacy utility routes (no auth) ───────────────────────────────────────
+  // These existed before the auth system and are preserved for compatibility.
+  app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+
+  app.get('/api/doctor', async (_req, res) => {
     try {
       const checks = await runAllChecks();
       res.json(checks);
@@ -51,10 +112,10 @@ export default function (app) {
     }
   });
 
-  app.post("/api/setup/db-init", async (req, res) => {
+  app.post('/api/setup/db-init', async (req, res) => {
     try {
       await db.init();
-      const { seed } = await import("../seed-lib.js");
+      const { seed } = await import('../seed-lib.js');
       await seed(process.env.DATABASE_URL);
       res.json({ success: true });
     } catch (e) {
@@ -62,9 +123,9 @@ export default function (app) {
     }
   });
 
-  app.get("/api/export/events", async (req, res) => {
+  app.get('/api/export/events', async (req, res) => {
     try {
-      const format = req.query.format === "json" ? "json" : "csv";
+      const format = req.query.format === 'json' ? 'json' : 'csv';
       const limit = Math.min(Number(req.query.limit) || 10000, 10000);
       const rows = await db.getEventsForExport({
         contract: req.query.contract,
@@ -72,33 +133,354 @@ export default function (app) {
         type: req.query.type,
         limit,
       });
-      if (format === "json") {
-        res.setHeader("Content-Disposition", 'attachment; filename="events.json"');
-        res.setHeader("Content-Type", "application/json");
+      if (format === 'json') {
+        res.setHeader('Content-Disposition', 'attachment; filename="events.json"');
+        res.setHeader('Content-Type', 'application/json');
         return res.json(rows);
       }
-      res.setHeader("Content-Disposition", 'attachment; filename="events.csv"');
-      res.setHeader("Content-Type", "text/csv");
+      res.setHeader('Content-Disposition', 'attachment; filename="events.csv"');
+      res.setHeader('Content-Type', 'text/csv');
       return res.send(rowsToCsv(rows, EVENT_COLUMNS));
     } catch (e) {
       res.status(500).json({ error: e.message });
     }
   });
 
-  app.get("/api/export/contracts", async (req, res) => {
+  app.get('/api/export/contracts', async (req, res) => {
     try {
-      const format = req.query.format === "json" ? "json" : "csv";
+      const format = req.query.format === 'json' ? 'json' : 'csv';
       const rows = await db.getContractsForExport();
-      if (format === "json") {
-        res.setHeader("Content-Disposition", 'attachment; filename="contracts.json"');
-        res.setHeader("Content-Type", "application/json");
+      if (format === 'json') {
+        res.setHeader('Content-Disposition', 'attachment; filename="contracts.json"');
+        res.setHeader('Content-Type', 'application/json');
         return res.json(rows);
       }
-      res.setHeader("Content-Disposition", 'attachment; filename="contracts.csv"');
-      res.setHeader("Content-Type", "text/csv");
+      res.setHeader('Content-Disposition', 'attachment; filename="contracts.csv"');
+      res.setHeader('Content-Type', 'text/csv');
       return res.send(rowsToCsv(rows, CONTRACT_COLUMNS));
     } catch (e) {
       res.status(500).json({ error: e.message });
     }
   });
+
+  // ── Auth-gated admin router ────────────────────────────────────────────────
+  const router = Router();
+
+  // Apply admin auth to all routes on this router.
+  router.use(adminAuthMiddleware);
+
+  // ── GET /api/admin/api-keys ────────────────────────────────────────────────
+  router.get('/api-keys', async (req, res) => {
+    try {
+      const page = Number(req.query.page) || 1;
+      const limit = Number(req.query.limit) || 50;
+      const result = await listKeys(page, limit);
+      res.json(result);
+    } catch (e) {
+      res.status(500).json({ error: e.message });
+    }
+  });
+
+  // ── POST /api/admin/api-keys ───────────────────────────────────────────────
+  router.post('/api-keys', async (req, res) => {
+    try {
+      const result = await createKey(req.body);
+      res.status(201).json(result);
+    } catch (e) {
+      const status = e.message.includes('required') || e.message.includes('must be') ? 400 : 500;
+      res.status(status).json({ error: e.message });
+    }
+  });
+
+  // ── PATCH /api/admin/api-keys/:id ─────────────────────────────────────────
+  router.patch('/api-keys/:id', async (req, res) => {
+    try {
+      const record = await updateKey(req.params.id, req.body);
+      res.json(record);
+    } catch (e) {
+      if (e.message.includes('not found')) return res.status(404).json({ error: e.message });
+      const status = e.message.includes('required') || e.message.includes('must be') || e.message.includes('No updatable') ? 400 : 500;
+      res.status(status).json({ error: e.message });
+    }
+  });
+
+  // ── DELETE /api/admin/api-keys/:id ────────────────────────────────────────
+  router.delete('/api-keys/:id', async (req, res) => {
+    try {
+      await deleteKey(req.params.id);
+      res.status(204).end();
+    } catch (e) {
+      if (e.message.includes('not found')) return res.status(404).json({ error: e.message });
+      res.status(500).json({ error: e.message });
+    }
+  });
+
+  // ── POST /api/admin/api-keys/:id/rotate ───────────────────────────────────
+  router.post('/api-keys/:id/rotate', async (req, res) => {
+    try {
+      const result = await rotateKey(req.params.id);
+      res.json(result);
+    } catch (e) {
+      if (e.message.includes('not found')) return res.status(404).json({ error: e.message });
+      res.status(500).json({ error: e.message });
+    }
+  });
+
+  // ── GET /api/admin/api-keys/:id/usage ─────────────────────────────────────
+  router.get('/api-keys/:id/usage', async (req, res) => {
+    try {
+      const days = Number(req.query.days) || 30;
+      const usage = await getKeyUsage(req.params.id, days);
+      res.json(usage);
+    } catch (e) {
+      res.status(500).json({ error: e.message });
+    }
+  });
+
+  // ── GET /api/admin/audit-log ───────────────────────────────────────────────
+  router.get('/audit-log', async (req, res) => {
+    try {
+      const {
+        api_key_id,
+        ip,
+        endpoint,
+        status_code,
+        from: fromTs,
+        to: toTs,
+        limit: limitParam = '100',
+        offset: offsetParam = '0',
+      } = req.query;
+
+      const limit = Math.min(Number(limitParam) || 100, 1000);
+      const offset = Math.max(0, Number(offsetParam) || 0);
+
+      const conditions = [];
+      const params = [];
+
+      if (api_key_id) {
+        params.push(api_key_id);
+        conditions.push(`api_key_id = $${params.length}`);
+      }
+      if (ip) {
+        params.push(ip);
+        conditions.push(`ip = $${params.length}::INET`);
+      }
+      if (endpoint) {
+        params.push(endpoint);
+        conditions.push(`endpoint = $${params.length}`);
+      }
+      if (status_code) {
+        params.push(Number(status_code));
+        conditions.push(`status_code = $${params.length}`);
+      }
+      if (fromTs) {
+        params.push(fromTs);
+        conditions.push(`timestamp >= $${params.length}`);
+      }
+      if (toTs) {
+        params.push(toTs);
+        conditions.push(`timestamp <= $${params.length}`);
+      }
+
+      const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+      params.push(limit, offset);
+
+      const { rows } = await pool.query(
+        `SELECT id, timestamp, api_key_id, key_name, tier, ip, method,
+                endpoint, status_code, response_time_ms, rate_limit_remaining, user_agent
+         FROM api_audit_log
+         ${where}
+         ORDER BY timestamp DESC
+         LIMIT $${params.length - 1} OFFSET $${params.length}`,
+        params,
+      );
+
+      res.json({ data: rows, limit, offset });
+    } catch (e) {
+      res.status(500).json({ error: e.message });
+    }
+  });
+
+  // ── GET /api/admin/audit-log/export ───────────────────────────────────────
+  router.get('/audit-log/export', async (req, res) => {
+    try {
+      const {
+        api_key_id,
+        ip,
+        endpoint,
+        status_code,
+        from: fromTs,
+        to: toTs,
+        limit: limitParam = '1000',
+        offset: offsetParam = '0',
+        format = 'json',
+      } = req.query;
+
+      const limit = Math.min(Number(limitParam) || 1000, 1000);
+      const offset = Math.max(0, Number(offsetParam) || 0);
+
+      const conditions = [];
+      const params = [];
+
+      if (api_key_id) {
+        params.push(api_key_id);
+        conditions.push(`api_key_id = $${params.length}`);
+      }
+      if (ip) {
+        params.push(ip);
+        conditions.push(`ip = $${params.length}::INET`);
+      }
+      if (endpoint) {
+        params.push(endpoint);
+        conditions.push(`endpoint = $${params.length}`);
+      }
+      if (status_code) {
+        params.push(Number(status_code));
+        conditions.push(`status_code = $${params.length}`);
+      }
+      if (fromTs) {
+        params.push(fromTs);
+        conditions.push(`timestamp >= $${params.length}`);
+      }
+      if (toTs) {
+        params.push(toTs);
+        conditions.push(`timestamp <= $${params.length}`);
+      }
+
+      const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+      params.push(limit, offset);
+
+      const { rows } = await pool.query(
+        `SELECT id, timestamp, api_key_id, key_name, tier, ip, method,
+                endpoint, status_code, response_time_ms, rate_limit_remaining, user_agent
+         FROM api_audit_log
+         ${where}
+         ORDER BY timestamp DESC
+         LIMIT $${params.length - 1} OFFSET $${params.length}`,
+        params,
+      );
+
+      if (format === 'csv') {
+        res.setHeader('Content-Disposition', 'attachment; filename="audit-log.csv"');
+        res.setHeader('Content-Type', 'text/csv');
+        return res.send(rowsToCsv(rows, AUDIT_LOG_COLUMNS));
+      }
+
+      res.setHeader('Content-Disposition', 'attachment; filename="audit-log.json"');
+      res.setHeader('Content-Type', 'application/json');
+      return res.json(rows);
+    } catch (e) {
+      res.status(500).json({ error: e.message });
+    }
+  });
+
+  // ── GET /api/admin/analytics/rate-limit-hits ──────────────────────────────
+  router.get('/analytics/rate-limit-hits', async (req, res) => {
+    try {
+      const minutes = Math.min(Number(req.query.minutes) || 60, 1440);
+      const { rows } = await pool.query(
+        `SELECT date_trunc('minute', timestamp) AS minute,
+                COUNT(*) AS hits
+         FROM api_audit_log
+         WHERE status_code = 429
+           AND timestamp >= NOW() - INTERVAL '1 minute' * $1
+         GROUP BY 1
+         ORDER BY 1 ASC`,
+        [minutes],
+      );
+      res.json(rows);
+    } catch (e) {
+      res.status(500).json({ error: e.message });
+    }
+  });
+
+  // ── GET /api/admin/analytics/top-users ────────────────────────────────────
+  router.get('/analytics/top-users', async (req, res) => {
+    try {
+      const window = req.query.window === '7d' ? 7 : req.query.window === '24h' ? 1 : req.query.window === '1h' ? null : 1;
+      let rows;
+      if (window === null) {
+        // 1 hour window — use audit log
+        ({ rows } = await pool.query(
+          `SELECT api_key_id, key_name, COUNT(*) AS total_requests
+           FROM api_audit_log
+           WHERE timestamp >= NOW() - INTERVAL '1 hour'
+             AND api_key_id IS NOT NULL
+           GROUP BY api_key_id, key_name
+           ORDER BY total_requests DESC
+           LIMIT 20`,
+        ));
+      } else {
+        ({ rows } = await pool.query(
+          `SELECT u.api_key_id, k.name AS key_name, SUM(u.total_requests) AS total_requests
+           FROM api_key_usage_daily u
+           JOIN api_keys k ON k.id = u.api_key_id
+           WHERE u.date >= CURRENT_DATE - INTERVAL '1 day' * $1
+           GROUP BY u.api_key_id, k.name
+           ORDER BY total_requests DESC
+           LIMIT 20`,
+          [window],
+        ));
+      }
+      res.json(rows);
+    } catch (e) {
+      res.status(500).json({ error: e.message });
+    }
+  });
+
+  // ── GET /api/admin/analytics/violation-heatmap ────────────────────────────
+  router.get('/analytics/violation-heatmap', async (req, res) => {
+    try {
+      const { rows } = await pool.query(
+        `SELECT EXTRACT(HOUR FROM timestamp)::INT AS hour,
+                EXTRACT(DOW FROM timestamp)::INT AS day_of_week,
+                COUNT(*) AS violations
+         FROM api_audit_log
+         WHERE status_code = 429
+           AND timestamp >= NOW() - INTERVAL '30 days'
+         GROUP BY 1, 2
+         ORDER BY 2, 1`,
+      );
+      res.json(rows);
+    } catch (e) {
+      res.status(500).json({ error: e.message });
+    }
+  });
+
+  // ── GET /api/admin/analytics/upgrade-recommendations ─────────────────────
+  router.get('/analytics/upgrade-recommendations', async (req, res) => {
+    try {
+      const { rows } = await pool.query(
+        `SELECT k.id, k.name, k.tier,
+                AVG(u.total_requests) AS avg_daily_requests,
+                CASE k.tier
+                  WHEN 'unauthenticated' THEN 60 * 60 * 24
+                  WHEN 'free'            THEN 1000 * 60 * 24
+                  WHEN 'pro'             THEN 10000 * 60 * 24
+                  ELSE NULL
+                END AS daily_tier_limit
+         FROM api_key_usage_daily u
+         JOIN api_keys k ON k.id = u.api_key_id
+         WHERE u.date >= CURRENT_DATE - INTERVAL '7 days'
+           AND k.revoked = FALSE
+         GROUP BY k.id, k.name, k.tier
+         HAVING
+           CASE k.tier
+             WHEN 'unauthenticated' THEN AVG(u.total_requests) > 0.8 * (60 * 60 * 24)
+             WHEN 'free'            THEN AVG(u.total_requests) > 0.8 * (1000 * 60 * 24)
+             WHEN 'pro'             THEN AVG(u.total_requests) > 0.8 * (10000 * 60 * 24)
+             ELSE FALSE
+           END
+         ORDER BY avg_daily_requests DESC`,
+      );
+      res.json(rows);
+    } catch (e) {
+      res.status(500).json({ error: e.message });
+    }
+  });
+
+  // Mount the router under /api/admin
+  app.use('/api/admin', router);
+
+  return router;
 }

--- a/indexer/src/usage/usageTracker.js
+++ b/indexer/src/usage/usageTracker.js
@@ -1,0 +1,223 @@
+/**
+ * Usage Tracker
+ *
+ * Increments Redis counters for per-key daily metrics on each request and
+ * periodically flushes them to the `api_key_usage_daily` PostgreSQL table.
+ *
+ * Redis counter keys (all are plain string counters):
+ *   usage:{keyId}:{date}:total_requests
+ *   usage:{keyId}:{date}:data_transfer_bytes
+ *   usage:{keyId}:{date}:rate_limit_hits
+ *   usage:{keyId}:{date}:endpoint:{endpointGroup}
+ *
+ * Two cron jobs:
+ *   - Every minute: flush Redis counters → upsert into api_key_usage_daily
+ *   - Nightly:      delete rows older than the tier's retention window
+ *
+ * Retention periods (matching the design document):
+ *   free:        7 days
+ *   pro:         90 days
+ *   enterprise:  3 years (1095 days)
+ */
+
+import cron from 'node-cron';
+import { getRedisClient } from '../rateLimit/tokenBucket.js';
+import { pool } from '../db.js';
+import { resolveEndpointGroup } from '../rateLimit/endpointGroups.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Returns today's date as YYYY-MM-DD in UTC.
+ * @returns {string}
+ */
+function todayUtc() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+// ── recordRequest ─────────────────────────────────────────────────────────────
+
+/**
+ * Increment Redis usage counters for one request.
+ *
+ * Fire-and-forget — errors are logged but never propagate to the caller.
+ *
+ * @param {string|null} keyId         — api_keys.id (UUID), or null for unauthed
+ * @param {string}      endpoint      — req.path
+ * @param {number}      responseBytes — response body byte count
+ * @param {boolean}     isRateLimited — whether the request was rate-limited (429)
+ */
+async function recordRequest(keyId, endpoint, responseBytes, isRateLimited) {
+  if (!keyId) return; // Do not track unauthenticated requests in per-key counters.
+
+  try {
+    const redis = await getRedisClient();
+    if (!redis?.isReady) return;
+
+    const date = todayUtc();
+    const endpointGroup = resolveEndpointGroup(endpoint);
+    const base = `usage:${keyId}:${date}`;
+
+    // Use a pipeline for efficiency.
+    const pipeline = redis.multi();
+    pipeline.incr(`${base}:total_requests`);
+    pipeline.incrBy(`${base}:data_transfer_bytes`, Math.max(0, Math.floor(responseBytes) || 0));
+    if (isRateLimited) {
+      pipeline.incr(`${base}:rate_limit_hits`);
+    }
+    pipeline.incr(`${base}:endpoint:${endpointGroup}`);
+    await pipeline.exec();
+  } catch (err) {
+    console.warn('[usageTracker] Failed to record request in Redis:', err.message);
+  }
+}
+
+// ── startUsageFlushCron ───────────────────────────────────────────────────────
+
+/**
+ * Start a cron job that runs every minute, scanning Redis for usage:{*} keys,
+ * aggregating them per (keyId, date), upserting into api_key_usage_daily,
+ * then deleting the processed Redis keys.
+ *
+ * @returns {cron.ScheduledTask}
+ */
+function startUsageFlushCron() {
+  return cron.schedule('* * * * *', async () => {
+    try {
+      const redis = await getRedisClient();
+      if (!redis?.isReady) return;
+
+      // Scan for all usage keys. SCAN is preferred over KEYS in production.
+      const usageKeys = [];
+      let cursor = 0;
+      do {
+        const result = await redis.scan(cursor, { MATCH: 'usage:*', COUNT: 200 });
+        cursor = result.cursor;
+        usageKeys.push(...result.keys);
+      } while (cursor !== 0);
+
+      if (usageKeys.length === 0) return;
+
+      // Group keys by (keyId, date).
+      // Key format: usage:{keyId}:{date}:{metric} or usage:{keyId}:{date}:endpoint:{group}
+      const buckets = new Map(); // key: `${keyId}:${date}` → { keyId, date, keys: [] }
+
+      for (const k of usageKeys) {
+        const parts = k.split(':');
+        // parts[0] = 'usage', parts[1] = keyId, parts[2] = date, parts[3+] = metric
+        if (parts.length < 4) continue;
+        const keyId = parts[1];
+        const date = parts[2];
+        const bucketKey = `${keyId}:${date}`;
+
+        if (!buckets.has(bucketKey)) {
+          buckets.set(bucketKey, { keyId, date, keys: [] });
+        }
+        buckets.get(bucketKey).keys.push(k);
+      }
+
+      // For each bucket, read all counters and upsert.
+      for (const [, bucket] of buckets) {
+        const { keyId, date, keys } = bucket;
+
+        // Fetch all values in one pipeline.
+        const pipeline = redis.multi();
+        for (const k of keys) pipeline.get(k);
+        const values = await pipeline.exec();
+
+        const keyValues = Object.fromEntries(keys.map((k, i) => [k, Number(values[i]) || 0]));
+
+        const base = `usage:${keyId}:${date}`;
+        const totalRequests = keyValues[`${base}:total_requests`] || 0;
+        const dataTransferBytes = keyValues[`${base}:data_transfer_bytes`] || 0;
+        const rateLimitHits = keyValues[`${base}:rate_limit_hits`] || 0;
+        const datTransferMb = dataTransferBytes / (1024 * 1024);
+
+        // Collect endpoint distribution.
+        const endpointDist = {};
+        for (const k of keys) {
+          const match = k.match(/^usage:[^:]+:[^:]+:endpoint:(.+)$/);
+          if (match) {
+            endpointDist[match[1]] = keyValues[k] || 0;
+          }
+        }
+
+        try {
+          await pool.query(
+            `INSERT INTO api_key_usage_daily
+               (api_key_id, date, total_requests, endpoint_distribution,
+                data_transfer_mb, rate_limit_hits)
+             VALUES ($1, $2, $3, $4, $5, $6)
+             ON CONFLICT (api_key_id, date) DO UPDATE SET
+               total_requests        = api_key_usage_daily.total_requests + EXCLUDED.total_requests,
+               endpoint_distribution = COALESCE(api_key_usage_daily.endpoint_distribution, '{}'::jsonb)
+                                       || EXCLUDED.endpoint_distribution,
+               data_transfer_mb      = api_key_usage_daily.data_transfer_mb + EXCLUDED.data_transfer_mb,
+               rate_limit_hits       = api_key_usage_daily.rate_limit_hits + EXCLUDED.rate_limit_hits`,
+            [keyId, date, totalRequests, JSON.stringify(endpointDist), datTransferMb, rateLimitHits],
+          );
+
+          // Only delete Redis keys after a successful DB write.
+          if (keys.length > 0) {
+            await redis.del(keys);
+          }
+        } catch (dbErr) {
+          console.error(`[usageTracker] DB upsert failed for key ${keyId}/${date}:`, dbErr.message);
+          // Leave Redis keys intact so the next run can retry.
+        }
+      }
+    } catch (err) {
+      console.error('[usageTracker] Flush cron error:', err.message);
+    }
+  });
+}
+
+// ── startRetentionCleanupCron ─────────────────────────────────────────────────
+
+/**
+ * Start a nightly cron job (runs at 02:00 UTC) that deletes usage rows older
+ * than the tier's retention window.
+ *
+ * Retention windows:
+ *   free:        7 days
+ *   pro:         90 days
+ *   enterprise:  1095 days (3 years)
+ *
+ * Unauthenticated tier records are cleaned up with the free policy.
+ *
+ * @returns {cron.ScheduledTask}
+ */
+function startRetentionCleanupCron() {
+  return cron.schedule('0 2 * * *', async () => {
+    try {
+      const retentionPolicies = [
+        { tier: 'free',         days: 7 },
+        { tier: 'unauthenticated', days: 7 },
+        { tier: 'pro',          days: 90 },
+        { tier: 'enterprise',   days: 1095 },
+      ];
+
+      for (const { tier, days } of retentionPolicies) {
+        try {
+          const { rowCount } = await pool.query(
+            `DELETE FROM api_key_usage_daily
+             WHERE api_key_id IN (
+               SELECT id FROM api_keys WHERE tier = $1
+             )
+             AND date < NOW() - INTERVAL '1 day' * $2`,
+            [tier, days],
+          );
+          if (rowCount > 0) {
+            console.log(`[usageTracker] Retention cleanup: deleted ${rowCount} rows for tier=${tier} (>${days}d)`);
+          }
+        } catch (tierErr) {
+          console.error(`[usageTracker] Retention cleanup failed for tier ${tier}:`, tierErr.message);
+        }
+      }
+    } catch (err) {
+      console.error('[usageTracker] Retention cron error:', err.message);
+    }
+  });
+}
+
+export { recordRequest, startUsageFlushCron, startRetentionCleanupCron };


### PR DESCRIPTION
Here's the PR message — copy and paste it on GitHub:

---

**Title:** `feat: API authentication and distributed rate limiting`

---

**Description:**

The REST API had no authentication or rate limiting, leaving it open to abuse and DDoS. This PR introduces a full production-grade auth and rate limiting system.

**What's in this PR:**

Rate limiting
- Redis-backed token bucket (CL.THROTTLE) with burst support across 4 tiers: unauthenticated (60 rpm), free (1k), pro (10k), enterprise (custom)
- Per-endpoint granular limits for `/api/events`, `/api/search`, `/api/contracts`, `/api/simulate`, and WebSocket connections
- Concurrent request limiting per key (HTTP + WebSocket) with Redis counters and safety-net TTLs
- GeoIP blocking and regional rate multipliers via MaxMind GeoLite2
- GraphQL query complexity limiting with per-tier cost budgets
- In-process fallback limiter when Redis is unavailable (fails open)

Auth & key management
- API key authenticator middleware with bcrypt verification and LRU cache (30s TTL, 1k entries)
- IP CIDR whitelisting and endpoint whitelisting per key
- Full CRUD admin API: create, list, update, soft-delete, rotate keys
- Timing-safe admin Bearer token auth

Abuse detection
- Auth brute-force: blocks IP after 10 failures in 60s
- Scraping: Jaccard URL similarity detection, reduces limit to 10% for 10 min
- DDoS: HyperLogLog distinct-IP detection with Cloudflare webhook integration
- Aggressive pagination: penalizes sequential page crawling
- Repeat offender: structured warning logs after 5 breaches in 10 min

Observability
- Async audit logging to partitioned `api_audit_log` (monthly partitions, auto-cleanup)
- Per-key daily usage tracking flushed to `api_key_usage_daily` via cron
- `X-RateLimit-Limit/Remaining/Reset/Tier` headers on every response
- Admin audit log search + CSV/JSON export endpoints

Billing
- Stripe webhook handler syncs `customer.subscription.updated/deleted` to key tiers

Dashboard
- New `/admin/rate-limits` page with real-time hits chart, top users table, violation heatmap, and tier upgrade recommendations (polls every 5s)

Migration
- `005_api_auth_rate_limiting.sql`: adds `api_keys`, `api_key_usage_daily`, `api_audit_log` with 18 monthly partitions

**Breaking changes:** None — all existing endpoints continue working without an API key under unauthenticated tier limits.

**Testing:** Set `ADMIN_SECRET`, `REDIS_URL`, and optionally `STRIPE_WEBHOOK_SECRET` in `.env`. See `.env.example` for all new variables.

closes #206 