### PR TITLE
fix(devcontainer+ci): resolve Codespace recovery-mode and contributor PR failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
           node-version: 20
 
       - name: Install indexer deps
-        run: npm install
+        run: npm ci
         working-directory: indexer
 
       - name: Apply all migrations on a blank database
@@ -143,6 +143,20 @@ jobs:
     name: Services (indexer + frontend)
     runs-on: ubuntu-latest
     needs: contracts
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: soroban
+          POSTGRES_PASSWORD: soroban_secret
+          POSTGRES_DB: soroban_explorer
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - uses: actions/checkout@v4
 
@@ -165,13 +179,13 @@ jobs:
 
       - name: Install deps
         run: |
-          cd indexer && npm install
+          cd indexer && npm ci
           cd ../frontend && npm ci
 
       - name: Lockfile drift check
         run: |
-          if ! git diff --exit-code indexer/package-lock.json; then
-            echo "::error::indexer/package-lock.json is out of sync — run 'npm install' in indexer/ and commit it."
+          if ! git diff --exit-code indexer/package-lock.json frontend/package-lock.json; then
+            echo "::error::A package-lock.json is out of sync — run 'npm install' in the relevant directory and commit the updated lockfile."
             exit 1
           fi
 
@@ -181,6 +195,8 @@ jobs:
       - name: Indexer tests
         run: npm test -- --coverage --coverageReporters=lcov
         working-directory: indexer
+        env:
+          TEST_DATABASE_URL: postgres://soroban:soroban_secret@localhost:5432/soroban_explorer
 
       - name: Upload indexer coverage to CodeCov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1,7 +1,7 @@
 name: PR Quality Gates
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, edited]
 
 concurrency:


### PR DESCRIPTION
## Summary

Fixes two independent issues that blocked every new contributor from using the repo:

### 1. Codespace recovery-mode on first open

Three bugs in the devcontainer configuration caused GitHub Codespaces to enter recovery mode:

- **Missing `soroban-net` network** — `docker-compose.devcontainer.yml` referenced a `soroban-net` network that was never defined in any compose file, causing Docker Compose to fail immediately
- **Full production stack included at startup** — `devcontainer.json` merged `../docker-compose.yml`, so Codespaces tried to build `stellar-quickstart`, `indexer`, `frontend`, and `seed` containers all at once (too heavy, prone to timeout)
- **Credential mismatch** — `docker-compose.yml` used `postgres:postgres` while `.env.example`, the indexer, and the devcontainer all expect `soroban:soroban_secret`

**Fixes:**
- `devcontainer.json`: removed `../docker-compose.yml` from `dockerComposeFile` — devcontainer now uses only the self-contained devcontainer compose file
- `docker-compose.devcontainer.yml`: rewrote to be self-contained — added its own postgres service with correct credentials, removed the undefined `soroban-net` network, added healthcheck so the devcontainer waits for postgres to be ready
- `docker-compose.yml`: corrected postgres credentials (`soroban:soroban_secret`) and healthcheck user to match `.env.example`

### 2. CI checks always failing on contributor PRs

Two bugs in `ci.yml` caused the `Services` job to always fail:

- **`npm install` before lockfile drift check** — `npm install` can silently update `package-lock.json`; the very next step's `git diff --exit-code` then detected the change and failed. Changed to `npm ci` (also applied to the new `migrations` job)
- **No postgres for indexer API tests** — `test/api/api.test.js` calls `db.init()` and `TRUNCATE` on a real database, but the `services` CI job had no postgres service container. Added postgres service + `TEST_DATABASE_URL` env var to the test step
- Extended lockfile drift check to cover `frontend/package-lock.json` too (was only checking indexer)

**Security fix** (`pr-quality.yml`): changed `pull_request_target` → `pull_request`. The original triggered on attacker-controlled code with `pull-requests: write` permission — a known pwn-request attack vector. Since no step needs repo secrets from the base branch, `pull_request` is correct here.

## Test plan

- [ ] Open a fresh Codespace on this branch — container should build without recovery mode
- [ ] Verify `make dev` works inside the Codespace after container is ready
- [ ] Open a PR against main and confirm all CI checks pass (contracts, migrations, services jobs)
- [ ] Confirm `pr-quality` labels the PR size and assigns the author correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)