### PR TITLE
perf: migrate GET /api/events to keyset (cursor) pagination

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -81,8 +81,12 @@ paths:
 
   /api/events:
     get:
-      summary: List contract events (offset pagination)
-      description: Returns a list of decoded events using page-based pagination.
+      summary: List contract events (keyset pagination)
+      description: >-
+        Returns a stable page of decoded events using keyset (seq-based)
+        pagination. Pass the `next_cursor` value from the previous response
+        as `after_seq` to fetch the next page; `next_cursor` is null when no
+        further pages exist.
       parameters:
         - name: contract
           in: query
@@ -106,25 +110,37 @@ paths:
             enum: [soroban, classic]
             example: "soroban"
           description: Filter by transaction type
-        - name: page
+        - name: after_seq
           in: query
           required: false
           schema:
             type: integer
-            default: 1
-            example: 1
-          description: Page number (starts at 1)
+            example: 42
+          description: Event seq cursor (`next_cursor` from the previous page); omit for the first page
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 25
+            maximum: 200
+            example: 25
+          description: Max number of items to return (max 200)
       responses:
         "200":
-          description: Array of decoded events
+          description: Paginated events with next_cursor
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/DecodedEvent"
+                $ref: "#/components/schemas/CursorPaginatedEvents"
         "400":
           description: Invalid request parameters
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "422":
+          description: Invalid limit or after_seq value
           content:
             application/json:
               schema:

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -200,6 +200,12 @@ export interface BurnAlert {
   flaggedAt: number;
 }
 
