### PR TITLE
feat(frontend): add Contract Registry page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import Nav from "./components/Nav";
 import ErrorBoundary from "./components/ErrorBoundary";
 
 const Home = lazy(() => import("./pages/Home"));
+const RegistryPage = lazy(() => import("./pages/RegistryPage"));
 const ContractPage = lazy(() => import("./pages/ContractPage"));
 const WalletPage = lazy(() => import("./pages/WalletPage"));
 const EventPage = lazy(() => import("./pages/EventPage"));
@@ -31,6 +32,7 @@ export default function App() {
         <Suspense fallback={<Fallback />}>
           <Routes>
             <Route path="/" element={<Home />} />
+            <Route path="/contracts" element={<RegistryPage />} />
             <Route path="/contract/:id" element={<ContractPage />} />
             <Route path="/contract/:id/workspace" element={<DeveloperWorkspace />} />
             <Route path="/wallet/:address" element={<WalletPage />} />

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -159,6 +159,28 @@ export interface ContractMeta {
   dependency_advisory?: DependencyAdvisory | null;
 }
 
+export interface ContractListItem {
+  id: string;
+  name: string;
+  description: string;
+  registered_by: string;
+  has_circuit_breaker: boolean;
+  is_paused: boolean;
+  is_rwa: boolean;
+  rwa_type: string | null;
+  created_at: string;
+}
+
+export interface ContractsListResponse {
+  contracts: ContractListItem[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    total_pages: number;
+  };
+}
+
 export type SearchKind = "contract" | "event" | "wallet";
 
 export interface SearchContract {
@@ -418,6 +440,12 @@ export const api = {
   },
   zkCosts: (seq: number) => get<{ calls: ZkHostCall[]; delta: ZkCostDelta | null }>(`/events/${seq}/zk-costs`),
   contract: (id: string) => get<ContractMeta>(`/contracts/${id}`),
+  listContracts: (page = 1, limit = 25) => {
+    const q = new URLSearchParams();
+    q.set("page", String(page));
+    q.set("limit", String(limit));
+    return get<ContractsListResponse>(`/contracts?${q}`);
+  },
   burnAlerts: (contract: string) => get<BurnAlert[]>(`/burn-alerts?contract=${contract}`),
   migrationStatus: (id: string) => get<MigrationStatus>(`/contracts/${id}/migration-status`),
   wallet: (address: string) => get<DecodedEvent[]>(`/wallet/${address}`),

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -33,6 +33,9 @@ export default function Nav() {
       <Link to="/" style={{ fontWeight: 700, fontSize: 16, whiteSpace: "nowrap" }}>
         ⬡ Soroban Explorer
       </Link>
+      <Link to="/contracts" style={{ fontSize: 13, whiteSpace: "nowrap", color: "var(--muted)" }}>
+        Registry
+      </Link>
       <Link to="/search" style={{ fontSize: 13, whiteSpace: "nowrap", color: "var(--muted)" }}>
         Search
       </Link>

--- a/frontend/src/pages/RegistryPage.tsx
+++ b/frontend/src/pages/RegistryPage.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api";
+import { truncateAddress } from "../utils/strkey";
+
+export default function RegistryPage() {
+  const [page, setPage] = useState(1);
+  const limit = 25;
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["contracts", "list", page, limit],
+    queryFn: () => api.listContracts(page, limit),
+  });
+
+  const contracts = data?.contracts ?? [];
+  const pagination = data?.pagination;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+      <div>
+        <h1 style={{ fontSize: 22, marginBottom: 4 }}>Contract Registry</h1>
+        <p style={{ color: "var(--muted)" }}>
+          Registered Soroban smart contracts on the Stellar network.
+        </p>
+      </div>
+
+      <div className="card">
+        {error && <p style={{ color: "#f85149" }}>{(error as Error).message}</p>}
+        {isLoading && <p style={{ color: "var(--muted)" }}>Loading…</p>}
+        {!isLoading && !error && contracts.length === 0 && (
+          <p style={{ color: "var(--muted)" }}>No contracts registered yet.</p>
+        )}
+        {!isLoading && contracts.length > 0 && (
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr style={{ borderBottom: "1px solid var(--border)", textAlign: "left" }}>
+                <th style={{ padding: "8px 4px" }}>Name</th>
+                <th style={{ padding: "8px 4px" }}>Contract ID</th>
+                <th style={{ padding: "8px 4px" }}>Registered By</th>
+                <th style={{ padding: "8px 4px" }}>Created At</th>
+              </tr>
+            </thead>
+            <tbody>
+              {contracts.map((c) => (
+                <tr key={c.id} style={{ borderBottom: "1px solid var(--border)" }}>
+                  <td style={{ padding: "10px 4px" }}>
+                    <Link to={`/contract/${c.id}`} style={{ fontWeight: 600 }}>
+                      {c.name || truncateAddress(c.id)}
+                    </Link>
+                    {c.description && (
+                      <p style={{ color: "var(--muted)", marginTop: 2, fontSize: 12 }}>
+                        {c.description}
+                      </p>
+                    )}
+                  </td>
+                  <td style={{ padding: "10px 4px" }}>
+                    <code style={{ fontSize: 12, color: "var(--muted)", wordBreak: "break-all" }}>
+                      {c.id}
+                    </code>
+                  </td>
+                  <td style={{ padding: "10px 4px" }}>
+                    <code style={{ fontSize: 12 }}>{truncateAddress(c.registered_by)}</code>
+                  </td>
+                  <td style={{ padding: "10px 4px", color: "var(--muted)", fontSize: 12 }}>
+                    {new Date(c.created_at).toLocaleString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {pagination && pagination.total_pages > 1 && (
+        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+          <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
+            ← Prev
+          </button>
+          <span style={{ color: "var(--muted)" }}>
+            Page {page} of {pagination.total_pages} ({pagination.total} total)
+          </span>
+          <button
+            disabled={page >= pagination.total_pages}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            Next →
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/test/RegistryPage.test.tsx
+++ b/frontend/test/RegistryPage.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import RegistryPage from "../src/pages/RegistryPage";
+
+describe("RegistryPage", () => {
+  it("renders empty state when no contracts exist", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        contracts: [],
+        pagination: { page: 1, limit: 25, total: 0, total_pages: 0 },
+      }),
+    });
+
+    (global as any).fetch = fetchMock;
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/contracts"]}>
+          <Routes>
+            <Route path="/contracts" element={<RegistryPage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/No contracts registered yet/i)).toBeDefined();
+    expect(fetchMock).toHaveBeenCalledWith("/api/contracts?page=1&limit=25");
+  });
+
+  it("renders contract list when contracts exist", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        contracts: [
+          {
+            id: "CABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+            name: "Test Contract",
+            description: "A test contract",
+            registered_by: "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234",
+            has_circuit_breaker: false,
+            is_paused: false,
+            is_rwa: false,
+            rwa_type: null,
+            created_at: "2026-06-29T00:00:00Z",
+          },
+        ],
+        pagination: { page: 1, limit: 25, total: 1, total_pages: 1 },
+      }),
+    });
+
+    (global as any).fetch = fetchMock;
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/contracts"]}>
+          <Routes>
+            <Route path="/contracts" element={<RegistryPage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText("Test Contract")).toBeDefined();
+    expect(screen.getByText("A test contract")).toBeDefined();
+    expect(fetchMock).toHaveBeenCalledWith("/api/contracts?page=1&limit=25");
+  });
+});


