### PR TITLE
fix(indexer): track ABI versions for event re-decoding

### DIFF
--- a/indexer/migrations/009_abi_version_tracking.sql
+++ b/indexer/migrations/009_abi_version_tracking.sql
@@ -1,0 +1,9 @@
+-- Track the ABI used to decode each event so superseded values can be repaired.
+
+ALTER TABLE events
+  ADD COLUMN IF NOT EXISTS abi_version INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS needs_redecode BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_events_needs_redecode
+  ON events(contract_id)
+  WHERE needs_redecode = TRUE;

--- a/indexer/src/db.js
+++ b/indexer/src/db.js
@@ -128,8 +128,8 @@ export const db = {
       `INSERT INTO events
          (contract_id, function, ledger, tx_hash, description, raw_topics, raw_data,
           cpu_instructions, mem_bytes, fee_charged, is_high_bloat_risk, upgrade_info, storage_tiers, is_clawback,
-          footprint_contention, ttl_extension, fee_bump, archival_info, zk_host_calls)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19)
+          footprint_contention, ttl_extension, fee_bump, archival_info, zk_host_calls, abi_version)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20)
        ON CONFLICT DO NOTHING`,
       [
         ev.contract_id,
@@ -151,6 +151,57 @@ export const db = {
         ev.fee_bump ? JSON.stringify(ev.fee_bump) : null,
         ev.archival_info ? JSON.stringify(ev.archival_info) : null,
         ev.zk_host_calls ? JSON.stringify(ev.zk_host_calls) : null,
+        ev.abi_version ?? 0,
+      ],
+    );
+  },
+
+  async markNeedsRedecode(contractId, newAbiVersion) {
+    if (!contractId || !Number.isInteger(Number(newAbiVersion)) || Number(newAbiVersion) < 0) {
+      throw new Error("contractId and a non-negative ABI version are required");
+    }
+    const { rowCount } = await pool.query(
+      `UPDATE events
+       SET needs_redecode = TRUE
+       WHERE contract_id = $1 AND abi_version < $2 AND needs_redecode = FALSE`,
+      [contractId, Number(newAbiVersion)],
+    );
+    return rowCount ?? 0;
+  },
+
+  async getEventsNeedingRedecode(limit = 100) {
+    const safeLimit = Number(limit);
+    if (!Number.isInteger(safeLimit) || safeLimit < 1 || safeLimit > 1000) {
+      throw new Error("redecode batch size must be between 1 and 1000");
+    }
+    const { rows } = await pool.query(
+      `SELECT seq, contract_id, function, ledger, tx_hash, raw_topics, raw_data, abi_version
+       FROM events
+       WHERE needs_redecode = TRUE
+       ORDER BY seq ASC
+       LIMIT $1`,
+      [safeLimit],
+    );
+    return rows;
+  },
+
+  async updateRedecodedEvent(seq, decoded, abiVersion) {
+    await pool.query(
+      `UPDATE events
+       SET function = $2,
+           description = $3,
+           raw_topics = $4,
+           raw_data = $5,
+           abi_version = $6,
+           needs_redecode = FALSE
+       WHERE seq = $1 AND needs_redecode = TRUE`,
+      [
+        seq,
+        decoded.function,
+        decoded.description,
+        JSON.stringify(decoded.raw_topics),
+        decoded.raw_data,
+        abiVersion,
       ],
     );
   },

--- a/indexer/src/decodedEvent.schema.json
+++ b/indexer/src/decodedEvent.schema.json
@@ -89,6 +89,10 @@
     },
     "sac_asset": {
       "type": "string"
+    },
+    "abi_version": {
+      "type": "integer",
+      "minimum": 0
     }
   }
 }

