### PR TITLE
test: add get_events pagination boundary test

### DIFF
--- a/contracts/explorer/src/lib.rs
+++ b/contracts/explorer/src/lib.rs
@@ -652,6 +652,30 @@ mod tests {
         assert_eq!(empty.len(), 0);
     }
 
+    // Boundary check for `get_events`: a page requested from the middle of the
+    // log must honour both the `start` offset and the `limit` cap, returning
+    // exactly `min(limit, total - start)` events beginning at `start`.
+    #[test]
+    fn test_get_events_pagination() {
+        let (env, client) = setup();
+        let admin = Address::generate(&env);
+        client.init(&admin, &0u32);
+
+        let cid: BytesN<32> = BytesN::from_array(&env, &[4u8; 32]);
+        let base = make_input(&env, &cid);
+
+        for _ in 0..5 {
+            client.submit_event(&admin, &base);
+        }
+        assert_eq!(client.event_count(), 5u64);
+
+        // start = 2, limit = 2 -> events with seq 2 and 3.
+        let page = client.get_events(&2u64, &2u32);
+        assert_eq!(page.len(), 2);
+        assert_eq!(page.get(0).unwrap().seq, 2);
+        assert_eq!(page.get(1).unwrap().seq, 3);
+    }
+
     #[test]
     #[should_panic]
     fn test_double_init_panics() {


### PR DESCRIPTION
## Summary

Adds a focused unit test that pins down the pagination boundary behaviour of `get_events(cursor, limit)`, which was previously untested for the mid-log offset case.

The contract's `get_events` returns at most `limit` events starting at `cursor`, i.e. `min(limit, total - start)` events. This PR adds a test that exercises that contract directly.

## Changes

- New unit test `test_get_events_pagination` in `contracts/explorer/src/lib.rs`:
  - Submits 5 events (seq 0..4).
  - Calls `get_events(2, 2)`.
  - Asserts exactly 2 events are returned.
  - Asserts the first returned event has `seq == 2` (and the second `seq == 3`), confirming the `start` offset is honoured and the `limit` cap is applied.

## Acceptance criteria

- [x] New test named `test_get_events_pagination`
- [x] Submits 5 events, then calls `get_events(2, 2)`
- [x] Asserts exactly 2 events returned
- [x] Asserts first event has `seq == 2`
- [x] All tests pass

## Testing

```
cargo test --lib
```

All 29 unit tests pass, including the new `test_get_events_pagination`.

closes #405