### PR DESCRIPTION
## Summary
Adds a dedicated Contract Registry page (`/contracts`) that lists all registered Soroban smart contracts from the indexer API. This addresses the acceptance criteria in #453: "At least one contract row is visible in the Contract Registry page."

## Changes
- **New page:** `frontend/src/pages/RegistryPage.tsx` — paginated table of registered contracts with name, contract ID, registered by, and created at columns.
- **API client:** `frontend/src/api.ts` — added `listContracts(page, limit)` method and `ContractListItem` / `ContractsListResponse` types.
- **Routing:** `frontend/src/App.tsx` — added `/contracts` route.
- **Navigation:** `frontend/src/components/Nav.tsx` — added "Registry" nav link.
- **Tests:** `frontend/test/RegistryPage.test.tsx` — verifies empty state and populated contract list rendering.

## Verification
- Frontend build passes: `npm run build` ✅
- Frontend typecheck passes: `tsc --noEmit` ✅
- Frontend lint passes: `eslint` ✅
- Frontend tests: 117 passed, 1 pre-existing unrelated failure ✅
- New RegistryPage tests: 2 passed ✅
- Explorer contract: `cargo fmt --check`, `cargo clippy`, `cargo build --target wasm32`, `cargo test` all pass ✅
- Ticket contract: `cargo test --features testutils --release` passes ✅
- Pre-push hook passes all contract checks ✅

## Acceptance Criteria
- [x] At least one contract row is visible in the Contract Registry page (when contracts are registered via `POST /api/contracts`).

Closes #453