### PR TITLE
test: unit tests for heuristicParser, SAC wrap/unwrap, SEP-41 transfer, and TTL bump ops

### DIFF
--- a/indexer/src/decoder.js
+++ b/indexer/src/decoder.js
@@ -205,7 +205,7 @@ export async function decode(ev) {
  * mint on native SAC = Classic XLM → Soroban (wrap)
  * burn on native SAC = Soroban → Classic XLM (unwrap)
  */
-function nativeXlmDescription(fnName, args, data) {
+export function nativeXlmDescription(fnName, args, data) {
   if (fnName === "mint") {
     const [to, amount] = args;
     const amt = amount ?? data;
@@ -247,7 +247,14 @@ function vaultDescription(fn, args, data, contractName, vaultMeta) {
   }
 }
 
-function buildDescription(fn, args, data, contractName) {
+/**
+ * Build a human-readable description from decoded ABI-matched function arguments.
+ *
+ * SEP-41 transfer format:
+ *   "Address {short-from} transferred {amount} {token} to {short-to} on {contractName}"
+ * where short addresses are truncated to "AAAAAA…ZZZZ" (6 + 4 chars).
+ */
+export function buildDescription(fn, args, data, contractName) {
   switch (fn) {
     case "swap": {
       const [from, amtIn, tokenIn, amtOut, tokenOut] = args;

--- a/indexer/src/heuristicParser.js
+++ b/indexer/src/heuristicParser.js
@@ -71,3 +71,28 @@ export function parseHeuristic(params) {
     ...guessType(p),
   }));
 }
+
+/**
+ * Generate a human-readable fallback description for an event using heuristics.
+ * Always returns a non-empty string — never null, undefined, or ''.
+ *
+ * Intended as the last-resort fallback in the decoder when no ABI is registered
+ * and no known SAC/vault pattern matches.
+ *
+ * @param {object} ev  Event object with function, raw_topics, and raw_data fields
+ * @returns {string}  Non-empty description string
+ */
+export function heuristicParser(ev) {
+  const fn = String(ev?.function ?? ev?.fn ?? "") || "unknown";
+  const rawTopics = Array.isArray(ev?.raw_topics) ? ev.raw_topics : [];
+  // Skip index 0 — that slot holds the function-name topic itself
+  const params = rawTopics.slice(1);
+  const heuristic = parseHeuristic(params);
+
+  if (!heuristic.length) {
+    return `${fn}() [heuristic]`;
+  }
+
+  const paramStr = heuristic.map((p) => p.value).join(", ");
+  return `${fn}(${paramStr}) [heuristic]`;
+}

--- a/indexer/src/ttlExtensionParser.js
+++ b/indexer/src/ttlExtensionParser.js
@@ -116,3 +116,33 @@ export function calculateRentPaid(extensionOp) {
   if (!extensionOp || extensionOp.costXlm == null) return 0;
   return Math.round(extensionOp.costXlm * 10_000_000);
 }
+
+/**
+ * Scan a txMeta object (decoded TransactionMeta or plain JS shape) for any
+ * BumpFootprintExpiration / TTL extension operations.
+ *
+ * Returns { ttl_extended: true, ...parsed } when a bump op is found,
+ * or { ttl_extended: false } when the txMeta contains no bump op.
+ *
+ * @param {object|null} txMeta  Transaction metadata; may be null/undefined.
+ * @returns {{ ttl_extended: boolean, fn_name?: string, extend_to?: number|null, min_extension?: number|null, max_extension?: number|null }}
+ */
+export function parseTTLFromTxMeta(txMeta) {
+  if (!txMeta) return { ttl_extended: false };
+
+  const operations = Array.isArray(txMeta.operations) ? txMeta.operations : [];
+
+  for (const op of operations) {
+    const parsed = parseTTLHostFunction(op?.hostFunction ?? op?.host_function ?? op);
+    if (parsed) {
+      return { ttl_extended: true, ...parsed };
+    }
+    // Also handle raw XDR operation type names for BumpFootprintExpiration
+    const opType = op?.type ?? op?.operationType ?? "";
+    if (opType === "bumpFootprintExpiration" || opType === "BUMP_FOOTPRINT_EXPIRATION") {
+      return { ttl_extended: true };
+    }
+  }
+
+  return { ttl_extended: false };
+}

--- a/indexer/test/decoder.sep41.test.js
+++ b/indexer/test/decoder.sep41.test.js
@@ -1,0 +1,103 @@
+/**
+ * Unit tests: decoder.js SEP-41 transfer description format.
+ * Closes #418
+ *
+ * SEP-41 transfer description format (from buildDescription):
+ *   "Address {short-from} transferred {amount} {token} to {short-to} on {contractName}"
+ * where addresses are shortened to "AAAAAA…ZZZZ" (first 6 + last 4 chars).
+ *
+ * Test vectors use hardcoded known-good ScVal-decoded values that mirror what
+ * scValToNative() would return for a real on-chain SEP-41 transfer event.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { xdr, scValToNative } from "@stellar/stellar-sdk";
+import { buildDescription } from "../src/decoder.js";
+
+// ── Known-good XDR-derived test values ────────────────────────────────────────
+// These mirror what scValToNative() returns for a real SEP-41 transfer event.
+
+// Sender address — 56-char G-address (scvAddress → account)
+const FROM = "G" + "A".repeat(55);
+// Recipient address — 56-char G-address
+const TO = "G" + "B".repeat(55);
+// Token code (scvSymbol)
+const TOKEN = "USDC";
+// Contract display label
+const CONTRACT_LABEL = "USDC Token";
+
+// Amount decoded from scvI128 via scValToNative → bigint
+const AMOUNT_I128 = scValToNative(
+  xdr.ScVal.scvI128(
+    new xdr.Int128Parts({
+      hi: xdr.Int64.fromString("0"),
+      lo: xdr.Uint64.fromString("100000000"),
+    })
+  )
+);
+
+// ── SEP-41 transfer ──────────────────────────────────────────────────────────
+
+describe("decoder — SEP-41 transfer description", () => {
+  it("description contains the token symbol", () => {
+    const desc = buildDescription("transfer", [FROM, TO, AMOUNT_I128, TOKEN], null, CONTRACT_LABEL);
+    assert.ok(desc.includes(TOKEN), `expected "${TOKEN}" in "${desc}"`);
+  });
+
+  it("description contains the amount", () => {
+    const desc = buildDescription("transfer", [FROM, TO, AMOUNT_I128, TOKEN], null, CONTRACT_LABEL);
+    assert.ok(
+      desc.includes(String(AMOUNT_I128)),
+      `expected amount "${AMOUNT_I128}" in "${desc}"`
+    );
+  });
+
+  it("description contains the contract name", () => {
+    const desc = buildDescription("transfer", [FROM, TO, AMOUNT_I128, TOKEN], null, CONTRACT_LABEL);
+    assert.ok(desc.includes(CONTRACT_LABEL), `expected "${CONTRACT_LABEL}" in "${desc}"`);
+  });
+
+  it("description matches the documented format", () => {
+    // Full format: "Address {short-from} transferred {amount} {token} to {short-to} on {contractName}"
+    const desc = buildDescription("transfer", [FROM, TO, AMOUNT_I128, TOKEN], null, CONTRACT_LABEL);
+    assert.match(desc, /^Address .+ transferred .+ to .+ on .+$/);
+  });
+
+  it("description includes 'transferred' keyword", () => {
+    const desc = buildDescription("transfer", [FROM, TO, 100n, TOKEN], null, CONTRACT_LABEL);
+    assert.ok(desc.includes("transferred"), `expected "transferred" in "${desc}"`);
+  });
+
+  it("short addresses use head…tail format", () => {
+    const desc = buildDescription("transfer", [FROM, TO, 100n, TOKEN], null, CONTRACT_LABEL);
+    // FROM starts with "GAAA", first 6 chars = "GAAAAA", last 4 chars = "AAAA"
+    assert.ok(desc.includes("GAAAAA…AAAA"), `expected truncated from address in "${desc}"`);
+  });
+
+  it("description is never null or empty when token is omitted", () => {
+    const desc = buildDescription("transfer", [FROM, TO, 100n], null, CONTRACT_LABEL);
+    assert.equal(typeof desc, "string");
+    assert.ok(desc.length > 0);
+    assert.ok(desc.includes("transferred"));
+  });
+});
+
+// ── SEP-41 mint ──────────────────────────────────────────────────────────────
+
+describe("decoder — SEP-41 mint description", () => {
+  it("description contains minted keyword and token", () => {
+    const desc = buildDescription("mint", [TO, AMOUNT_I128, TOKEN], null, CONTRACT_LABEL);
+    assert.ok(desc.includes("minted"), `expected "minted" in "${desc}"`);
+    assert.ok(desc.includes(TOKEN));
+  });
+});
+
+// ── SEP-41 burn ──────────────────────────────────────────────────────────────
+
+describe("decoder — SEP-41 burn description", () => {
+  it("description contains burned keyword and token", () => {
+    const desc = buildDescription("burn", [FROM, AMOUNT_I128, TOKEN], null, CONTRACT_LABEL);
+    assert.ok(desc.includes("burned"), `expected "burned" in "${desc}"`);
+    assert.ok(desc.includes(TOKEN));
+  });
+});

--- a/indexer/test/heuristicParser.test.js
+++ b/indexer/test/heuristicParser.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { guessType, parseHeuristic } from "../src/heuristicParser.js";
+import { guessType, parseHeuristic, heuristicParser } from "../src/heuristicParser.js";
 
 // 64-char hex hash
 const HASH = "a".repeat(64);
@@ -88,5 +88,52 @@ describe("parseHeuristic", () => {
     assert.equal(results[2].type, "Amount");
     assert.equal(results[3].type, "Symbol");
     assert.equal(results[4].type, "Hash");
+  });
+});
+
+// Closes #420 — heuristicParser(ev) must never return null, undefined, or ''
+describe("heuristicParser — non-null fallback for unknown function names", () => {
+  const ADDR = "G" + "A".repeat(55);
+
+  it('returns a non-empty string for unknown function "foo_bar"', () => {
+    const ev = { function: "foo_bar", raw_topics: ["foo_bar", ADDR] };
+    const result = heuristicParser(ev);
+    assert.equal(typeof result, "string");
+    assert.ok(result.length > 0, "must not be empty string");
+    assert.notEqual(result, null);
+    assert.notEqual(result, undefined);
+  });
+
+  it('returns a non-empty string for unknown function "do_something_custom"', () => {
+    const ev = { function: "do_something_custom", raw_topics: ["do_something_custom", ADDR, "100"] };
+    const result = heuristicParser(ev);
+    assert.equal(typeof result, "string");
+    assert.ok(result.length > 0);
+  });
+
+  it('returns a non-empty string for unknown function "process_v2"', () => {
+    const ev = { function: "process_v2", raw_topics: ["process_v2"] };
+    const result = heuristicParser(ev);
+    assert.equal(typeof result, "string");
+    assert.ok(result.length > 0);
+  });
+
+  it("returns a non-empty string when function field is missing", () => {
+    const ev = { raw_topics: [] };
+    const result = heuristicParser(ev);
+    assert.equal(typeof result, "string");
+    assert.ok(result.length > 0);
+  });
+
+  it("returns a non-empty string for null input", () => {
+    const result = heuristicParser(null);
+    assert.equal(typeof result, "string");
+    assert.ok(result.length > 0);
+  });
+
+  it("description includes the function name when provided", () => {
+    const ev = { function: "stake_tokens", raw_topics: ["stake_tokens"] };
+    const result = heuristicParser(ev);
+    assert.ok(result.includes("stake_tokens"), `expected "stake_tokens" in "${result}"`);
   });
 });

--- a/indexer/test/sac.test.js
+++ b/indexer/test/sac.test.js
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for sac.js SAC detection and native XLM wrap/unwrap descriptions.
+ * Closes #419
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Asset, Contract, Networks } from "@stellar/stellar-sdk";
+import { detectSac, detectSacAsset, sacLabel } from "../src/sac.js";
+import { nativeXlmDescription } from "../src/decoder.js";
+
+// Derive the native XLM SAC contract ID for testnet (matches the default NETWORK_PASSPHRASE)
+const NATIVE_SAC_ID = new Contract(
+  Asset.native().contractId(Networks.TESTNET)
+).contractId();
+
+// Arbitrary Stellar account address (56 chars, G-prefix)
+const USER_ADDR = "G" + "A".repeat(55);
+
+// ── SAC detection ─────────────────────────────────────────────────────────────
+
+describe("detectSac — native XLM", () => {
+  it("recognises the native XLM SAC contract ID", () => {
+    const { isSac, assetCode } = detectSac(NATIVE_SAC_ID);
+    assert.equal(isSac, true);
+    assert.equal(assetCode, "XLM");
+  });
+
+  it("returns isSac: false for an unknown contract", () => {
+    const { isSac } = detectSac("C" + "B".repeat(55));
+    assert.equal(isSac, false);
+  });
+});
+
+describe("detectSacAsset — native XLM", () => {
+  it("returns assetCode XLM and null issuer for native SAC", () => {
+    const result = detectSacAsset(NATIVE_SAC_ID);
+    assert.equal(result.isSac, true);
+    assert.equal(result.assetCode, "XLM");
+    assert.equal(result.assetIssuer, null);
+  });
+});
+
+describe("sacLabel — native XLM", () => {
+  it("returns XLM for native SAC contract ID", () => {
+    assert.equal(sacLabel(NATIVE_SAC_ID), "XLM");
+  });
+
+  it("falls back to the contract ID for unknown contracts", () => {
+    const unknown = "C" + "Z".repeat(55);
+    assert.equal(sacLabel(unknown), unknown);
+  });
+});
+
+// ── Native XLM wrap / unwrap descriptions ────────────────────────────────────
+// nativeXlmDescription() in decoder.js is invoked when the SAC contract ID is
+// the native XLM SAC and the function name is "mint" (wrap) or "burn" (unwrap).
+
+describe("nativeXlmDescription — wrap (mint on native SAC)", () => {
+  // 10_000_000 stroops = 1 XLM
+  const AMOUNT = 10_000_000;
+
+  it("produces a description that contains XLM", () => {
+    const result = nativeXlmDescription("mint", [USER_ADDR, AMOUNT], null);
+    assert.ok(result !== null);
+    assert.ok(result.description.includes("XLM"), `expected XLM in "${result.description}"`);
+  });
+
+  it("produces a description that contains the formatted amount", () => {
+    const result = nativeXlmDescription("mint", [USER_ADDR, AMOUNT], null);
+    // 10_000_000 stroops → "1" XLM (fmtXlm divides by 1e7)
+    assert.ok(result.description.includes("1"), `expected amount "1" in "${result.description}"`);
+  });
+
+  it("sets function to wrap_native", () => {
+    const result = nativeXlmDescription("mint", [USER_ADDR, AMOUNT], null);
+    assert.equal(result.function, "wrap_native");
+  });
+
+  it("description mentions Classic → Soroban direction", () => {
+    const result = nativeXlmDescription("mint", [USER_ADDR, AMOUNT], null);
+    assert.ok(result.description.includes("Classic"), `expected "Classic" in "${result.description}"`);
+    assert.ok(result.description.includes("Soroban"), `expected "Soroban" in "${result.description}"`);
+  });
+});
+
+describe("nativeXlmDescription — unwrap (burn on native SAC)", () => {
+  const AMOUNT = 50_000_000; // 5 XLM
+
+  it("produces a description that contains XLM", () => {
+    const result = nativeXlmDescription("burn", [USER_ADDR, AMOUNT], null);
+    assert.ok(result !== null);
+    assert.ok(result.description.includes("XLM"), `expected XLM in "${result.description}"`);
+  });
+
+  it("produces a description that contains the formatted amount", () => {
+    const result = nativeXlmDescription("burn", [USER_ADDR, AMOUNT], null);
+    // 50_000_000 stroops → "5" XLM
+    assert.ok(result.description.includes("5"), `expected amount "5" in "${result.description}"`);
+  });
+
+  it("sets function to unwrap_native", () => {
+    const result = nativeXlmDescription("burn", [USER_ADDR, AMOUNT], null);
+    assert.equal(result.function, "unwrap_native");
+  });
+
+  it("description mentions Soroban → Classic direction", () => {
+    const result = nativeXlmDescription("burn", [USER_ADDR, AMOUNT], null);
+    assert.ok(result.description.includes("Soroban"), `expected "Soroban" in "${result.description}"`);
+    assert.ok(result.description.includes("Classic"), `expected "Classic" in "${result.description}"`);
+  });
+
+  it("returns null for non-wrap/unwrap function names", () => {
+    assert.equal(nativeXlmDescription("transfer", [USER_ADDR, AMOUNT], null), null);
+    assert.equal(nativeXlmDescription("approve", [], null), null);
+  });
+});

--- a/indexer/test/ttlExtensionParser.test.js
+++ b/indexer/test/ttlExtensionParser.test.js
@@ -3,13 +3,14 @@
  */
 
 import assert from "node:assert/strict";
-import test from "node:test";
+import test, { describe } from "node:test";
 import {
   parseTTLHostFunction,
   parseTTLExtension,
   extractTTLModifications,
   formatTTLExtension,
   calculateRentPaid,
+  parseTTLFromTxMeta,
 } from "../src/ttlExtensionParser.js";
 
 test("parseTTLHostFunction returns null for unsupported operations", () => {
@@ -135,4 +136,97 @@ test("calculateRentPaid converts XLM to stroops", () => {
 
 test("calculateRentPaid returns zero when no cost is present", () => {
   assert.equal(calculateRentPaid({}), 0);
+});
+
+// Closes #421 — parseTTLFromTxMeta correctly detects TTL bump ops in txMeta
+
+describe("parseTTLFromTxMeta — ttl_extended field", () => {
+  test("returns ttl_extended: true for extend_contract_instance_ttl op in txMeta", () => {
+    const txMeta = {
+      operations: [
+        {
+          function_name: "extend_contract_instance_ttl",
+          args: { extend_to: 500000, min_extension: 17280, max_extension: 34560 },
+        },
+      ],
+    };
+    const result = parseTTLFromTxMeta(txMeta);
+    assert.equal(result.ttl_extended, true);
+  });
+
+  test("returns ttl_extended: true for extend_contract_code_ttl op in txMeta", () => {
+    const txMeta = {
+      operations: [
+        {
+          function_name: "extend_contract_code_ttl",
+          args: { extend_to: 600000, min_extension: 8640, max_extension: 17280 },
+        },
+      ],
+    };
+    const result = parseTTLFromTxMeta(txMeta);
+    assert.equal(result.ttl_extended, true);
+  });
+
+  test("includes parsed fn_name and extend_to in the result", () => {
+    const txMeta = {
+      operations: [
+        {
+          function_name: "extend_contract_instance_ttl",
+          args: { extend_to: 500000, min_extension: 17280, max_extension: 34560 },
+        },
+      ],
+    };
+    const result = parseTTLFromTxMeta(txMeta);
+    assert.equal(result.fn_name, "extend_contract_instance_ttl");
+    assert.equal(result.extend_to, 500000);
+  });
+
+  test("returns ttl_extended: true for bumpFootprintExpiration op type", () => {
+    const txMeta = {
+      operations: [{ type: "bumpFootprintExpiration" }],
+    };
+    const result = parseTTLFromTxMeta(txMeta);
+    assert.equal(result.ttl_extended, true);
+  });
+
+  test("returns ttl_extended: true via nested hostFunction", () => {
+    const txMeta = {
+      operations: [
+        {
+          hostFunction: {
+            function_name: "extend_ttl",
+            args: { extend_to: 400000, min_extension: 5000, max_extension: 10000 },
+          },
+        },
+      ],
+    };
+    const result = parseTTLFromTxMeta(txMeta);
+    assert.equal(result.ttl_extended, true);
+  });
+
+  test("returns ttl_extended: false when txMeta has no bump op", () => {
+    const txMeta = {
+      operations: [
+        { type: "payment" },
+        { type: "createAccount" },
+      ],
+    };
+    const result = parseTTLFromTxMeta(txMeta);
+    assert.equal(result.ttl_extended, false);
+  });
+
+  test("returns ttl_extended: false for empty operations array", () => {
+    const result = parseTTLFromTxMeta({ operations: [] });
+    assert.equal(result.ttl_extended, false);
+  });
+
+  test("returns ttl_extended: false for null txMeta", () => {
+    const result = parseTTLFromTxMeta(null);
+    assert.equal(result.ttl_extended, false);
+  });
+
+  test("returns ttl_extended: false for undefined txMeta", () => {
+    const result = parseTTLFromTxMeta(undefined);
+    assert.equal(result.ttl_extended, false);
+  });
 });


### PR DESCRIPTION
## Summary

- **#420** — Add `heuristicParser(ev)` to `heuristicParser.js` that always returns a non-empty string fallback for events with unknown function names; 6 new assertions in `test/heuristicParser.test.js`
- **#419** — New `test/sac.test.js`: verify `detectSac` recognises native XLM SAC and `nativeXlmDescription` produces descriptions containing "XLM" and the formatted amount for both wrap and unwrap directions
- **#418** — Export `buildDescription` + `nativeXlmDescription` from `decoder.js`, document SEP-41 transfer description format in a comment; new `test/decoder.sep41.test.js` with hardcoded ScVal-derived test vectors
- **#421** — Add `parseTTLFromTxMeta(txMeta)` to `ttlExtensionParser.js` returning `{ ttl_extended: boolean }`; 9 new assertions in `test/ttlExtensionParser.test.js` covering bump ops, nested `hostFunction`, non-bump ops, and null/undefined input

## Test plan

- [ ] `node --test test/heuristicParser.test.js` — all existing + 6 new assertions pass
- [ ] `node --test test/sac.test.js` — wrap/unwrap and SAC detection assertions pass
- [ ] `node --test test/decoder.sep41.test.js` — SEP-41 transfer/mint/burn assertions pass
- [ ] `node --test test/ttlExtensionParser.test.js` — all existing + 9 new assertions pass

Closes #418
Closes #419
Closes #420
Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)