### PR TITLE
Mock the /api/events/99999 call to return 404

### DIFF
--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -19,7 +19,14 @@ export default function EventPage() {
   });
 
   if (isLoading) return <p style={{ color: "var(--muted)" }}>Loading…</p>;
-  if (!ev) return <p>Event not found.</p>;
+  if (!ev) return (
+  <div style={{ textAlign: "center", marginTop: "2rem" }}>
+    <p>Event not found.</p>
+    <Link to="/" style={{ color: "var(--primary)", textDecoration: "underline" }}>
+      Back to events
+    </Link>
+  </div>
+);
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>


### PR DESCRIPTION
I displayed a user friendly error When an event is not found, the page now renders a centered message “Event not found.” with a “Back to events” link that navigates to the home feed (/).
Added appropriate styling for visibility and user friendliness.



This PR closes #431 