### PR TITLE
feat(explorer): deregister, pause/unpause, auth tests, event cap

### DIFF
--- a/contracts/explorer/src/lib.rs
+++ b/contracts/explorer/src/lib.rs
@@ -13,6 +13,7 @@ pub enum Error {
     Unauthorized = 2,
     AlreadyExists = 3,
     BelowFloor = 4,
+    ContractPaused = 5,
 }
 
 // ── Storage keys ─────────────────────────────────────────────────────────────
@@ -23,6 +24,7 @@ pub enum DataKey {
     EventLog(u64),        // slot → DecodedEvent  (slot = seq % max_events)
     EventSeq,             // monotonic counter (never wraps)
     MaxEvents,            // u32 ring-buffer capacity
+    Paused,               // bool — contract pause flag (#264)
 }
 
 /// Minimum allowed value for max_events (prevents accidental data loss).
@@ -115,6 +117,9 @@ impl ExplorerContract {
         meta: ContractMeta,
     ) {
         caller.require_auth();
+        if env.storage().instance().get(&DataKey::Paused).unwrap_or(false) {
+            panic_with_error!(&env, Error::ContractPaused);
+        }
         let key = DataKey::Contract(contract_id.clone());
         if env.storage().persistent().has(&key) {
             panic_with_error!(&env, Error::AlreadyExists);
@@ -134,6 +139,9 @@ impl ExplorerContract {
     /// Update metadata (admin or original registrant only).
     pub fn update_contract(env: Env, caller: Address, contract_id: BytesN<32>, meta: ContractMeta) {
         caller.require_auth();
+        if env.storage().instance().get(&DataKey::Paused).unwrap_or(false) {
+            panic_with_error!(&env, Error::ContractPaused);
+        }
         let key = DataKey::Contract(contract_id.clone());
         let existing: ContractMeta = env
             .storage()
@@ -163,6 +171,29 @@ impl ExplorerContract {
             .unwrap_or_else(|| panic_with_error!(&env, Error::NotFound))
     }
 
+    /// Remove a contract from the registry. (#258)
+    /// Only the original registrant or admin may deregister.
+    pub fn deregister_contract(env: Env, caller: Address, contract_id: BytesN<32>) {
+        caller.require_auth();
+        if env.storage().instance().get(&DataKey::Paused).unwrap_or(false) {
+            panic_with_error!(&env, Error::ContractPaused);
+        }
+        let key = DataKey::Contract(contract_id.clone());
+        let existing: ContractMeta = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| panic_with_error!(&env, Error::NotFound));
+
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if caller != existing.registered_by && caller != admin {
+            panic_with_error!(&env, Error::Unauthorized);
+        }
+        env.storage().persistent().remove(&key);
+        env.events()
+            .publish((symbol_short!("deregist"), contract_id), caller);
+    }
+
     // ── Event cap management ──────────────────────────────────────────────────
 
     /// Admin-only: change the ring-buffer cap.  Floor: MIN_MAX_EVENTS.
@@ -190,6 +221,38 @@ impl ExplorerContract {
         (count, max)
     }
 
+    // ── Pause / unpause (#264) ────────────────────────────────────────────────
+
+    /// Admin-only: freeze all state-mutating operations.
+    pub fn pause(env: Env, caller: Address) {
+        caller.require_auth();
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if caller != admin {
+            panic_with_error!(&env, Error::Unauthorized);
+        }
+        env.storage().instance().set(&DataKey::Paused, &true);
+        env.events().publish((symbol_short!("paused"),), ());
+    }
+
+    /// Admin-only: unfreeze the contract.
+    pub fn unpause(env: Env, caller: Address) {
+        caller.require_auth();
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if caller != admin {
+            panic_with_error!(&env, Error::Unauthorized);
+        }
+        env.storage().instance().set(&DataKey::Paused, &false);
+        env.events().publish((symbol_short!("unpaused"),), ());
+    }
+
+    /// Return whether the contract is currently paused.
+    pub fn is_paused(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false)
+    }
+
     // ── Event Decoder ─────────────────────────────────────────────────────────
 
     /// Submit a decoded event (called by the off-chain indexer via a trusted tx).
@@ -199,6 +262,9 @@ impl ExplorerContract {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         if caller != admin {
             panic_with_error!(&env, Error::Unauthorized);
+        }
+        if env.storage().instance().get(&DataKey::Paused).unwrap_or(false) {
+            panic_with_error!(&env, Error::ContractPaused);
         }
 
         let seq: u64 = env

--- a/contracts/explorer/tests/auth_tests.rs
+++ b/contracts/explorer/tests/auth_tests.rs
@@ -211,3 +211,227 @@ fn test_set_max_events_non_admin() {
     }]);
     client.set_max_events(&stranger, &2000u32);
 }
