### PR TITLE
feat: add NFT explorer at /nft/:contractId

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ const SetupPage = lazy(() => import("./pages/SetupPage"));
 const BatchMultiCall = lazy(() => import("./pages/BatchMultiCall"));
 const SubInvocationPage = lazy(() => import("./pages/SubInvocationPage"));
 const RateLimitDashboard = lazy(() => import("./pages/RateLimitDashboard"));
+const NftGallery = lazy(() => import("./pages/NftGallery"));
 
 function Fallback() {
   return <p style={{ padding: 32, textAlign: "center", color: "var(--muted)" }}>Loading…</p>;
@@ -47,6 +48,7 @@ export default function App() {
             <Route path="/batch" element={<BatchMultiCall />} />
             <Route path="/sub-invocations" element={<SubInvocationPage />} />
             <Route path="/admin/rate-limits" element={<RateLimitDashboard />} />
+            <Route path="/nft/:contractId" element={<NftGallery />} />
           </Routes>
         </Suspense>
       </main>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -368,6 +368,54 @@ export interface AddressGraphData {
   edges: GraphEdge[];
 }
 
+// NFT token metadata from on-chain storage (schema is contract-defined)
+export interface NftMetadata {
+  name?: string;
+  description?: string;
+  image?: string;
+  attributes?: { trait_type: string; value: string | number }[];
+  [key: string]: unknown;
+}
+
+// Single NFT token entry returned from GET /api/tokens/:contractId/nfts
+export interface NftToken {
+  token_id: string;
+  owner: string;
+  metadata: NftMetadata | null;
+  last_transfer_ledger: number | null;
+}
+
+// Paginated response from GET /api/tokens/:contractId/nfts
+export interface NftTokensResponse {
+  contract_id: string;
+  tokens: NftToken[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    total_pages: number;
+    has_next: boolean;
+  };
+}
+
+// Single event entry in NFT token history
+export interface NftHistoryEvent {
+  seq: number;
+  function: string;
+  ledger: number;
+  tx_hash: string | null;
+  description: string;
+  raw_topics: string[] | null;
+  created_at: string;
+}
+
+// Response from GET /api/tokens/:contractId/nfts/:tokenId/history
+export interface NftTokenHistoryResponse {
+  contract_id: string;
+  token_id: string;
+  events: NftHistoryEvent[];
+}
+
 // Sub-invocation filter options for the advanced search endpoint
 export interface SubInvocationFilter {
   contract?: string;
@@ -450,6 +498,23 @@ export const api = {
   migrationStatus: (id: string) => get<MigrationStatus>(`/contracts/${id}/migration-status`),
   wallet: (address: string) => get<DecodedEvent[]>(`/wallet/${address}`),
   roles: (id: string) => get<PrivilegedRole[]>(`/contracts/${id}/roles`),
+
+  // NFT collection tokens with optional owner filter and pagination
+  nfts: (
+    contractId: string,
+    params: { owner?: string; page?: number; limit?: number } = {},
+  ) => {
+    const q = new URLSearchParams();
+    if (params.owner) q.set("owner", params.owner);
+    if (params.page) q.set("page", String(params.page));
+    if (params.limit) q.set("limit", String(params.limit));
+    const qs = q.toString();
+    return get<NftTokensResponse>(`/tokens/${contractId}/nfts${qs ? `?${qs}` : ""}`);
+  },
+
+  // Full transfer + mint history for a single NFT token
+  nftHistory: (contractId: string, tokenId: string) =>
+    get<NftTokenHistoryResponse>(`/tokens/${contractId}/nfts/${encodeURIComponent(tokenId)}/history`),
   networkComparison: (id: string) => get<NetworkComparisonResult>(`/contracts/${id}/network-comparison`),
   addressGraph: (id: string) => get<AddressGraphData>(`/contracts/${id}/address-graph`),
 

--- a/frontend/src/components/NftCard.tsx
+++ b/frontend/src/components/NftCard.tsx
@@ -1,0 +1,150 @@
+import { useState } from "react";
+import type { NftToken } from "../api";
+
+interface Props {
+  token: NftToken;
+  onClick: (token: NftToken) => void;
+}
+
+/** Truncate a Stellar address to the first 6 + last 4 characters. */
+function truncateAddress(addr: string): string {
+  if (addr.length <= 12) return addr;
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+export default function NftCard({ token, onClick }: Props) {
+  const [copied, setCopied] = useState(false);
+
+  const imageUrl: string | null =
+    typeof token.metadata?.image === "string" && token.metadata.image.trim()
+      ? token.metadata.image
+      : null;
+
+  const displayName: string =
+    typeof token.metadata?.name === "string" && token.metadata.name.trim()
+      ? token.metadata.name
+      : `Token #${token.token_id}`;
+
+  function handleCopy(e: React.MouseEvent) {
+    e.stopPropagation();
+    navigator.clipboard.writeText(token.owner).catch(() => {});
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  return (
+    <article
+      className="card"
+      role="button"
+      tabIndex={0}
+      aria-label={`View details for ${displayName}`}
+      onClick={() => onClick(token)}
+      onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && onClick(token)}
+      style={{ cursor: "pointer", padding: 0, overflow: "hidden" }}
+    >
+      {/* NFT image / placeholder */}
+      <div
+        style={{
+          width: "100%",
+          aspectRatio: "1 / 1",
+          background: "var(--bg)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          overflow: "hidden",
+        }}
+      >
+        {imageUrl ? (
+          <img
+            src={imageUrl}
+            alt={displayName}
+            loading="lazy"
+            style={{ width: "100%", height: "100%", objectFit: "cover" }}
+            onError={(e) => {
+              (e.currentTarget as HTMLImageElement).style.display = "none";
+            }}
+          />
+        ) : (
+          // SVG placeholder with token ID
+          <svg
+            viewBox="0 0 100 100"
+            style={{ width: "60%", height: "60%", opacity: 0.25 }}
+            aria-hidden="true"
+          >
+            <rect width="100" height="100" rx="8" fill="var(--border)" />
+            <text
+              x="50"
+              y="55"
+              textAnchor="middle"
+              fontSize="14"
+              fill="var(--muted)"
+              fontFamily="system-ui, sans-serif"
+            >
+              #{token.token_id}
+            </text>
+          </svg>
+        )}
+      </div>
+
+      {/* Card body */}
+      <div style={{ padding: "12px 14px 14px" }}>
+        <p
+          style={{
+            fontWeight: 600,
+            fontSize: 13,
+            marginBottom: 6,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+          title={displayName}
+        >
+          {displayName}
+        </p>
+
+        {/* Owner row */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+            marginBottom: 6,
+          }}
+        >
+          <span style={{ color: "var(--muted)", fontSize: 11 }}>Owner</span>
+          <code
+            style={{ fontSize: 11, color: "var(--text)", flex: 1, overflow: "hidden", textOverflow: "ellipsis" }}
+            title={token.owner}
+          >
+            {truncateAddress(token.owner)}
+          </code>
+          <button
+            onClick={handleCopy}
+            aria-label="Copy owner address"
+            title={copied ? "Copied!" : "Copy owner address"}
+            style={{
+              padding: "2px 6px",
+              fontSize: 10,
+              background: "var(--border)",
+              color: "var(--text)",
+              borderRadius: 4,
+              flexShrink: 0,
+            }}
+          >
+            {copied ? "✓" : "⎘"}
+          </button>
+        </div>
+
+        {/* Last transfer ledger */}
+        {token.last_transfer_ledger != null && (
+          <div style={{ display: "flex", gap: 4, alignItems: "center" }}>
+            <span style={{ color: "var(--muted)", fontSize: 11 }}>Ledger</span>
+            <span className="badge" style={{ fontSize: 10 }}>
+              {token.last_transfer_ledger.toLocaleString()}
+            </span>
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/components/NftDetailModal.tsx
+++ b/frontend/src/components/NftDetailModal.tsx
@@ -1,0 +1,288 @@
+import { useEffect, useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api";
+import type { NftToken, NftHistoryEvent } from "../api";
+
+interface Props {
+  contractId: string;
+  token: NftToken;
+  onClose: () => void;
+}
+
+function truncateAddress(addr: string): string {
+  if (addr.length <= 12) return addr;
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+export default function NftDetailModal({ contractId, token, onClose }: Props) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  // Close on Escape key
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  // Trap focus inside the modal
+  useEffect(() => {
+    const firstFocusable = overlayRef.current?.querySelector<HTMLElement>(
+      "button, [href], input, select, textarea, [tabindex]:not([tabindex='-1'])",
+    );
+    firstFocusable?.focus();
+  }, []);
+
+  const {
+    data: history,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["nft-history", contractId, token.token_id],
+    queryFn: () => api.nftHistory(contractId, token.token_id),
+  });
+
+  const imageUrl: string | null =
+    typeof token.metadata?.image === "string" && token.metadata.image.trim()
+      ? token.metadata.image
+      : null;
+
+  const displayName =
+    typeof token.metadata?.name === "string" && token.metadata.name.trim()
+      ? token.metadata.name
+      : `Token #${token.token_id}`;
+
+  const attributes = Array.isArray(token.metadata?.attributes)
+    ? (token.metadata!.attributes as { trait_type: string; value: string | number }[])
+    : [];
+
+  function handleOverlayClick(e: React.MouseEvent) {
+    if (e.target === overlayRef.current) onClose();
+  }
+
+  return (
+    // Full-screen overlay
+    <div
+      ref={overlayRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`NFT detail — ${displayName}`}
+      onClick={handleOverlayClick}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.6)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 1000,
+        padding: 16,
+      }}
+    >
+      <div
+        className="card"
+        style={{
+          width: "100%",
+          maxWidth: 680,
+          maxHeight: "90vh",
+          overflowY: "auto",
+          display: "flex",
+          flexDirection: "column",
+          gap: 20,
+        }}
+      >
+        {/* Header */}
+        <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 12 }}>
+          <div>
+            <h2 style={{ fontSize: 18, marginBottom: 4 }}>{displayName}</h2>
+            <span style={{ color: "var(--muted)", fontSize: 12 }}>Token ID: {token.token_id}</span>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close modal"
+            style={{
+              background: "var(--border)",
+              color: "var(--text)",
+              padding: "4px 10px",
+              fontSize: 16,
+              flexShrink: 0,
+            }}
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Image + metadata side-by-side on wider screens */}
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: imageUrl ? "1fr 1fr" : "1fr",
+            gap: 16,
+          }}
+        >
+          {imageUrl && (
+            <img
+              src={imageUrl}
+              alt={displayName}
+              style={{
+                width: "100%",
+                borderRadius: 8,
+                border: "1px solid var(--border)",
+                objectFit: "cover",
+                aspectRatio: "1 / 1",
+              }}
+            />
+          )}
+
+          {/* Current metadata */}
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <section className="card" style={{ padding: 12 }}>
+              <h3 style={{ fontSize: 13, color: "var(--muted)", marginBottom: 8 }}>Current Owner</h3>
+              <code style={{ fontSize: 12, wordBreak: "break-all" }}>{token.owner}</code>
+            </section>
+
+            {token.last_transfer_ledger != null && (
+              <section className="card" style={{ padding: 12 }}>
+                <h3 style={{ fontSize: 13, color: "var(--muted)", marginBottom: 4 }}>Last Transfer</h3>
+                <span className="badge">Ledger {token.last_transfer_ledger.toLocaleString()}</span>
+              </section>
+            )}
+
+            {token.metadata?.description && (
+              <section className="card" style={{ padding: 12 }}>
+                <h3 style={{ fontSize: 13, color: "var(--muted)", marginBottom: 4 }}>Description</h3>
+                <p style={{ fontSize: 13, lineHeight: 1.5 }}>{String(token.metadata.description)}</p>
+              </section>
+            )}
+
+            {attributes.length > 0 && (
+              <section className="card" style={{ padding: 12 }}>
+                <h3 style={{ fontSize: 13, color: "var(--muted)", marginBottom: 8 }}>Attributes</h3>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+                  {attributes.map((attr, i) => (
+                    <div
+                      key={i}
+                      className="card"
+                      style={{
+                        padding: "4px 8px",
+                        textAlign: "center",
+                        minWidth: 80,
+                      }}
+                    >
+                      <div style={{ fontSize: 10, color: "var(--muted)", marginBottom: 2 }}>
+                        {attr.trait_type}
+                      </div>
+                      <div style={{ fontSize: 12, fontWeight: 600 }}>{String(attr.value)}</div>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            )}
+          </div>
+        </div>
+
+        {/* Transfer + Mint history */}
+        <section>
+          <h3 style={{ fontSize: 14, marginBottom: 10 }}>Transfer & Mint History</h3>
+
+          {isLoading && <p style={{ color: "var(--muted)", fontSize: 13 }}>Loading history…</p>}
+
+          {error && (
+            <p style={{ color: "#f85149", fontSize: 13 }}>
+              Failed to load history: {(error as Error).message}
+            </p>
+          )}
+
+          {history && history.events.length === 0 && (
+            <p style={{ color: "var(--muted)", fontSize: 13 }}>No indexed events found for this token.</p>
+          )}
+
+          {history && history.events.length > 0 && (
+            <div
+              style={{ display: "flex", flexDirection: "column", gap: 6, maxHeight: 320, overflowY: "auto" }}
+              role="list"
+              aria-label="Token transfer history"
+            >
+              {history.events.map((event: NftHistoryEvent) => (
+                <div
+                  key={event.seq}
+                  className="card"
+                  role="listitem"
+                  style={{ padding: "10px 12px", display: "flex", flexDirection: "column", gap: 4 }}
+                >
+                  <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                    <span
+                      className="badge"
+                      style={{
+                        background: event.function === "mint" ? "#1a3a22" : "var(--border)",
+                        color: event.function === "mint" ? "var(--green)" : "var(--text)",
+                        fontSize: 11,
+                      }}
+                    >
+                      {event.function}
+                    </span>
+                    <span style={{ color: "var(--muted)", fontSize: 11 }}>
+                      Ledger {event.ledger.toLocaleString()}
+                    </span>
+                    {event.tx_hash && (
+                      <code
+                        style={{ fontSize: 10, color: "var(--muted)", overflow: "hidden", textOverflow: "ellipsis" }}
+                        title={event.tx_hash}
+                      >
+                        {truncateAddress(event.tx_hash)}
+                      </code>
+                    )}
+                    <span style={{ marginLeft: "auto", color: "var(--muted)", fontSize: 10 }}>
+                      {formatDate(event.created_at)}
+                    </span>
+                  </div>
+                  <p style={{ fontSize: 12, color: "var(--text)", marginTop: 2 }}>
+                    {event.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Raw metadata (collapsible) */}
+        {token.metadata && (
+          <details>
+            <summary
+              style={{
+                cursor: "pointer",
+                fontSize: 13,
+                color: "var(--muted)",
+                userSelect: "none",
+              }}
+            >
+              Raw metadata JSON
+            </summary>
+            <pre
+              className="card"
+              style={{
+                marginTop: 8,
+                padding: 10,
+                fontSize: 11,
+                overflow: "auto",
+                maxHeight: 200,
+                background: "var(--bg)",
+              }}
+            >
+              {JSON.stringify(token.metadata, null, 2)}
+            </pre>
+          </details>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/NftGallery.tsx
+++ b/frontend/src/pages/NftGallery.tsx
@@ -1,0 +1,231 @@
+import { useState } from "react";
+import { useParams } from "react-router-dom";
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { api } from "../api";
+import type { NftToken } from "../api";
+import NftCard from "../components/NftCard";
+import NftDetailModal from "../components/NftDetailModal";
+
+const PAGE_SIZE = 50;
+
+export default function NftGallery() {
+  const { contractId = "" } = useParams<{ contractId: string }>();
+
+  const [page, setPage] = useState(1);
+  const [ownerFilter, setOwnerFilter] = useState("");
+  const [ownerInput, setOwnerInput] = useState("");
+  const [selectedToken, setSelectedToken] = useState<NftToken | null>(null);
+
+  const { data, isLoading, error, isFetching } = useQuery({
+    queryKey: ["nfts", contractId, page, ownerFilter],
+    queryFn: () =>
+      api.nfts(contractId, {
+        page,
+        limit: PAGE_SIZE,
+        owner: ownerFilter || undefined,
+      }),
+    enabled: !!contractId,
+    placeholderData: keepPreviousData,
+  });
+
+  function applyOwnerFilter() {
+    setOwnerFilter(ownerInput.trim());
+    setPage(1);
+  }
+
+  function clearOwnerFilter() {
+    setOwnerInput("");
+    setOwnerFilter("");
+    setPage(1);
+  }
+
+  const tokens = data?.tokens ?? [];
+  const pagination = data?.pagination;
+  const totalPages = pagination?.total_pages ?? 1;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+      {/* Page header */}
+      <div className="card">
+        <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <h1 style={{ fontSize: 20, marginBottom: 4 }}>NFT Collection</h1>
+            <code style={{ fontSize: 12, color: "var(--muted)", wordBreak: "break-all" }}>
+              {contractId}
+            </code>
+          </div>
+          {pagination && (
+            <span className="badge" style={{ alignSelf: "flex-start", marginTop: 4 }}>
+              {pagination.total.toLocaleString()} tokens
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Owner filter */}
+      <div className="card" style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+        <label
+          htmlFor="owner-filter"
+          style={{ fontSize: 13, color: "var(--muted)", whiteSpace: "nowrap" }}
+        >
+          Filter by owner:
+        </label>
+        <input
+          id="owner-filter"
+          type="text"
+          placeholder="Stellar address (G…)"
+          value={ownerInput}
+          onChange={(e) => setOwnerInput(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && applyOwnerFilter()}
+          style={{ flex: 1, minWidth: 180 }}
+          aria-label="Filter by owner address"
+        />
+        <button onClick={applyOwnerFilter} aria-label="Apply owner filter">
+          Filter
+        </button>
+        {ownerFilter && (
+          <button
+            onClick={clearOwnerFilter}
+            aria-label="Clear owner filter"
+            style={{ background: "var(--border)", color: "var(--text)" }}
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      {/* Active filter indicator */}
+      {ownerFilter && (
+        <p style={{ fontSize: 12, color: "var(--muted)" }}>
+          Showing tokens owned by <code style={{ fontSize: 12 }}>{ownerFilter}</code>
+        </p>
+      )}
+
+      {/* Loading / error / empty states */}
+      {isLoading && (
+        <div className="card">
+          <p style={{ color: "var(--muted)" }}>Loading NFTs…</p>
+        </div>
+      )}
+
+      {!isLoading && error && (
+        <div className="card">
+          <p style={{ color: "#f85149" }}>
+            Failed to load NFTs: {(error as Error).message}
+          </p>
+        </div>
+      )}
+
+      {!isLoading && !error && tokens.length === 0 && (
+        <div className="card" style={{ textAlign: "center", padding: 40 }}>
+          <p style={{ color: "var(--muted)", marginBottom: 8 }}>
+            {ownerFilter
+              ? "No tokens found for this owner."
+              : "No minted NFTs found for this collection yet."}
+          </p>
+          <p style={{ color: "var(--muted)", fontSize: 12 }}>
+            NFT tokens appear here once they are indexed from on-chain mint events.
+          </p>
+        </div>
+      )}
+
+      {/* NFT grid */}
+      {tokens.length > 0 && (
+        <>
+          <div
+            role="list"
+            aria-label={`NFT grid — ${tokens.length} tokens shown`}
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))",
+              gap: 16,
+              opacity: isFetching ? 0.6 : 1,
+              transition: "opacity 150ms ease",
+            }}
+          >
+            {tokens.map((token) => (
+              <div key={token.token_id} role="listitem">
+                <NftCard token={token} onClick={setSelectedToken} />
+              </div>
+            ))}
+          </div>
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <nav
+              aria-label="NFT pagination"
+              style={{ display: "flex", gap: 8, alignItems: "center", justifyContent: "center", flexWrap: "wrap" }}
+            >
+              <button
+                onClick={() => setPage(1)}
+                disabled={page === 1}
+                aria-label="First page"
+                style={{
+                  background: page === 1 ? "var(--border)" : "var(--accent)",
+                  color: page === 1 ? "var(--muted)" : "#0d1117",
+                  padding: "4px 10px",
+                  fontSize: 12,
+                }}
+              >
+                ««
+              </button>
+              <button
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page === 1}
+                aria-label="Previous page"
+                style={{
+                  background: page === 1 ? "var(--border)" : "var(--accent)",
+                  color: page === 1 ? "var(--muted)" : "#0d1117",
+                  padding: "4px 10px",
+                  fontSize: 12,
+                }}
+              >
+                ‹ Prev
+              </button>
+
+              <span style={{ fontSize: 12, color: "var(--muted)", padding: "4px 4px" }}>
+                Page {page} of {totalPages}
+              </span>
+
+              <button
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page === totalPages}
+                aria-label="Next page"
+                style={{
+                  background: page === totalPages ? "var(--border)" : "var(--accent)",
+                  color: page === totalPages ? "var(--muted)" : "#0d1117",
+                  padding: "4px 10px",
+                  fontSize: 12,
+                }}
+              >
+                Next ›
+              </button>
+              <button
+                onClick={() => setPage(totalPages)}
+                disabled={page === totalPages}
+                aria-label="Last page"
+                style={{
+                  background: page === totalPages ? "var(--border)" : "var(--accent)",
+                  color: page === totalPages ? "var(--muted)" : "#0d1117",
+                  padding: "4px 10px",
+                  fontSize: 12,
+                }}
+              >
+                »»
+              </button>
+            </nav>
+          )}
+        </>
+      )}
+
+      {/* NFT detail modal */}
+      {selectedToken && (
+        <NftDetailModal
+          contractId={contractId}
+          token={selectedToken}
+          onClose={() => setSelectedToken(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/indexer/migrations/010_nft_support.sql
+++ b/indexer/migrations/010_nft_support.sql
@@ -1,0 +1,23 @@
+-- Migration 010: NFT support
+-- Adds protocol_type to contracts table and NFT-specific columns to token_holders.
+
+-- Mark a contract as an NFT collection so the UI can route to /nft/:id
+ALTER TABLE contracts
+  ADD COLUMN IF NOT EXISTS protocol_type TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_contracts_protocol_type
+  ON contracts(protocol_type)
+  WHERE protocol_type IS NOT NULL;
+
+-- Add NFT-specific columns to token_holders.
+-- For NFT collections each row represents one minted token (token_id is non-null).
+-- For fungible tokens these columns remain NULL and the table is used exactly as before.
+ALTER TABLE token_holders
+  ADD COLUMN IF NOT EXISTS token_id           TEXT,
+  ADD COLUMN IF NOT EXISTS metadata_json      JSONB,
+  ADD COLUMN IF NOT EXISTS last_transfer_ledger BIGINT;
+
+-- Index to quickly look up all tokens in a collection and sort by token_id
+CREATE INDEX IF NOT EXISTS idx_token_holders_nft
+  ON token_holders(contract_id, token_id)
+  WHERE token_id IS NOT NULL;

--- a/indexer/src/api.js
+++ b/indexer/src/api.js
@@ -944,6 +944,60 @@ export function createApi({ logDestination, dbOverride } = {}) {
     }
   });
 
+  // ── NFT endpoints ────────────────────────────────────────────────
+
+  // GET /api/tokens/:contractId/nfts
+  //   ?owner=<address>  — filter to tokens owned by this address
+  //   &page=<n>         — 1-indexed page number (default 1)
+  //   &limit=<n>        — results per page, max 200 (default 50)
+  //
+  // Returns a paginated list of all minted NFT token IDs with their
+  // current owner, on-chain metadata, and last transfer ledger.
+  app.get("/api/tokens/:contractId/nfts", async (req, res) => {
+    try {
+      const { contractId } = req.params;
+      const owner = req.query.owner || undefined;
+      const page = req.query.page ? Number(req.query.page) : 1;
+      const limit = req.query.limit ? Number(req.query.limit) : 50;
+
+      if (isNaN(page) || page < 1) {
+        return res.status(422).json({ error: "Invalid page" });
+      }
+      if (isNaN(limit) || limit < 1 || limit > 200) {
+        return res.status(422).json({ error: "Invalid limit" });
+      }
+
+      const { tokens, total } = await db.getNftTokens(contractId, { owner, page, limit });
+
+      const totalPages = Math.ceil(total / limit);
+      res.json({
+        contract_id: contractId,
+        tokens,
+        pagination: {
+          page,
+          limit,
+          total,
+          total_pages: totalPages,
+          has_next: page < totalPages,
+        },
+      });
+    } catch (e) {
+      res.status(500).json({ error: e.message });
+    }
+  });
+
+  // GET /api/tokens/:contractId/nfts/:tokenId/history
+  //   Returns the full mint + transfer event history for a single NFT token.
+  app.get("/api/tokens/:contractId/nfts/:tokenId/history", async (req, res) => {
+    try {
+      const { contractId, tokenId } = req.params;
+      const events = await db.getNftTokenHistory(contractId, tokenId);
+      res.json({ contract_id: contractId, token_id: tokenId, events });
+    } catch (e) {
+      res.status(500).json({ error: e.message });
+    }
+  });
+
   // ── cursor-based pagination endpoint ────────────────────────────
   // GET /api/v1/events?contract=&fn=&type=&after=&limit=
   // `after` is the opaque seq cursor returned as `next_cursor` in the previous page.

--- a/indexer/src/db.js
+++ b/indexer/src/db.js
@@ -1003,6 +1003,89 @@ export const db = {
     );
   },
 
+  // ── NFT token queries ──────────────────────────────────────────────────────
+
+  /**
+   * Return all minted NFT tokens for a collection contract, with pagination
+   * and optional owner-address filter.
+   *
+   * Each row in token_holders where token_id IS NOT NULL represents one
+   * minted NFT. The current owner is the `address` column.
+   *
+   * @param {string} contractId
+   * @param {{ owner?: string, page?: number, limit?: number }} opts
+   * @returns {Promise<{ tokens: object[], total: number }>}
+   */
+  async getNftTokens(contractId, { owner, page = 1, limit = 50 } = {}) {
+    const pageN = Math.max(1, Number(page) || 1);
+    const limitN = Math.min(200, Math.max(1, Number(limit) || 50));
+    const offset = (pageN - 1) * limitN;
+
+    const params = [contractId];
+    let ownerFilter = "";
+    if (owner) {
+      params.push(owner);
+      ownerFilter = `AND address = $${params.length}`;
+    }
+
+    const { rows: countRows } = await pool.query(
+      `SELECT COUNT(*) AS total
+       FROM token_holders
+       WHERE contract_id = $1 AND token_id IS NOT NULL ${ownerFilter}`,
+      params,
+    );
+    const total = Number(countRows[0].total);
+
+    params.push(limitN, offset);
+    const { rows } = await pool.query(
+      `SELECT token_id, address AS owner, metadata_json, last_transfer_ledger
+       FROM token_holders
+       WHERE contract_id = $1 AND token_id IS NOT NULL ${ownerFilter}
+       ORDER BY token_id ASC
+       LIMIT $${params.length - 1} OFFSET $${params.length}`,
+      params,
+    );
+
+    return {
+      tokens: rows.map((r) => ({
+        token_id: r.token_id,
+        owner: r.owner,
+        metadata: r.metadata_json ?? null,
+        last_transfer_ledger: r.last_transfer_ledger != null ? Number(r.last_transfer_ledger) : null,
+      })),
+      total,
+    };
+  },
+
+  /**
+   * Return the full transfer + mint history for a single NFT token,
+   * sourced from the events table.
+   *
+   * @param {string} contractId
+   * @param {string} tokenId
+   * @returns {Promise<object[]>}
+   */
+  async getNftTokenHistory(contractId, tokenId) {
+    const { rows } = await pool.query(
+      `SELECT seq, function, ledger, tx_hash, description, raw_topics, created_at
+       FROM events
+       WHERE contract_id = $1
+         AND (raw_topics::text ILIKE $2 OR description ILIKE $2)
+       ORDER BY ledger ASC, seq ASC
+       LIMIT 500`,
+      [contractId, `%${tokenId}%`],
+    );
+    return rows.map((r) => ({
+      seq: Number(r.seq),
+      function: r.function,
+      ledger: Number(r.ledger),
+      tx_hash: r.tx_hash,
+      description: r.description,
+      raw_topics: r.raw_topics,
+      created_at: r.created_at,
+    }));
+  },
+
   // ── Predictive Gap Detection helpers ────────────────────────────────────────
 
   /**


### PR DESCRIPTION
- Migration 010: add protocol_type to contracts, add token_id / metadata_json / last_transfer_ledger columns to token_holders so each minted NFT is tracked as a distinct row

- Indexer db.js: getNftTokens() paginated query with optional owner filter; getNftTokenHistory() fetches mint + transfer events for a single token

- Indexer api.js: GET /api/tokens/:contractId/nfts (paginated list, ?owner= filter, max 200/page) and GET /api/tokens/:contractId/nfts/:tokenId/history

- Frontend api.ts: NftToken / NftMetadata / NftTokensResponse / NftHistoryEvent / NftTokenHistoryResponse types; nfts() and nftHistory() API methods

- NftCard component: image (or SVG placeholder), owner with copy button, last_transfer_ledger badge

- NftDetailModal component: full token detail with image, attributes, description, scrollable transfer/mint history, raw metadata JSON

- NftGallery page: responsive grid (auto-fill 180px), owner filter input, pagination controls, empty/loading/error states

- App.tsx: lazy-loaded /nft/:contractId route

## Description

Provide a brief summary of the changes introduced by this pull request.

## Related Issues

Closes #<issue_number>

## Screenshots / Screen Recordings (if applicable)

Add visual proof of changes if they affect the user interface.

## Testing & Verification Notes

How did you test your changes? Add commands run or verification details.

## Checklist

- [ ] Code compiles and runs locally without errors.
- [ ] Running `npm run doctor` returns no environment errors.
- [ ] Format rules applied (`cargo fmt`, `npx prettier --write`).
- [ ] Linting tests passed (`npx eslint`).
- [ ] Unit tests pass successfully (`cargo test`, `npm test`).

closes #649