+// keyset-paginated events list response (GET /api/events)
+export interface EventsPage {
+  data: DecodedEvent[];
+  next_cursor: number | null;
+}
+
 // paginated contract transaction response
 export interface ContractTransactionsResponse {
   data: DecodedEvent[];
@@ -394,13 +400,14 @@ export interface TransactionTreeDiff {
 }
 
 export const api = {
-  events: (params: { contract?: string; fn?: string; page?: number; type?: string }) => {
+  events: (params: { contract?: string; fn?: string; after_seq?: number; limit?: number; type?: string }) => {
     const q = new URLSearchParams();
     if (params.contract) q.set("contract", params.contract);
     if (params.fn) q.set("fn", params.fn);
-    if (params.page) q.set("page", String(params.page));
+    if (params.after_seq) q.set("after_seq", String(params.after_seq));
+    if (params.limit) q.set("limit", String(params.limit));
     if (params.type) q.set("type", params.type);
-    return get<DecodedEvent[]>(`/events?${q}`);
+    return get<EventsPage>(`/events?${q}`);
   },
   event: (seq: number) => get<DecodedEvent>(`/events/${seq}`),
   search: (q: string, limit = 10) => {

--- a/frontend/src/pages/ContractPage.tsx
+++ b/frontend/src/pages/ContractPage.tsx
@@ -58,7 +58,7 @@ export default function ContractPage() {
 
   const { data: events = [], isLoading: evLoading } = useQuery({
     queryKey: ["events", id],
-    queryFn: () => api.events({ contract: id }),
+    queryFn: () => api.events({ contract: id }).then((page) => page.data),
     enabled: !!id,
   });
   const contractEvents = Array.isArray(events) ? events : [];

--- a/frontend/src/pages/DeveloperWorkspace.tsx
+++ b/frontend/src/pages/DeveloperWorkspace.tsx
@@ -37,7 +37,7 @@ export default function DeveloperWorkspace() {
 
   const { data: events = [], isLoading: evLoading } = useQuery({
     queryKey: ["events", id],
-    queryFn: () => api.events({ contract: id }),
+    queryFn: () => api.events({ contract: id }).then((page) => page.data),
     enabled: !!id,
   });
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -31,28 +31,33 @@ const TYPE_LABELS: { key: TxType; label: string; title: string }[] = [
 
 export default function Home() {
   const [fnFilter, setFnFilter] = useState("");
-  const [page, setPage] = useState(1);
+  // Keyset pagination (#490): stack of after_seq cursors for the pages we've
+  // navigated past — empty stack = first page, pop to go back.
+  const [cursorStack, setCursorStack] = useState<number[]>([]);
   const [txType, setTxType] = useState<TxType>("all");
+  const afterSeq = cursorStack.length ? cursorStack[cursorStack.length - 1] : undefined;
 
   const queryClient = useQueryClient();
-  const { data: events = [], isLoading } = useQuery({
-    queryKey: ["events", fnFilter, page, txType],
+  const { data: eventsPage, isLoading } = useQuery({
+    queryKey: ["events", fnFilter, afterSeq ?? 0, txType],
     queryFn: () =>
       api.events({
         fn: fnFilter || undefined,
-        page,
+        after_seq: afterSeq,
         type: txType !== "all" ? txType : undefined,
       }),
   });
+  const events = eventsPage?.data ?? [];
+  const nextCursor = eventsPage?.next_cursor ?? null;
 
-  // invalidate the event list when a live event arrives on page 1
+  // invalidate the event list when a live event arrives on the first page
   const handleLiveEvent = useCallback(
     (ev: DecodedEvent) => {
-      if (page === 1 && (!fnFilter || ev.function === fnFilter)) {
-        queryClient.invalidateQueries({ queryKey: ["events", fnFilter, 1] });
+      if (cursorStack.length === 0 && (!fnFilter || ev.function === fnFilter)) {
+        queryClient.invalidateQueries({ queryKey: ["events", fnFilter, 0] });
       }
     },
-    [page, fnFilter, queryClient],
+    [cursorStack.length, fnFilter, queryClient],
   );
 
   useEventStream(handleLiveEvent);
@@ -89,7 +94,7 @@ export default function Home() {
               title={title}
               onClick={() => {
                 setTxType(key);
-                setPage(1);
+                setCursorStack([]);
               }}
               style={{
                 background: txType === key ? "var(--accent)" : "var(--surface)",
@@ -112,7 +117,7 @@ export default function Home() {
             value={fnFilter}
             onChange={(e) => {
               setFnFilter(e.target.value);
-              setPage(1);
+              setCursorStack([]);
             }}
           >
             {FUNCTIONS.map((f) => (
@@ -138,11 +143,16 @@ export default function Home() {
 
       {/* Pagination */}
       <div style={{ display: "flex", gap: 8 }}>
-        <button disabled={page === 1} onClick={() => setPage((p) => p - 1)}>
+        <button disabled={cursorStack.length === 0} onClick={() => setCursorStack((s) => s.slice(0, -1))}>
           ← Prev
         </button>
-        <span style={{ padding: "6px 10px", color: "var(--muted)" }}>Page {page}</span>
-        <button disabled={events.length < 25} onClick={() => setPage((p) => p + 1)}>
+        <span style={{ padding: "6px 10px", color: "var(--muted)" }}>Page {cursorStack.length + 1}</span>
+        <button
+          disabled={nextCursor === null}
+          onClick={() => {
+            if (nextCursor !== null) setCursorStack((s) => [...s, nextCursor]);
+          }}
+        >
           Next →
         </button>
       </div>

--- a/frontend/test/Home.test.tsx
+++ b/frontend/test/Home.test.tsx
@@ -42,7 +42,7 @@ vi.mock("../src/api", async (importOriginal) => {
     ...original,
     api: {
       ...original.api,
-      events: vi.fn().mockResolvedValue([]),
+      events: vi.fn().mockResolvedValue({ data: [], next_cursor: null }),
     },
   };
 });

--- a/frontend/test/api.test.ts
+++ b/frontend/test/api.test.ts
@@ -9,13 +9,14 @@ async function get(path: string) {
 }
 
 const api = {
-  events: (params: { contract?: string; fn?: string; page?: number; type?: string }) => {
+  events: (params: { contract?: string; fn?: string; after_seq?: number; limit?: number; type?: string }) => {
     const q = new URLSearchParams();
     if (params.contract) q.set("contract", params.contract);
     if (params.fn) q.set("fn", params.fn);
-    if (params.page) q.set("page", String(params.page));
+    if (params.after_seq) q.set("after_seq", String(params.after_seq));
+    if (params.limit) q.set("limit", String(params.limit));
     if (params.type) q.set("type", params.type);
-    return get<Array<{ seq: number }>>(`/events?${q}`);
+    return get<{ data: Array<{ seq: number }>; next_cursor: number | null }>(`/events?${q}`);
   },
   event: (seq: number) => get<{ seq: number }>(`/events/${seq}`),
   contract: (id: string) => get<{ id: string; name: string }>(`/contracts/${id}`),
@@ -103,29 +104,31 @@ describe("api utility", () => {
   }
 
   it("events builds query string with contract filter", async () => {
-    mockFetch([{ seq: 1 }]);
+    mockFetch({ data: [{ seq: 1 }], next_cursor: null });
     const result = await api.events({ contract: "C1" });
-    expect(result).toEqual([{ seq: 1 }]);
+    expect(result).toEqual({ data: [{ seq: 1 }], next_cursor: null });
     const [url] = (fetch as any).mock.calls[0];
     expect(url).toContain("contract=C1");
   });
 
   it("events builds query string with all params", async () => {
-    mockFetch([{ seq: 2 }]);
-    await api.events({ contract: "C1", fn: "transfer", page: 2, type: "soroban" });
+    mockFetch({ data: [{ seq: 2 }], next_cursor: 2 });
+    await api.events({ contract: "C1", fn: "transfer", after_seq: 42, limit: 50, type: "soroban" });
     const [url] = (fetch as any).mock.calls[0];
     expect(url).toContain("contract=C1");
     expect(url).toContain("fn=transfer");
-    expect(url).toContain("page=2");
+    expect(url).toContain("after_seq=42");
+    expect(url).toContain("limit=50");
     expect(url).toContain("type=soroban");
   });
 
   it("events omits undefined params", async () => {
-    mockFetch([]);
+    mockFetch({ data: [], next_cursor: null });
     await api.events({});
     const [url] = (fetch as any).mock.calls[0];
     expect(url).not.toContain("contract=");
     expect(url).not.toContain("fn=");
+    expect(url).not.toContain("after_seq=");
   });
 
   it("event fetches single event by seq", async () => {

--- a/indexer/migrations/006_keyset_index.sql
+++ b/indexer/migrations/006_keyset_index.sql
@@ -1,0 +1,13 @@
+-- Migration 006: Keyset pagination index for GET /api/events
+--
+-- Closes #490 — /api/events now paginates by seq (keyset) instead of OFFSET.
+--
+-- `seq` is the BIGSERIAL PRIMARY KEY (see 002_core_schema.sql), so a plain
+-- btree on seq already exists. This composite index additionally covers the
+-- common filtered scan — `WHERE contract_id = $1 AND seq < $2 ORDER BY seq
+-- DESC LIMIT N` — letting the planner walk seq in descending order and check
+-- contract_id from the index without heap fetches.
+--
+-- Idempotent (IF NOT EXISTS) so the migration is safe to re-run.
+CREATE INDEX IF NOT EXISTS idx_events_seq_desc_contract_id
+  ON events (seq DESC, contract_id);

--- a/indexer/src/api.js
+++ b/indexer/src/api.js
@@ -286,34 +286,54 @@ export function createApi({ logDestination, dbOverride } = {}) {
 
   // ── Existing endpoints ──────────────────────────────────────────────────────
 
-  // GET /api/events?contract=&fn=&page=
+  // GET /api/events?contract=&fn=&type=&after_seq=&limit=
+  // Keyset (cursor) pagination — `after_seq` is the `next_cursor` value from
+  // the previous page (omit for the first page). Responds with
+  // { data: Event[], next_cursor: number|null } (#490).
   app.get(
     "/api/events",
+    // Validate before the cache middleware so malformed params can never be
+    // served a cached 200 (their cache key normalizes to the first page).
+    (req, res, next) => {
+      if (req.query.limit !== undefined) {
+        const parsedLimit = Number(req.query.limit);
+        if (isNaN(parsedLimit) || parsedLimit <= 0 || parsedLimit > 200) {
+          return res.status(422).json({ error: "Invalid limit" });
+        }
+      }
+      if (req.query.after_seq !== undefined) {
+        const parsedAfter = Number(req.query.after_seq);
+        if (!Number.isInteger(parsedAfter) || parsedAfter < 0) {
+          return res.status(422).json({ error: "Invalid after_seq" });
+        }
+      }
+      next();
+    },
     makeCache("events_list", (req) => {
-      const { contract = "", fn = "", page = "1", type = "" } = req.query;
-      return `events:list:${contract}:${fn}:${page}:${type}`;
+      const { contract = "", fn = "", type = "" } = req.query;
+      const after = Number(req.query.after_seq) || 0;
+      const limit = Number(req.query.limit) || 25;
+      return `events:list:${contract}:${fn}:${after}:${limit}:${type}`;
     }),
     async (req, res) => {
       try {
-        const key = `events:list:${req.query.contract ?? ""}:${req.query.fn ?? ""}:${Number(req.query.page) || 1}:${req.query.type ?? ""}`;
-        const events = await db.getEvents({
-          contract: req.query.contract,
-          fn: req.query.fn,
-          page: Number(req.query.page) || 1,
-          type: req.query.type,
-        });
+        const contract = req.query.contract || undefined;
+        const fn = req.query.fn || undefined;
+        const type = req.query.type || undefined;
+        const after_seq = req.query.after_seq ? Number(req.query.after_seq) : 0;
+        const limit = req.query.limit ? Number(req.query.limit) : 25;
+
+        const result = await db.getEventsCursor({ contract, fn, type, after_seq, limit });
+
         // Predictive pre-fetch: next page if user is paginating
-        schedulePrefetch(key, {
-          [`events:list:${req.query.contract ?? ""}:${req.query.fn ?? ""}:${(Number(req.query.page) || 1) + 1}:${req.query.type ?? ""}`]:
-            () =>
-              db.getEvents({
-                contract: req.query.contract,
-                fn: req.query.fn,
-                page: (Number(req.query.page) || 1) + 1,
-                type: req.query.type,
-              }),
-        });
-        res.json(events);
+        if (result.next_cursor !== null) {
+          const key = `events:list:${contract ?? ""}:${fn ?? ""}:${after_seq}:${limit}:${type ?? ""}`;
+          schedulePrefetch(key, {
+            [`events:list:${contract ?? ""}:${fn ?? ""}:${result.next_cursor}:${limit}:${type ?? ""}`]: () =>
+              db.getEventsCursor({ contract, fn, type, after_seq: result.next_cursor, limit }),
+          });
+        }
+        res.json(result);
       } catch (e) {
         res.status(500).json({ error: e.message });
       }

--- a/indexer/src/cacheWarming.js
+++ b/indexer/src/cacheWarming.js
@@ -15,16 +15,21 @@ export async function warmCache() {
   console.log("[cache:warm] starting...");
   const results = { warmed: 0, failed: 0 };
 
-  // Warm events list pages 1–3
+  // Warm the first 3 keyset pages of the events list (cursor chain, #490).
+  // Keys mirror the /api/events cache key: events:list:{contract}:{fn}:{after}:{limit}:{type}
+  let after = 0;
   for (let page = 1; page <= 3; page++) {
     try {
-      const events = await db.getEvents({ page });
-      const key = `events:list:::${page}:`;
-      await cacheSet(key, events, "events_list", 0);
+      const result = await db.getEventsCursor({ after_seq: after, limit: 25 });
+      const key = `events:list:::${after}:25:`;
+      await cacheSet(key, result, "events_list", 0);
       results.warmed++;
+      if (result.next_cursor === null) break;
+      after = result.next_cursor;
     } catch (e) {
       console.warn(`[cache:warm] events page ${page} failed:`, e.message);
       results.failed++;
+      break;
     }
   }
 

--- a/indexer/src/db.js
+++ b/indexer/src/db.js
@@ -78,7 +78,8 @@ export const db = {
 
     const hasMore = rows.length > limit;
     const data = hasMore ? rows.slice(0, limit) : rows;
-    const next_cursor = hasMore ? data[data.length - 1].seq : null;
+    // seq is BIGINT so pg returns it as a string — coerce for a numeric cursor
+    const next_cursor = hasMore ? Number(data[data.length - 1].seq) : null;
 
     return { data, next_cursor };
   },
@@ -132,6 +133,11 @@ export const db = {
     await this.upsertEvent(validated);
   },
 
+  /**
+   * @deprecated OFFSET pagination degrades to a full-table scan at depth on
+   * large tables — use getEventsCursor() instead (#490). Kept only for the
+   * page-based GET /api/contracts/:id/events endpoint.
+   */
   async getEvents({ contract, fn, page = 1, limit = 25, type } = {}) {
     const conditions = [];
     const params = [];

--- a/indexer/test/api.test.js
+++ b/indexer/test/api.test.js
@@ -14,8 +14,8 @@ describe("API request correlation and logging", () => {
     const app = createApi({
       logDestination: logStream,
       dbOverride: {
-        async getEvents() {
-          return [];
+        async getEventsCursor() {
+          return { data: [], next_cursor: null };
         },
       },
     });
@@ -41,8 +41,8 @@ describe("API request correlation and logging", () => {
     const app = createApi({
       logDestination: new PassThrough(),
       dbOverride: {
-        async getEvents() {
-          return [];
+        async getEventsCursor() {
+          return { data: [], next_cursor: null };
         },
       },
     });

--- a/indexer/test/api/api.test.js
+++ b/indexer/test/api/api.test.js
@@ -134,24 +134,69 @@ describe("REST API Integration Tests", () => {
     });
   });
 
-  describe("GET /api/events (Page-based)", () => {
-    it("should return events list with page-based pagination", async () => {
-      const res = await request(app).get("/api/events?page=1");
+  describe("GET /api/events (Keyset cursor)", () => {
+    // Each test uses a distinct X-Forwarded-For so the per-IP unauthenticated
+    // rate-limit bucket (burst 10) is not shared with the rest of the suite.
+    let ipCounter = 0;
+    const getEvents = (url) => request(app).get(url).set("X-Forwarded-For", `10.90.0.${++ipCounter}`);
+
+    it("should return { data, next_cursor } with default limit 25", async () => {
+      const res = await getEvents("/api/events");
       expect(res.status).toBe(200);
-      expect(Array.isArray(res.body)).toBe(true);
-      expect(res.body.length).toBeLessThanOrEqual(25);
+      expect(Array.isArray(res.body.data)).toBe(true);
+      expect(res.body.data.length).toBe(25);
+      expect(res.body.next_cursor).not.toBeNull();
+    });
+
+    it("should return null next_cursor when no further pages exist", async () => {
+      const res = await getEvents("/api/events?limit=200");
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(50);
+      expect(res.body.next_cursor).toBeNull();
+    });
+
+    it("should paginate correctly using next_cursor as after_seq", async () => {
+      const res1 = await getEvents("/api/events?limit=30");
+      expect(res1.status).toBe(200);
+      expect(res1.body.data.length).toBe(30);
+      const nextCursor = res1.body.next_cursor;
+      expect(nextCursor).not.toBeNull();
+
+      const res2 = await getEvents(`/api/events?limit=30&after_seq=${nextCursor}`);
+      expect(res2.status).toBe(200);
+      expect(res2.body.data.length).toBe(20);
+      expect(res2.body.next_cursor).toBeNull();
+
+      // No overlap: every seq on page 2 is below the cursor
+      const maxPage2Seq = Math.max(...res2.body.data.map((e) => Number(e.seq)));
+      expect(maxPage2Seq).toBeLessThan(Number(nextCursor));
     });
 
     it("should filter events by contract", async () => {
-      const res = await request(app).get("/api/events?contract=C1");
+      const res = await getEvents("/api/events?contract=C1");
       expect(res.status).toBe(200);
-      expect(res.body.every((ev) => ev.contract_id === "C1")).toBe(true);
+      expect(res.body.data.every((ev) => ev.contract_id === "C1")).toBe(true);
     });
 
     it("should filter events by function name", async () => {
-      const res = await request(app).get("/api/events?fn=transfer");
+      const res = await getEvents("/api/events?fn=transfer");
       expect(res.status).toBe(200);
-      expect(res.body.every((ev) => ev.function === "transfer")).toBe(true);
+      expect(res.body.data.every((ev) => ev.function === "transfer")).toBe(true);
+    });
+
+    it("should return 422 for invalid limit values", async () => {
+      const invalidLimits = ["-5", "0", "999", "abc"];
+      for (const val of invalidLimits) {
+        const res = await getEvents(`/api/events?limit=${val}`);
+        expect(res.status).toBe(422);
+        expect(res.body).toEqual({ error: "Invalid limit" });
+      }
+    });
+
+    it("should return 422 for an invalid after_seq value", async () => {
+      const res = await getEvents("/api/events?after_seq=abc");
+      expect(res.status).toBe(422);
+      expect(res.body).toEqual({ error: "Invalid after_seq" });
     });
   });
 
@@ -278,6 +323,54 @@ describe("REST API Integration Tests", () => {
     it("should return 400 for a malformed address", async () => {
       const res = await request(app).get("/api/wallet/not-a-valid-address");
       expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /api/events — keyset pagination over 500 events (#490)", () => {
+    // Distinct contract id so these events (and their cache keys) don't
+    // collide with the 50 events seeded for the earlier tests.
+    const PAGINATION_CONTRACT = "CPAGINATION";
+
+    beforeAll(async () => {
+      const values = [];
+      const params = [];
+      for (let i = 1; i <= 500; i++) {
+        const base = params.length;
+        params.push(PAGINATION_CONTRACT, "transfer", 5000 + i, `pagination_tx_${i}`, `Pagination event ${i}`, "[]", "{}");
+        values.push(`($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6}, $${base + 7})`);
+      }
+      await db.query(
+        `INSERT INTO events (contract_id, function, ledger, tx_hash, description, raw_topics, raw_data)
+         VALUES ${values.join(", ")}`,
+        params,
+      );
+    });
+
+    it("returns all 500 events exactly once across pages of 25", async () => {
+      const seenSeqs = [];
+      let after = null;
+      let pages = 0;
+
+      do {
+        const url =
+          after === null
+            ? `/api/events?contract=${PAGINATION_CONTRACT}&limit=25`
+            : `/api/events?contract=${PAGINATION_CONTRACT}&limit=25&after_seq=${after}`;
+        // Unique client IP per request so the per-IP unauthenticated
+        // rate-limit bucket (burst 10) never throttles the pagination walk.
+        const res = await request(app).get(url).set("X-Forwarded-For", `10.91.0.${pages + 1}`);
+        expect(res.status).toBe(200);
+        expect(res.body.data.length).toBeLessThanOrEqual(25);
+        for (const ev of res.body.data) seenSeqs.push(Number(ev.seq));
+        after = res.body.next_cursor;
+        pages++;
+        // Safety guard against an infinite pagination loop
+        expect(pages).toBeLessThanOrEqual(21);
+      } while (after !== null);
+
+      expect(pages).toBe(20);
+      expect(seenSeqs.length).toBe(500);
+      expect(new Set(seenSeqs).size).toBe(500);
     });
   });
 });


### PR DESCRIPTION
Closes #490

## Problem

`GET /api/events` used `LIMIT $N OFFSET $M` pagination: PostgreSQL must scan and discard `M` rows before returning each page, degrading to a full-table scan at depth. Measured on a **5M-row** events table (Postgres 16): page ~196,000 (`OFFSET 4900000`) took **74.5 s**, while the equivalent keyset query returned in **< 1 ms**.

## Changes

### API (`indexer/src/api.js`)
- `GET /api/events` now calls `db.getEventsCursor()` (keyset on `seq`).
- Accepts `?after_seq=` (the `next_cursor` from the previous page; omit for the first page) and `?limit=` (max 200, default 25). Existing `contract`, `fn`, and `type` filters are preserved.
- Response shape changed from `Event[]` to `{ data: Event[], next_cursor: number | null }` — `next_cursor` is `null` when no further pages exist.
- Invalid `limit`/`after_seq` return **422**, validated *before* the cache middleware so malformed params can never be served a cached 200 (their cache key would normalize to the first page).
- The predictive-prefetch hook and `cacheWarming.js` now chain cursors instead of incrementing page numbers.

### DB (`indexer/src/db.js`)
- `getEvents()` is marked `@deprecated`. It is intentionally **kept** for one caller: the page-based `GET /api/contracts/:id/events` endpoint, whose public contract (`?page=&limit=`, `{ events, pagination }`) is exercised by the e2e suite and is out of scope for #490. Every other caller now uses `getEventsCursor()`.
- `next_cursor` is coerced to a number (`pg` returns `BIGINT` columns as strings; this also fixes the string cursor previously returned by `/api/v1/events`).

### Migration (`indexer/migrations/006_keyset_index.sql`)
- Adds composite `(seq DESC, contract_id)` index (idempotent). Note: the issue named `indexer/src/migrations/`, but the migration runner (`src/migrate.js`) reads `indexer/migrations/`, so the file lives there. `seq` is already the `BIGSERIAL` primary key, so unfiltered keyset scans were covered; the composite covers contract-filtered scans.

### Frontend
- `api.events()` takes `after_seq`/`limit` and returns the new `EventsPage` shape.
- The events list (`Home.tsx`, which owns pagination for `EventTable`) keeps a cursor stack, so **Prev/Next both still work**; Next disables exactly when `next_cursor` is `null` (previously it guessed from `events.length < 25`). Filter changes reset to the first page. `ContractPage`/`DeveloperWorkspace` read `.data`.

### Docs & tests
- `docs/api/openapi.yaml`: `/api/events` documents `after_seq`, `limit`, the `CursorPaginatedEvents` response, and the 422 case.
- `indexer/test/api/api.test.js`: events tests rewritten for the cursor shape, plus the required test seeding **500 synthetic events and walking them in pages of 25 via `next_cursor`, asserting all 500 are returned exactly once with no duplicates** (passes: 20 pages, 500 unique seqs, 0 dupes). New tests set distinct `X-Forwarded-For` values so the per-IP unauthenticated rate-limit bucket (burst 10) doesn't throttle the suite.
- Frontend tests updated for the new response shape.

## Performance verification (`EXPLAIN ANALYZE`, 5M rows, index in place)

| Query | Time |
|---|---|
| keyset, `seq < 100000` (deep page) | 0.20 ms |
| keyset, `seq < 4999000` (first pages) | 0.10 ms |
| keyset + `contract_id` filter | 9.6 ms (warm) |
| `OFFSET 4900000` (old approach) | **74,550 ms** |

All plans are backward index scans; no sort, no throwaway row scan.

Also verified end-to-end against a live server: paginated all seeded events over HTTP in pages of 25 — exactly-once delivery, `next_cursor: null` on the final page, 422 on malformed params, `{ data: [], next_cursor: null }` for an exhausted cursor, and cache `X-Cache: HIT` on repeat pages.

Note: pre-existing test failures in `test/api/api.test.js` (health-check DB mocks, `POST /api/contracts` auth) and `test/api.test.js` (request-id logging) reproduce identically on `main` in my environment and are untouched by this PR.