+
+// ── #258: deregister_contract auth tests ─────────────────────────────────────
+
+// 8. deregister by registrant succeeds
+#[test]
+fn test_deregister_by_registrant() {
+    let (env, client, _admin) = setup_with_admin();
+    let registrant = Address::generate(&env);
+    let cid = BytesN::from_array(&env, &[10u8; 32]);
+    let meta = make_meta(&env, &registrant);
+
+    env.mock_auths(&[MockAuth {
+        address: &registrant,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "register_contract",
+            args: (registrant.clone(), cid.clone(), meta.clone()).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.register_contract(&registrant, &cid, &meta);
+
+    env.mock_auths(&[MockAuth {
+        address: &registrant,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "deregister_contract",
+            args: (registrant.clone(), cid.clone()).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.deregister_contract(&registrant, &cid);
+}
+
+// 9. deregister by admin succeeds
+#[test]
+fn test_deregister_by_admin() {
+    let (env, client, admin) = setup_with_admin();
+    let registrant = Address::generate(&env);
+    let cid = BytesN::from_array(&env, &[11u8; 32]);
+    let meta = make_meta(&env, &registrant);
+
+    env.mock_auths(&[MockAuth {
+        address: &registrant,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "register_contract",
+            args: (registrant.clone(), cid.clone(), meta.clone()).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.register_contract(&registrant, &cid, &meta);
+
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "deregister_contract",
+            args: (admin.clone(), cid.clone()).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.deregister_contract(&admin, &cid);
+}
+
+// 10. deregister by stranger → Unauthorized
+#[test]
+#[should_panic]
+fn test_deregister_by_stranger() {
+    let (env, client, _admin) = setup_with_admin();
+    let registrant = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    let cid = BytesN::from_array(&env, &[12u8; 32]);
+    let meta = make_meta(&env, &registrant);
+
+    env.mock_auths(&[MockAuth {
+        address: &registrant,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "register_contract",
+            args: (registrant.clone(), cid.clone(), meta.clone()).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.register_contract(&registrant, &cid, &meta);
+
+    env.mock_auths(&[MockAuth {
+        address: &stranger,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "deregister_contract",
+            args: (stranger.clone(), cid.clone()).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.deregister_contract(&stranger, &cid);
+}
+
+// ── #261: max_events cap auth tests ──────────────────────────────────────────
+
+// 11. init with custom cap is respected
+#[test]
+fn test_init_custom_cap() {
+    let env = Env::default();
+    let id = env.register_contract(None, soroban_explorer_contract::ExplorerContract);
+    let client = ExplorerContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    env.mock_all_auths();
+    client.init(&admin, &1000u32);
+    let (_, max) = client.storage_utilisation();
+    assert_eq!(max, 1000u32);
+}
+
+// ── #264: pause / unpause auth tests ─────────────────────────────────────────
+
+// 12. pause by non-admin → Unauthorized
+#[test]
+#[should_panic]
+fn test_pause_non_admin() {
+    let (env, client, _admin) = setup_with_admin();
+    let stranger = Address::generate(&env);
+    env.mock_auths(&[MockAuth {
+        address: &stranger,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "pause",
+            args: (stranger.clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.pause(&stranger);
+}
+
+// 13. unpause by non-admin → Unauthorized
+#[test]
+#[should_panic]
+fn test_unpause_non_admin() {
+    let (env, client, admin) = setup_with_admin();
+    // First pause as admin
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "pause",
+            args: (admin.clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.pause(&admin);
+
+    let stranger = Address::generate(&env);
+    env.mock_auths(&[MockAuth {
+        address: &stranger,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "unpause",
+            args: (stranger.clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.unpause(&stranger);
+}
+
+// 14. admin can pause and unpause
+#[test]
+fn test_admin_pause_unpause() {
+    let (env, client, admin) = setup_with_admin();
+    assert!(!client.is_paused());
+
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "pause",
+            args: (admin.clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.pause(&admin);
+    assert!(client.is_paused());
+
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "unpause",
+            args: (admin.clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.unpause(&admin);
+    assert!(!client.is_paused());
+}
+
+// 15. register_contract while paused → ContractPaused
+#[test]
+#[should_panic]
+fn test_register_while_paused() {
+    let (env, client, admin) = setup_with_admin();
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "pause",
+            args: (admin.clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.pause(&admin);
+
+    let registrant = Address::generate(&env);
+    let cid = BytesN::from_array(&env, &[20u8; 32]);
+    let meta = make_meta(&env, &registrant);
+    env.mock_auths(&[MockAuth {
+        address: &registrant,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "register_contract",
+            args: (registrant.clone(), cid.clone(), meta.clone()).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.register_contract(&registrant, &cid, &meta);
+}


### PR DESCRIPTION
## Summary

Resolves four open issues in the `ContractRegistry` and `ExplorerContract`:

### #258 — Contract deregistration
Added `deregister_contract(caller, contract_id)` restricted to the admin or the original registrant. Removes the entry from persistent storage and emits a `deregist` diagnostic event. Returns `Unauthorized` for any other caller.

### #260 — Auth rejection tests
Extended `tests/auth_tests.rs` with 8 new tests (tests 8–15) covering:
- Deregister by registrant (passes)
- Deregister by admin (passes)
- Deregister by stranger → `Unauthorized` (rejects)
- `init` with custom cap (verifies #261 cap stored correctly)
- `pause` by non-admin → `Unauthorized`
- `unpause` by non-admin → `Unauthorized`
- Admin pause/unpause round-trip
- `register_contract` while paused → `ContractPaused`

### #261 — Event count cap
`init(admin, max_events)` already merged in upstream (#632ba47). Added `test_init_custom_cap` to verify the configurable cap is stored at init time.

### #264 — Pause / unpause mechanism
Added `pause(caller)` / `unpause(caller)` admin-only functions with a new `ContractPaused(5)` error variant and `Paused` storage key. All state-mutating operations (`register_contract`, `update_contract`, `deregister_contract`, `submit_event`) check the flag and return `ContractPaused` when set. Added `is_paused()` read-only helper.

## Testing

All 28 tests pass (`cargo test -p soroban-explorer-contract`):
- 12 unit tests in `src/lib.rs`
- 15 auth tests in `tests/auth_tests.rs`
- 1 storage bench in `tests/storage_bench.rs`

Closes #258
Closes #260
Closes #261
Closes #264
