### PR TITLE
feat(indexer): performance indexes, migration CI verification, and ZK detect()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,41 @@ jobs:
         working-directory: contracts/ticket
         run: cargo test --features testutils --release
 
+  # ── Migrations ────────────────────────────────────────────────────────────
+  # Closes #425 — verify every SQL migration applies cleanly on a fresh
+  # PostgreSQL 16 instance, in order, with no missing-table or type conflicts.
+  migrations:
+    name: Migrations (fresh PostgreSQL 16)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: test
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install indexer deps
+        run: npm install
+        working-directory: indexer
+
+      - name: Apply all migrations on a blank database
+        env:
+          DATABASE_URL: postgres://postgres:test@localhost:5433/postgres
+        run: node src/migrate.js
+        working-directory: indexer
+
   # ── Services ──────────────────────────────────────────────────────────────
   services:
     name: Services (indexer + frontend)

--- a/indexer/migrations/005_performance_indexes.sql
+++ b/indexer/migrations/005_performance_indexes.sql
@@ -1,0 +1,27 @@
+-- Migration 005: Performance indexes for events pagination and contract history
+--
+-- Closes #423 — index supporting GET /api/events cursor pagination.
+-- Closes #424 — index supporting GET /api/wallet/:address and
+--               GET /api/contracts/:id/events contract-history lookups.
+--
+-- NOTE ON COLUMN NAMING:
+--   Issues #423/#424 refer to a column `events.ledger_sequence`. In this
+--   schema (see 002_core_schema.sql) the ledger-sequence value is stored in
+--   the column `events.ledger`. The indexes below target the real column so
+--   the migration applies cleanly on a fresh database (see #425).
+--
+-- All statements are idempotent (IF NOT EXISTS) so the migration is safe to
+-- re-run and never conflicts with indexes created by earlier migrations.
+
+-- #423 — pagination cursor on ledger sequence.
+-- GET /api/events orders by ledger DESC; a descending index lets the planner
+-- satisfy `ORDER BY ledger DESC LIMIT N` with a forward index scan instead of
+-- a full table scan + sort as the events table grows.
+CREATE INDEX IF NOT EXISTS idx_events_ledger_sequence
+  ON events (ledger DESC);
+
+-- #424 — contract history lookup.
+-- GET /api/wallet/:address and GET /api/contracts/:id/events filter by
+-- contract_id; this index turns those sequential scans into index scans.
+CREATE INDEX IF NOT EXISTS idx_events_contract_id
+  ON events (contract_id);

--- a/indexer/src/migrate.js
+++ b/indexer/src/migrate.js
@@ -63,3 +63,20 @@ export async function runMigrations(pool) {
   if (ran === 0) console.log("[migrations] schema up to date");
   return ran;
 }
+
+// ── CLI entry point ───────────────────────────────────────────────────────────
+// `node src/migrate.js` applies all pending migrations against DATABASE_URL and
+// exits 0 on success / 1 on failure. Used by the CI migration check (see #425).
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const { default: pg } = await import("pg");
+  const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+  try {
+    await runMigrations(pool);
+    process.exitCode = 0;
+  } catch (err) {
+    console.error(`[migrations] ${err.message}`);
+    process.exitCode = 1;
+  } finally {
+    await pool.end();
+  }
+}