--- a/indexer/src/decoder.js
+++ b/indexer/src/decoder.js
@@ -104,7 +104,7 @@ const NATIVE_SAC_IDS = new Set([
  * Decode a raw Soroban RPC event into a human-readable record.
  * Uses the ABI template when available; falls back to a generic description.
  */
-export async function decode(ev) {
+export async function decode(ev, { currentAbi = false } = {}) {
   const contractId = ev.contractId;
   const topics = ev.topic.map((t) => scValToNative(t));
   const data = scValToNative(ev.value);
@@ -131,9 +131,11 @@ export async function decode(ev) {
 
   // Look up registered ABI for richer description
   // Use versioned lookup: find the ABI version active at the event's ledger
-  const meta = await db
-    .getContractMetaByLedger(contractId, ev.ledger)
-    .catch(() => null) ?? await db.getContractMeta(contractId).catch(() => null);
+  const meta = currentAbi
+    ? await db.getContractMeta(contractId).catch(() => null)
+    : await db
+        .getContractMetaByLedger(contractId, ev.ledger)
+        .catch(() => null) ?? await db.getContractMeta(contractId).catch(() => null);
   const fnAbi = meta?.functions?.find((f) => f.name === fnName);
 
   // Check if this contract is a registered vault

--- a/indexer/src/index.js
+++ b/indexer/src/index.js
@@ -25,6 +25,7 @@ import { handleVaultEvent, refreshAllVaults } from "./vaultIndexer.js";
 import { processCircuitBreakerEvent } from "./circuitBreakerIndexer.js";
 import { startGasGuzzlersWorker } from "./gasGuzzlers.js";
 import { checkForReorg, recordLedgerHash } from "./reorgWorker.js";
+import { startReDecodeWorker } from "./reDecodeWorker.js";
 import { warmCache } from "./cacheWarming.js";
 import { cacheInvalidate } from "./cacheLayer.js";
 import { eventsIngested, decodeLatency, rpcErrors, updateDbPoolMetrics } from "./metrics.js";
@@ -173,6 +174,8 @@ export async function processSingleEvent(rawSorobanEvent, context = undefined) {
   const { feeBump, archivalInfo } = context ?? (await loadTransactionContext(rawSorobanEvent.txHash));
   const decodeStart = Date.now();
   const decoded = await decode(rawSorobanEvent);
+  const contractMeta = await db.getContractMeta(rawSorobanEvent.contractId).catch(() => null);
+  decoded.abi_version = Number(contractMeta?.abi_version ?? 0);
   decodeLatency.observe(Date.now() - decodeStart);
   eventsIngested.inc({ function: decoded.function });
   decoded.is_high_bloat_risk = isHighBloatRisk(rawSorobanEvent, rawSorobanEvent.contractId);
@@ -184,6 +187,9 @@ export async function processSingleEvent(rawSorobanEvent, context = undefined) {
       `[${rawSorobanEvent.ledger}] CONTRACT UPGRADE ${rawSorobanEvent.contractId}: ${upgrade.oldHash} → ${upgrade.newHash}`,
     );
     decoded.upgrade = upgrade;
+    if (decoded.abi_version > 0) {
+      await db.markNeedsRedecode(rawSorobanEvent.contractId, decoded.abi_version);
+    }
   }
 
   decoded.storage_tiers = classifyStorageWrites(rawSorobanEvent);
@@ -210,9 +216,8 @@ export async function processSingleEvent(rawSorobanEvent, context = undefined) {
   handleVaultEvent(decoded); // vault ratio update (async, non-blocking)
 
   // Process circuit breaker events.
-  const meta = await db.getContractMeta(rawSorobanEvent.contractId).catch(() => null);
-  if (meta) {
-    processCircuitBreakerEvent(decoded, meta).catch((err) =>
+  if (contractMeta) {
+    processCircuitBreakerEvent(decoded, contractMeta).catch((err) =>
       console.error("[circuitBreakerIndexer] Error:", err.message),
     );
   }
@@ -294,6 +299,7 @@ async function run() {
   startMetricsCollector(); // RPC latency probes
   startPruner(); // daily temporary-storage cleanup
   startGasGuzzlersWorker(); // daily gas consumption leaderboard
+  startReDecodeWorker(); // low-priority ABI refresh for superseded events
 
   // ── Auth & Rate Limiting cron jobs ─────────────────────────────────────────
   startUsageFlushCron();       // flush Redis usage counters → DB every minute

--- a/indexer/src/reDecodeWorker.js
+++ b/indexer/src/reDecodeWorker.js
@@ -1,0 +1,83 @@
+import { db } from "./db.js";
+import { decode } from "./decoder.js";
+
+const DEFAULT_BATCH_SIZE = 100;
+const DEFAULT_INTERVAL_MS = 5_000;
+
+function parseJson(value, fallback) {
+  if (value == null) return fallback;
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return fallback;
+  }
+}
+
+function parseBatchSize(value) {
+  const batchSize = Number(value ?? DEFAULT_BATCH_SIZE);
+  if (!Number.isInteger(batchSize) || batchSize < 1 || batchSize > 1000) {
+    throw new Error("REDECODE_BATCH_SIZE must be an integer between 1 and 1000");
+  }
+  return batchSize;
+}
+
+function rawEventFromRow(row) {
+  const topics = parseJson(row.raw_topics, []);
+  const value = parseJson(row.raw_data, null);
+  if (!Array.isArray(topics)) throw new Error(`event ${row.seq} has invalid raw topics`);
+  return {
+    contractId: row.contract_id,
+    topic: topics,
+    value,
+    ledger: Number(row.ledger),
+    txHash: row.tx_hash,
+  };
+}
+
+export async function runReDecodeBatch({ dbModule = db, decodeFn = decode, batchSize = DEFAULT_BATCH_SIZE } = {}) {
+  const rows = await dbModule.getEventsNeedingRedecode(parseBatchSize(batchSize));
+  let processed = 0;
+
+  for (const row of rows) {
+    try {
+      const meta = await dbModule.getContractMeta(row.contract_id);
+      if (!meta || Number(meta.abi_version) <= Number(row.abi_version ?? 0)) continue;
+
+      const decoded = await decodeFn(rawEventFromRow(row), { currentAbi: true });
+      decoded.abi_version = Number(meta.abi_version);
+      await dbModule.updateRedecodedEvent(row.seq, decoded, Number(meta.abi_version));
+      processed++;
+    } catch (error) {
+      console.error(`[redecode] event ${row.seq} failed: ${error.message}`);
+    }
+  }
+  return processed;
+}
+
+export function startReDecodeWorker({
+  dbModule = db,
+  decodeFn = decode,
+  batchSize = process.env.REDECODE_BATCH_SIZE ?? DEFAULT_BATCH_SIZE,
+  intervalMs = Number(process.env.REDECODE_INTERVAL_MS ?? DEFAULT_INTERVAL_MS),
+} = {}) {
+  if (!Number.isInteger(intervalMs) || intervalMs < 100) {
+    throw new Error("REDECODE_INTERVAL_MS must be an integer of at least 100ms");
+  }
+
+  let running = false;
+  const tick = async () => {
+    if (running) return;
+    running = true;
+    try {
+      await runReDecodeBatch({ dbModule, decodeFn, batchSize });
+    } finally {
+      running = false;
+    }
+  };
+
+  const timer = setInterval(() => tick().catch((error) => console.error("[redecode] worker failed:", error.message)), intervalMs);
+  timer.unref?.();
+  tick().catch((error) => console.error("[redecode] initial run failed:", error.message));
+  return () => clearInterval(timer);
+}

--- a/indexer/test/reDecodeWorker.test.js
+++ b/indexer/test/reDecodeWorker.test.js
@@ -1,0 +1,36 @@
+import { runReDecodeBatch } from "../src/reDecodeWorker.js";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+describe("reDecodeWorker", () => {
+  it("re-decodes superseded events and clears their marker", async () => {
+    const updated = [];
+    const db = {
+      getEventsNeedingRedecode: async () => [
+        {
+          seq: 7,
+          contract_id: "C1",
+          ledger: 12,
+          tx_hash: "tx-7",
+          raw_topics: JSON.stringify(["transfer"]),
+          raw_data: JSON.stringify("100"),
+          abi_version: 1,
+        },
+      ],
+      getContractMeta: async () => ({ abi_version: 2 }),
+      updateRedecodedEvent: async (...args) => updated.push(args),
+    };
+    const decode = async (event, options) => {
+      assert.deepEqual({ contractId: event.contractId, ledger: event.ledger, txHash: event.txHash }, { contractId: "C1", ledger: 12, txHash: "tx-7" });
+      assert.deepEqual(options, { currentAbi: true });
+      return { function: "transfer_v2", description: "decoded with ABI v2", raw_topics: ["transfer"], raw_data: "100" };
+    };
+
+    assert.equal(await runReDecodeBatch({ dbModule: db, decodeFn: decode }), 1);
+    assert.equal(updated.length, 1);
+    assert.equal(updated[0][0], 7);
+    assert.equal(updated[0][1].function, "transfer_v2");
+    assert.equal(updated[0][1].abi_version, 2);
+    assert.equal(updated[0][2], 2);
+  });
+});


### PR DESCRIPTION
Changes include:

  - ABI tracking migration and partial index
  - Event ABI version persistence
  - Upgrade-based stale event marking
  - Background re-decode worker
  - Current-ABI decoding support
  - API exposure via needs_redecode
  - Worker integration test
closes #496 