### PR TITLE
fix: resolve docker compose health checks and service dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,11 @@ services:
       - ./indexer/src:/app/src
     environment:
       - DATABASE_URL=postgres://postgres:postgres@postgres:5432/soroban_explorer
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -f http://localhost:3001/api/setup/status || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     depends_on:
       postgres:
         condition: service_healthy
@@ -55,8 +60,14 @@ services:
       - ./frontend/public:/app/public
     environment:
       - VITE_API_URL=http://localhost:3001
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -f http://localhost:5173 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     depends_on:
-      - indexer
+      indexer:
+        condition: service_healthy
 
   seed:
     image: node:18-alpine

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -3,6 +3,7 @@ FROM node:18-alpine
 WORKDIR /app
 COPY package*.json ./
 RUN npm install
+RUN apk add --no-cache curl
 
 COPY . .
 

--- a/indexer/Dockerfile.dev
+++ b/indexer/Dockerfile.dev
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 RUN npm install -g nodemon
+RUN apk add --no-cache curl
 
 COPY . .
 


### PR DESCRIPTION
## What was done
- Added native Docker `healthcheck` configurations for both `indexer` and `frontend` services in `docker-compose.yml`.
- Updated the `frontend` service's `depends_on` clause to strictly require `indexer` to be `service_healthy` before starting, instead of just `service_started`.
- Injected `RUN apk add --no-cache curl` into both `indexer/Dockerfile.dev` and `frontend/Dockerfile.dev` since `node:18-alpine` does not bundle `curl` by default, ensuring internal Docker health probes succeed.

## Why it was done
As described in #436, `docker-compose.yml` orchestrates Postgres, Indexer, and Frontend. However, the `indexer` and `frontend` were missing their respective health checks, leading to premature stack readiness indicators (`docker compose ps`). Furthermore, without a strict dependency order (`service_healthy`), the frontend container could boot up and crash if the indexer API was not fully initialized and listening on port 3001.

## How it was verified
- Verified that `docker-compose.yml` correctly targets `/api/setup/status` on port 3001 and the base URL on port 5173 for health checks.
- Verified that dependency chaining logic forces the `postgres` -> `indexer` -> `frontend` boot sequence securely.

Closes #436 