--- a/indexer/src/zkHostFunctions.js
+++ b/indexer/src/zkHostFunctions.js
@@ -147,6 +147,44 @@ export function parseZkHostFunctions(ev) {
 }
 
 /**
+ * High-level ZK detection for the EventPage cost panel (CAP-0080).
+ *
+ * Given a transaction meta (XDR `TransactionMeta` object) — or an event-like
+ * wrapper already carrying `txMeta` / `diagnosticEvents` / `hostFunctions` —
+ * returns a flat result describing whether the transaction invoked any native
+ * ZK host function and, if so, the aggregate cost delta versus a Wasm-side
+ * implementation.
+ *
+ * @param {object} txMeta  Stellar `TransactionMeta` XDR object, or event-like wrapper
+ * @returns {{ is_zk: boolean, calls: ZkHostCall[], total_native: number, total_legacy: number, saved_cpu: number, saved_pct: number }}
+ */
+export function detect(txMeta) {
+  // Accept either a raw txMeta XDR object or an event-like wrapper. The parser
+  // looks for ZK calls under ev.txMeta / ev.diagnosticEvents / ev.hostFunctions,
+  // so wrap a bare txMeta accordingly.
+  const ev =
+    txMeta &&
+    (txMeta.txMeta || txMeta.diagnosticEvents || txMeta.diagnostic_events ||
+      txMeta.hostFunctions || txMeta.host_functions)
+      ? txMeta
+      : { txMeta };
+
+  const calls = parseZkHostFunctions(ev);
+  if (!calls || calls.length === 0) {
+    return {
+      is_zk: false,
+      calls: [],
+      total_native: 0,
+      total_legacy: 0,
+      saved_cpu: 0,
+      saved_pct: 0,
+    };
+  }
+
+  return { is_zk: true, calls, ...computeZkCostDelta(calls) };
+}
+
+/**
  * Compute aggregate cost delta across all ZK calls in an event.
  *
  * @param {ZkHostCall[]} calls

--- a/indexer/test/zkHostFunctions.test.js
+++ b/indexer/test/zkHostFunctions.test.js
@@ -3,7 +3,7 @@
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { parseZkHostFunctions, computeZkCostDelta } from "../src/zkHostFunctions.js";
+import { parseZkHostFunctions, computeZkCostDelta, detect } from "../src/zkHostFunctions.js";
 
 // ── parseZkHostFunctions ──────────────────────────────────────────────────────
 
@@ -106,6 +106,73 @@ describe("parseZkHostFunctions", () => {
       diagnosticEvents: [null, undefined, {}, { event: null }],
     };
     assert.equal(parseZkHostFunctions(ev), null);
+  });
+});
+
+// ── detect (issue #422) ───────────────────────────────────────────────────────
+
+// Build a txMeta whose accessor-method shape mirrors the @stellar/stellar-sdk
+// `TransactionMeta` XDR object the parser's Source 3 path consumes:
+//   txMeta.v3().sorobanMeta().diagnosticEvents()[i].event().body().v0().data().sym()
+function mockTxMeta(fnNames) {
+  const diagnosticEvents = fnNames.map((fnName) => ({
+    event: () => ({
+      body: () => ({
+        v0: () => ({
+          data: () => ({ sym: () => fnName }),
+        }),
+      }),
+    }),
+  }));
+  return {
+    v3: () => ({
+      sorobanMeta: () => ({
+        diagnosticEvents: () => diagnosticEvents,
+      }),
+    }),
+  };
+}
+
+describe("detect", () => {
+  it("returns is_zk: true with populated cost fields for a ZK txMeta XDR", () => {
+    const result = detect(mockTxMeta(["bls12_381_pairing_check"]));
+    assert.equal(result.is_zk, true);
+    assert.equal(result.calls.length, 1);
+    assert.equal(result.calls[0].fn_name, "bls12_381_pairing_check");
+    assert.ok(result.total_native > 0);
+    assert.ok(result.total_legacy > 0);
+    assert.ok(result.saved_cpu > 0);
+    assert.ok(result.saved_pct > 0);
+    assert.equal(result.total_legacy - result.total_native, result.saved_cpu);
+  });
+
+  it("aggregates cost across multiple ZK calls in one txMeta", () => {
+    const result = detect(mockTxMeta(["bn254_g1_msm", "bn254_pairing_check"]));
+    assert.equal(result.is_zk, true);
+    assert.equal(result.calls.length, 2);
+    assert.ok(result.saved_cpu > 0);
+  });
+
+  it("returns is_zk: false for a non-ZK txMeta XDR", () => {
+    const result = detect(mockTxMeta(["transfer", "mint"]));
+    assert.equal(result.is_zk, false);
+    assert.deepEqual(result.calls, []);
+    assert.equal(result.total_native, 0);
+    assert.equal(result.total_legacy, 0);
+    assert.equal(result.saved_cpu, 0);
+    assert.equal(result.saved_pct, 0);
+  });
+
+  it("returns is_zk: false for empty / missing txMeta", () => {
+    assert.equal(detect(mockTxMeta([])).is_zk, false);
+    assert.equal(detect(undefined).is_zk, false);
+    assert.equal(detect({}).is_zk, false);
+  });
+
+  it("also accepts an event-like wrapper carrying hostFunctions", () => {
+    const result = detect({ hostFunctions: ["bn254_fr_mul"] });
+    assert.equal(result.is_zk, true);
+    assert.equal(result.calls[0].fn_name, "bn254_fr_mul");
   });
 });
 


### PR DESCRIPTION
## Summary

Implements four indexer issues in one PR:

- **#423** — DB index on events for pagination performance
- **#424** — DB index on events for contract-history lookup
- **#425** — Verify all SQL migrations apply cleanly on fresh PostgreSQL 16 (+ CI step)
- **#422** — Verify ZK host-function detection identifies ZK calls

## Changes

### `indexer/migrations/005_performance_indexes.sql` (new) — #423, #424
- `idx_events_ledger_sequence ON events(ledger DESC)` — lets `GET /api/events`
  satisfy `ORDER BY ledger DESC LIMIT N` with an index scan instead of a full
  scan + sort.
- `idx_events_contract_id ON events(contract_id)` — turns the contract-history
  filters in `GET /api/wallet/:address` and `GET /api/contracts/:id/events`
  into index scans.
- Both `IF NOT EXISTS`, so the migration is idempotent and never conflicts with
  indexes from earlier migrations.

> **Column-name note:** issues #423/#424 reference `events.ledger_sequence`, but
> in this schema (`002_core_schema.sql`) the ledger-sequence value lives in the
> column `events.ledger`. The indexes target the real column so the migration
> applies cleanly (see #425). The pagination index uses `DESC` to match the
> `ORDER BY ledger DESC` access pattern from the acceptance criteria.

### `indexer/src/migrate.js` — #425
- Added a CLI entry point so `node src/migrate.js` applies all pending
  migrations against `DATABASE_URL` and exits `0` on success / `1` on failure.
  (Previously the module only exported `runMigrations`, so running it directly
  was a no-op.)

### `.github/workflows/ci.yml` — #425
- New **migrations** job spins up `postgres:16-alpine` as a service container
  and applies every SQL migration on a blank database, failing CI on any
  missing-table or type conflict.

### `indexer/src/zkHostFunctions.js` + tests — #422
- Added `detect(txMeta)` returning `{ is_zk, calls, total_native,
  total_legacy, saved_cpu, saved_pct }` — the flat shape the EventPage ZK cost
  panel needs.
- Tests construct a txMeta matching the `@stellar/stellar-sdk` `TransactionMeta`
  XDR accessor shape and assert `is_zk: true` with populated cost fields for ZK
  calls, and `is_zk: false` for non-ZK / empty txMeta.

## Notes
- Per request, this PR was not validated by running the suite locally
  (Node is unavailable in the authoring environment); files are syntactically
  ESM-valid and the CI migrations job exercises #425 end-to-end.

Closes #423
Closes #424
Closes #425
Closes #422
