### PR TITLE
build: add contract CI check targets and clean workspace config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,6 @@
 resolver = "2"
 members  = ["contracts/explorer"]
 
-
-[workspace.dependencies]
-soroban-sdk = { version = "25.0.2" }
-
 [profile.release]
 opt-level = "z"
 overflow-checks = true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test deploy indexer frontend clean \
+.PHONY: build test deploy indexer frontend clean fmt fmt-check \
 	docker-up docker-down docker-build docker-logs docker-test docker-staging docker-prod \
 	e2e e2e-setup e2e-test e2e-api e2e-chaos e2e-property e2e-playwright e2e-k6 e2e-full
 
@@ -9,6 +9,12 @@ build:
 
 test:
 	cargo test -p soroban-explorer-contract
+
+fmt:
+	cargo fmt
+
+fmt-check:
+	cargo fmt --check
 
 optimize:
 	stellar contract optimize \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test deploy indexer frontend clean fmt fmt-check \
+.PHONY: build test deploy indexer frontend clean fmt fmt-check lint \
 	docker-up docker-down docker-build docker-logs docker-test docker-staging docker-prod \
 	e2e e2e-setup e2e-test e2e-api e2e-chaos e2e-property e2e-playwright e2e-k6 e2e-full
 
@@ -15,6 +15,9 @@ fmt:
 
 fmt-check:
 	cargo fmt --check
+
+lint:
+	cargo clippy -- -D warnings
 
 optimize:
 	stellar contract optimize \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test deploy indexer frontend clean fmt fmt-check lint \
+.PHONY: build test check deploy indexer frontend clean fmt fmt-check lint \
 	docker-up docker-down docker-build docker-logs docker-test docker-staging docker-prod \
 	e2e e2e-setup e2e-test e2e-api e2e-chaos e2e-property e2e-playwright e2e-k6 e2e-full
 
@@ -18,6 +18,8 @@ fmt-check:
 
 lint:
 	cargo clippy -- -D warnings
+
+check: fmt-check lint test
 
 optimize:
 	stellar contract optimize \


### PR DESCRIPTION
## Summary

- Add `fmt` and `fmt-check` Makefile targets so contributors can run formatting locally
- Add `lint` Makefile target for running `cargo clippy -- -D warnings`
- Remove stale `[workspace.dependencies]` block (referenced sdk v25.0.2 while both contracts use v21.x — never consumed by any member)
- Add `check` target that chains `fmt-check`, `lint`, and `test`, mirroring the contracts CI gate

All four CI checks (`cargo fmt --check`, `cargo clippy -- -D warnings`, WASM build, and all 25 unit tests including the three required ones) pass on this branch.

Closes #398
Closes #399
Closes #400
Closes #401