### PR TITLE
Add contract tab empty states

### DIFF
--- a/frontend/src/components/AddressConnectionGraph.tsx
+++ b/frontend/src/components/AddressConnectionGraph.tsx
@@ -38,6 +38,8 @@ export default function AddressConnectionGraph({ contractId }: Props) {
     queryFn: () => api.addressGraph(contractId),
     enabled: !!contractId,
   });
+  const nodes = Array.isArray(data?.nodes) ? data.nodes : [];
+  const edges = Array.isArray(data?.edges) ? data.edges : [];
 
   useEffect(() => {
     if (!data || !containerRef.current) return;
@@ -50,14 +52,14 @@ export default function AddressConnectionGraph({ contractId }: Props) {
       }
 
       const elements = [
-        ...data.nodes.map((n) => ({
+        ...nodes.map((n) => ({
           data: {
             id: n.id,
             label: n.label.length > 12 ? `${n.label.slice(0, 6)}…${n.label.slice(-4)}` : n.label,
             type: n.type,
           },
         })),
-        ...data.edges.map((e, i) => ({
+        ...edges.map((e, i) => ({
           data: {
             id: `e${i}`,
             source: e.source,
@@ -123,8 +125,16 @@ export default function AddressConnectionGraph({ contractId }: Props) {
 
   if (isLoading) return <p style={{ color: "var(--muted)" }}>Loading graph…</p>;
   if (error) return <p style={{ color: "#ef4444" }}>Failed to load address graph.</p>;
-  if (!data || data.nodes.length === 0)
-    return <p style={{ color: "var(--muted)" }}>No connections found for this contract.</p>;
+  if (nodes.length === 0) {
+    return (
+      <div className="card" style={{ color: "var(--muted)", fontSize: 13 }}>
+        <strong style={{ display: "block", color: "var(--text)", fontSize: 14, marginBottom: 6 }}>
+          No address graph data available
+        </strong>
+        No wallet or contract connections were returned for this contract.
+      </div>
+    );
+  }
 
   return (
     <div className="card">
@@ -183,7 +193,7 @@ export default function AddressConnectionGraph({ contractId }: Props) {
         }}
       />
       <p style={{ fontSize: 11, color: "var(--muted)", marginTop: 8 }}>
-        Scroll to zoom · Drag to pan · {data.nodes.length} nodes · {data.edges.length} connections
+        Scroll to zoom · Drag to pan · {nodes.length} nodes · {edges.length} connections
       </p>
     </div>
   );

--- a/frontend/src/components/NetworkComparison.tsx
+++ b/frontend/src/components/NetworkComparison.tsx
@@ -21,10 +21,20 @@ export default function NetworkComparison({ contractId }: { contractId: string }
     queryFn: () => api.networkComparison(contractId),
     enabled: !!contractId,
   });
+  const statuses = Array.isArray(data?.statuses) ? data.statuses : [];
 
   if (isLoading) return <p style={{ color: "var(--muted)" }}>Checking networks…</p>;
   if (error) return <p style={{ color: "#ef4444" }}>Failed to load network comparison.</p>;
-  if (!data) return null;
+  if (statuses.length === 0) {
+    return (
+      <div className="card" style={{ color: "var(--muted)", fontSize: 13 }}>
+        <strong style={{ display: "block", color: "var(--text)", fontSize: 14, marginBottom: 6 }}>
+          No network data available
+        </strong>
+        No deployment status was returned for this contract.
+      </div>
+    );
+  }
 
   return (
     <div className="card">
@@ -62,7 +72,7 @@ export default function NetworkComparison({ contractId }: { contractId: string }
             </tr>
           </thead>
           <tbody>
-            {data.statuses.map((s) => (
+            {statuses.map((s) => (
               <tr key={s.network} style={{ borderBottom: "1px solid var(--border)" }}>
                 <td style={td}>
                   <span style={{ textTransform: "capitalize", fontWeight: 500 }}>{s.network}</span>

--- a/frontend/src/components/StateDiffTimeline.tsx
+++ b/frontend/src/components/StateDiffTimeline.tsx
@@ -24,11 +24,12 @@ export default function StateDiffTimeline({ contractId }: Props) {
   const [sliderIndex, setSliderIndex] = useState(0);
   const [filterKey, setFilterKey] = useState("");
 
-  const { data: diffs = [], isLoading } = useQuery({
+  const { data: diffResponse = [], isLoading } = useQuery({
     queryKey: ["state-diffs", contractId],
     queryFn: () => api.stateDiffs(contractId),
     enabled: !!contractId,
   });
+  const diffs = Array.isArray(diffResponse) ? diffResponse : [];
 
   // Group diffs by ledger, sorted ascending
   const ledgerGroups = useMemo(() => {
@@ -48,31 +49,33 @@ export default function StateDiffTimeline({ contractId }: Props) {
     return Array.from(s).sort();
   }, [diffs]);
 
+  const maxIndex = ledgerGroups.length - 1;
+  const safeSliderIndex = Math.min(sliderIndex, Math.max(maxIndex, 0));
+  const current = ledgerGroups[safeSliderIndex];
+  const visibleEntries = current ? (filterKey ? current.entries.filter((e) => e.key === filterKey) : current.entries) : [];
+
+  // Cumulative state up to current ledger for context
+  const cumulativeState = useMemo(() => {
+    const state: Record<string, string | null> = {};
+    for (let i = 0; i <= safeSliderIndex && i < ledgerGroups.length; i++) {
+      const group = ledgerGroups[i];
+      if (!group) continue;
+      for (const d of group.entries) {
+        state[d.key] = d.new_value;
+      }
+    }
+    return state;
+  }, [ledgerGroups, safeSliderIndex]);
+
   if (isLoading) return <p style={{ color: "var(--muted)" }}>Loading state diffs…</p>;
 
-  if (ledgerGroups.length === 0) {
+  if (!current) {
     return (
       <div className="card" style={{ color: "var(--muted)", fontSize: 13 }}>
         No storage state changes recorded for this contract yet.
       </div>
     );
   }
-
-  const maxIndex = ledgerGroups.length - 1;
-  const current = ledgerGroups[sliderIndex];
-
-  const visibleEntries = filterKey ? current.entries.filter((e) => e.key === filterKey) : current.entries;
-
-  // Cumulative state up to current ledger for context
-  const cumulativeState = useMemo(() => {
-    const state: Record<string, string | null> = {};
-    for (let i = 0; i <= sliderIndex; i++) {
-      for (const d of ledgerGroups[i].entries) {
-        state[d.key] = d.new_value;
-      }
-    }
-    return state;
-  }, [ledgerGroups, sliderIndex]);
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
@@ -87,7 +90,7 @@ export default function StateDiffTimeline({ contractId }: Props) {
         >
           <span style={{ fontSize: 13, fontWeight: 600 }}>Block {current.ledger.toLocaleString()}</span>
           <span style={{ fontSize: 12, color: "var(--muted)" }}>
-            {sliderIndex + 1} / {ledgerGroups.length} snapshots
+            {safeSliderIndex + 1} / {ledgerGroups.length} snapshots
           </span>
         </div>
 
@@ -95,7 +98,7 @@ export default function StateDiffTimeline({ contractId }: Props) {
           type="range"
           min={0}
           max={maxIndex}
-          value={sliderIndex}
+          value={safeSliderIndex}
           onChange={(e) => setSliderIndex(Number(e.target.value))}
           style={{ width: "100%", accentColor: "var(--accent)" }}
           aria-label="Timeline slider — scrub through block history"
@@ -111,7 +114,8 @@ export default function StateDiffTimeline({ contractId }: Props) {
               style={{
                 flex: 1,
                 height: Math.min(6, 2 + g.entries.length),
-                background: i === sliderIndex ? "var(--accent)" : i < sliderIndex ? "var(--muted)" : "var(--border)",
+                background:
+                  i === safeSliderIndex ? "var(--accent)" : i < safeSliderIndex ? "var(--muted)" : "var(--border)",
                 borderRadius: 2,
                 cursor: "pointer",
                 transition: "background 0.15s",

--- a/frontend/src/pages/ContractPage.tsx
+++ b/frontend/src/pages/ContractPage.tsx
@@ -24,40 +24,22 @@ import SourceVerificationBadge from "../components/SourceVerificationBadge";
 import StateDiffTimeline from "../components/StateDiffTimeline";
 import ExportButton from "../components/ExportButton";
 
-// Demo source shown when no verified source is uploaded
-const DEMO_SOURCE = `// Verified source not yet uploaded for this contract.
-// Example Soroban contract structure:
-
-use soroban_sdk::{contract, contractimpl, Env, Symbol, Address};
-
-#[contract]
-pub struct MyContract;
-
-#[contractimpl]
-impl MyContract {
-    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
-        from.require_auth();
-        let mut balance: i128 = env.storage().instance().get(&from).unwrap_or(0);
-        balance -= amount;
-        env.storage().instance().set(&from, &balance);
-    }
-}`;
-
-// Demo invocation tree shown when no real trace is available
-const DEMO_TREE: InvocationNode = {
-  contract: "ContractA",
-  fn: "swap",
-  children: [
-    {
-      contract: "ContractB",
-      fn: "transfer",
-      children: [{ contract: "ContractC", fn: "update_balance" }],
-    },
-    { contract: "ContractB", fn: "emit_event" },
-  ],
-};
-
 type Tab = "overview" | "source" | "simulate" | "flow" | "roles" | "networks" | "graph" | "state-diff";
+
+function EmptyState({ title, message }: { title: string; message: string }) {
+  return (
+    <div className="card" style={{ color: "var(--muted)", fontSize: 13 }}>
+      <strong style={{ display: "block", color: "var(--text)", fontSize: 14, marginBottom: 6 }}>{title}</strong>
+      {message}
+    </div>
+  );
+}
+
+function isInvocationNode(value: unknown): value is InvocationNode {
+  if (!value || typeof value !== "object") return false;
+  const node = value as Partial<InvocationNode>;
+  return typeof node.contract === "string" && node.contract.length > 0 && typeof node.fn === "string" && node.fn.length > 0;
+}
 
 export default function ContractPage() {
   const { id = "" } = useParams();
@@ -79,6 +61,7 @@ export default function ContractPage() {
     queryFn: () => api.events({ contract: id }),
     enabled: !!id,
   });
+  const contractEvents = Array.isArray(events) ? events : [];
 
   const { data: migrationStatus } = useQuery({
     queryKey: ["migration-status", id],
@@ -90,9 +73,13 @@ export default function ContractPage() {
     api.downloadAbi(id).catch((err) => console.error("Download ABI failed:", err));
   };
 
+  const functions = meta?.functions ?? [];
+  const sourceFiles = meta?.source_files ?? [];
+  const invocationTree = (meta as any)?.invocation_tree;
+
   // A contract is considered "unverified" when the server has no registered
   // metadata for it (meta is null/404) or it has no functions defined.
-  const isUnverified = !meta || meta.functions.length === 0;
+  const isUnverified = !meta || functions.length === 0;
 
   if (metaLoading) return <p style={{ color: "var(--muted)" }}>Loading…</p>;
   if (!meta) {
@@ -142,7 +129,7 @@ export default function ContractPage() {
             {evLoading ? (
               <p style={{ color: "var(--muted)" }}>Loading…</p>
             ) : (
-              <LocalAbiEventTable events={events} localAbi={localAbi} />
+              <LocalAbiEventTable events={contractEvents} localAbi={localAbi} />
             )}
           </div>
         )}
@@ -187,8 +174,10 @@ export default function ContractPage() {
           }}
         >
           <div>
-            <h2 style={{ marginBottom: 8 }}>{meta.name}</h2>
-            <p style={{ color: "var(--muted)", marginBottom: 12 }}>{meta.description}</p>
+            <h2 style={{ marginBottom: 8 }}>{meta.name || "Unnamed Contract"}</h2>
+            <p style={{ color: "var(--muted)", marginBottom: 12 }}>
+              {meta.description || "No contract description available."}
+            </p>
             <code
               style={{
                 fontSize: 12,
@@ -404,11 +393,11 @@ export default function ContractPage() {
           {/* Live TTL expiration progress bars */}
           <TTLProgressBar contractId={id} />
 
-          {meta.functions.length > 0 && (
+          {functions.length > 0 ? (
             <div className="card">
               <h3 style={{ marginBottom: 8, fontSize: 14 }}>Functions</h3>
               <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                {meta.functions.map((f) => (
+                {functions.map((f) => (
                   <div key={f.name} className="card" style={{ padding: "8px 12px" }}>
                     <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
                       <span className="badge">{f.name}</span>
@@ -434,6 +423,11 @@ export default function ContractPage() {
                 ))}
               </div>
             </div>
+          ) : (
+            <EmptyState
+              title="No functions available"
+              message="This contract did not return ABI function metadata yet."
+            />
           )}
 
           <div
@@ -451,9 +445,9 @@ export default function ContractPage() {
               <p style={{ color: "var(--muted)" }}>Loading…</p>
             ) : localAbi ? (
               // Re-render with local ABI descriptions
-              <LocalAbiEventTable events={events} localAbi={localAbi} />
+              <LocalAbiEventTable events={contractEvents} localAbi={localAbi} />
             ) : (
-              <EventTable events={events} />
+              <EventTable events={contractEvents} />
             )}
           </div>
         </>
@@ -463,10 +457,15 @@ export default function ContractPage() {
       {tab === "source" && (
         <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
           <SourceVerificationBadge contractId={id} wasmHash={(meta as any).wasm_hash ?? undefined} />
-          {meta.source_files && meta.source_files.length > 0 ? (
-            <SourceFileTree files={meta.source_files} />
+          {sourceFiles.length > 0 ? (
+            <SourceFileTree files={sourceFiles} />
+          ) : meta.source ? (
+            <RustCodeViewer source={meta.source} filename={meta.source_file ?? `${id.slice(0, 8)}.rs`} />
           ) : (
-            <RustCodeViewer source={meta.source ?? DEMO_SOURCE} filename={meta.source_file ?? `${id.slice(0, 8)}.rs`} />
+            <EmptyState
+              title="No source available"
+              message="No verified source files were returned for this contract."
+            />
           )}
         </div>
       )}
@@ -476,26 +475,37 @@ export default function ContractPage() {
         <div className="card" style={{ display: "flex", flexDirection: "column", gap: 16 }}>
           <h3 style={{ fontSize: 14 }}>Simulate Contract Call</h3>
           <p style={{ color: "var(--muted)", fontSize: 13 }}>Preview execution results without spending real fees.</p>
-          {meta.functions.length > 0 && (
+          {functions.length > 0 ? (
             <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
               <label style={{ color: "var(--muted)" }}>Function:</label>
               <select value={selectedFn} onChange={(e) => setSelectedFn(e.target.value)}>
                 <option value="">— select —</option>
-                {meta.functions.map((f) => (
+                {functions.map((f) => (
                   <option key={f.name} value={f.name}>
                     {f.name}
                   </option>
                 ))}
               </select>
             </div>
+          ) : (
+            <p style={{ color: "var(--muted)", fontSize: 13 }}>
+              No callable functions were returned for this contract.
+            </p>
           )}
           {selectedFn && <SimulateButton contractId={id} fnName={selectedFn} />}
-          {!selectedFn && meta.functions.length === 0 && <SimulateButton contractId={id} fnName="transfer" />}
         </div>
       )}
 
       {/* Tab: Invocation Flow — */}
-      {tab === "flow" && <InvocationFlowChart root={(meta as any).invocation_tree ?? DEMO_TREE} />}
+      {tab === "flow" &&
+        (isInvocationNode(invocationTree) ? (
+          <InvocationFlowChart root={invocationTree} />
+        ) : (
+          <EmptyState
+            title="No invocation flow available"
+            message="No cross-contract invocation trace has been recorded for this contract yet."
+          />
+        ))}
 
       {/* Tab: Privileged Roles */}
       {tab === "roles" && <PrivilegedRoles contractId={id} />}


### PR DESCRIPTION
I fixed `ContractPage.tsx` so all eight tabs render clear loading or empty states instead of blank panels or crashes when contract/API data is missing.

Closes #432 