### PR TITLE
docs: record verified WASM build size and hash for explorer contract (closes #441)

### DIFF
--- a/docs/testnet-deployment.md
+++ b/docs/testnet-deployment.md
@@ -48,6 +48,18 @@ If the contract lives in a workspace package, run the Cargo command from that pa
 find . -path "*target/wasm32-unknown-unknown/release/*.wasm"
 ```
 
+### Verified Build Reference
+
+A clean release build of `soroban-explorer-contract` was verified at commit `002fc6a` (2026-07-21) per [#441](https://github.com/Soroban-Smart-Block-Explorer/Soroban-Smart-Block/issues/441):
+
+| Field | Value |
+| --- | --- |
+| Artifact | `target/wasm32-unknown-unknown/release/soroban_explorer_contract.wasm` |
+| Size | 30,778 bytes (~30 KB, well under the 100 KB budget) |
+| SHA256 | `82dd8081e1af944a331905a69892b45ad9c115ee8e96cdb4ac7ba566bf41b2fd` |
+
+This is a point-in-time record, not a guarantee for future builds — recompute the size and hash after any contract source change before deploying.
+
 ## 2. Deploy The Contract To Testnet
 
 Configure the CLI and fund the deployer account if needed:


### PR DESCRIPTION
## What

closes #441

The issue asked for a fresh release WASM build of `soroban-explorer-contract`, verification that the artifact stays under the 100 KB budget expected for a simple registry contract, and the SHA256 checksum recorded in deployment notes or this PR description.

## Approach

- Ran a clean `cargo build --target wasm32-unknown-unknown --release -p soroban-explorer-contract` (no reused artifacts from a prior flag configuration).
- Verified the resulting `soroban_explorer_contract.wasm` size and computed its SHA256.
- Added a "Verified Build Reference" note to `docs/testnet-deployment.md` (the existing testnet deployment runbook) recording the size, hash, and the commit it was built from, so the record lives in the repo and not just in this PR description. It's explicitly marked as a point-in-time snapshot to regenerate after any future contract change.

No contract source changes were needed — the existing code already builds well within budget.

## Build verification

| Field | Value |
| --- | --- |
| Command | `cargo build --target wasm32-unknown-unknown --release -p soroban-explorer-contract` |
| Artifact | `target/wasm32-unknown-unknown/release/soroban_explorer_contract.wasm` |
| Size | 30,778 bytes (~30 KB) — well under the 100 KB budget |
| SHA256 | `82dd8081e1af944a331905a69892b45ad9c115ee8e96cdb4ac7ba566bf41b2fd` |
| Built from | `002fc6a` (main) |

## Testing

Ran the full contracts CI checklist locally, matching `.github/workflows/ci.yml`'s `contracts` job:

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo build --target wasm32-unknown-unknown --release -p soroban-explorer-contract` — succeeds, 30,778 bytes
- `cargo llvm-cov -p soroban-explorer-contract` — 97.39% line coverage (threshold: 80%)
- `cargo llvm-cov` for `contracts/ticket` — 88.05% line coverage (threshold: 85%)
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps -p soroban-explorer-contract` — builds clean

This is a documentation-only change (no indexer/frontend/migration code touched), so those CI jobs are unaffected.