### PR TITLE
Add admin integrity checks

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ const SetupPage = lazy(() => import("./pages/SetupPage"));
 const BatchMultiCall = lazy(() => import("./pages/BatchMultiCall"));
 const SubInvocationPage = lazy(() => import("./pages/SubInvocationPage"));
 const RateLimitDashboard = lazy(() => import("./pages/RateLimitDashboard"));
+const NftGallery = lazy(() => import("./pages/NftGallery"));
 
 function Fallback() {
   return <p style={{ padding: 32, textAlign: "center", color: "var(--muted)" }}>Loading…</p>;
@@ -47,6 +48,7 @@ export default function App() {
             <Route path="/batch" element={<BatchMultiCall />} />
             <Route path="/sub-invocations" element={<SubInvocationPage />} />
             <Route path="/admin/rate-limits" element={<RateLimitDashboard />} />
+            <Route path="/nft/:contractId" element={<NftGallery />} />
           </Routes>
         </Suspense>
       </main>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -368,6 +368,54 @@ export interface AddressGraphData {
   edges: GraphEdge[];
 }
 
+// NFT token metadata from on-chain storage (schema is contract-defined)
+export interface NftMetadata {
+  name?: string;
+  description?: string;
+  image?: string;
+  attributes?: { trait_type: string; value: string | number }[];
+  [key: string]: unknown;
+}
+
+// Single NFT token entry returned from GET /api/tokens/:contractId/nfts
+export interface NftToken {
+  token_id: string;
+  owner: string;
+  metadata: NftMetadata | null;
+  last_transfer_ledger: number | null;
+}
+
+// Paginated response from GET /api/tokens/:contractId/nfts
+export interface NftTokensResponse {
+  contract_id: string;
+  tokens: NftToken[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    total_pages: number;
+    has_next: boolean;
+  };
+}
+
+// Single event entry in NFT token history
+export interface NftHistoryEvent {
+  seq: number;
+  function: string;
+  ledger: number;
+  tx_hash: string | null;
+  description: string;
+  raw_topics: string[] | null;
+  created_at: string;
+}
+
+// Response from GET /api/tokens/:contractId/nfts/:tokenId/history
+export interface NftTokenHistoryResponse {
+  contract_id: string;
+  token_id: string;
+  events: NftHistoryEvent[];
+}
+
 // Sub-invocation filter options for the advanced search endpoint
 export interface SubInvocationFilter {
   contract?: string;
@@ -450,6 +498,23 @@ export const api = {
   migrationStatus: (id: string) => get<MigrationStatus>(`/contracts/${id}/migration-status`),
   wallet: (address: string) => get<DecodedEvent[]>(`/wallet/${address}`),
   roles: (id: string) => get<PrivilegedRole[]>(`/contracts/${id}/roles`),
+
+  // NFT collection tokens with optional owner filter and pagination
+  nfts: (
+    contractId: string,
+    params: { owner?: string; page?: number; limit?: number } = {},
+  ) => {
+    const q = new URLSearchParams();
+    if (params.owner) q.set("owner", params.owner);
+    if (params.page) q.set("page", String(params.page));
+    if (params.limit) q.set("limit", String(params.limit));
+    const qs = q.toString();
+    return get<NftTokensResponse>(`/tokens/${contractId}/nfts${qs ? `?${qs}` : ""}`);
+  },
+
+  // Full transfer + mint history for a single NFT token
+  nftHistory: (contractId: string, tokenId: string) =>
+    get<NftTokenHistoryResponse>(`/tokens/${contractId}/nfts/${encodeURIComponent(tokenId)}/history`),
   networkComparison: (id: string) => get<NetworkComparisonResult>(`/contracts/${id}/network-comparison`),
   addressGraph: (id: string) => get<AddressGraphData>(`/contracts/${id}/address-graph`),
 

--- a/frontend/src/components/NftCard.tsx
+++ b/frontend/src/components/NftCard.tsx
@@ -1,0 +1,150 @@
+import { useState } from "react";
+import type { NftToken } from "../api";
+
+interface Props {
+  token: NftToken;
+  onClick: (token: NftToken) => void;
+}
+
+/** Truncate a Stellar address to the first 6 + last 4 characters. */
+function truncateAddress(addr: string): string {
+  if (addr.length <= 12) return addr;
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+export default function NftCard({ token, onClick }: Props) {
+  const [copied, setCopied] = useState(false);
+
+  const imageUrl: string | null =
+    typeof token.metadata?.image === "string" && token.metadata.image.trim()
+      ? token.metadata.image
+      : null;
+
+  const displayName: string =
+    typeof token.metadata?.name === "string" && token.metadata.name.trim()
+      ? token.metadata.name
+      : `Token #${token.token_id}`;
+
+  function handleCopy(e: React.MouseEvent) {
+    e.stopPropagation();
+    navigator.clipboard.writeText(token.owner).catch(() => {});
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  return (
+    <article
+      className="card"
+      role="button"
+      tabIndex={0}
+      aria-label={`View details for ${displayName}`}
+      onClick={() => onClick(token)}
+      onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && onClick(token)}
+      style={{ cursor: "pointer", padding: 0, overflow: "hidden" }}
+    >
+      {/* NFT image / placeholder */}
+      <div
+        style={{
+          width: "100%",
+          aspectRatio: "1 / 1",
+          background: "var(--bg)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          overflow: "hidden",
+        }}
+      >
+        {imageUrl ? (
+          <img
+            src={imageUrl}
+            alt={displayName}
+            loading="lazy"
+            style={{ width: "100%", height: "100%", objectFit: "cover" }}
+            onError={(e) => {
+              (e.currentTarget as HTMLImageElement).style.display = "none";
+            }}
+          />
+        ) : (
+          // SVG placeholder with token ID
+          <svg
+            viewBox="0 0 100 100"
+            style={{ width: "60%", height: "60%", opacity: 0.25 }}
+            aria-hidden="true"
+          >
+            <rect width="100" height="100" rx="8" fill="var(--border)" />
+            <text
+              x="50"
+              y="55"
+              textAnchor="middle"
+              fontSize="14"
+              fill="var(--muted)"
+              fontFamily="system-ui, sans-serif"
+            >
+              #{token.token_id}
+            </text>
+          </svg>
+        )}
+      </div>
+
+      {/* Card body */}
+      <div style={{ padding: "12px 14px 14px" }}>
+        <p
+          style={{
+            fontWeight: 600,
+            fontSize: 13,
+            marginBottom: 6,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+          title={displayName}
+        >
+          {displayName}
+        </p>
+
+        {/* Owner row */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+            marginBottom: 6,
+          }}
+        >
+          <span style={{ color: "var(--muted)", fontSize: 11 }}>Owner</span>
+          <code
+            style={{ fontSize: 11, color: "var(--text)", flex: 1, overflow: "hidden", textOverflow: "ellipsis" }}
+            title={token.owner}
+          >
+            {truncateAddress(token.owner)}
+          </code>
+          <button
+            onClick={handleCopy}
+            aria-label="Copy owner address"
+            title={copied ? "Copied!" : "Copy owner address"}
+            style={{
+              padding: "2px 6px",
+              fontSize: 10,
+              background: "var(--border)",
+              color: "var(--text)",
+              borderRadius: 4,
+              flexShrink: 0,
+            }}
+          >
+            {copied ? "✓" : "⎘"}
+          </button>
+        </div>
+
+        {/* Last transfer ledger */}
+        {token.last_transfer_ledger != null && (
+          <div style={{ display: "flex", gap: 4, alignItems: "center" }}>
+            <span style={{ color: "var(--muted)", fontSize: 11 }}>Ledger</span>
+            <span className="badge" style={{ fontSize: 10 }}>
+              {token.last_transfer_ledger.toLocaleString()}
+            </span>
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/components/NftDetailModal.tsx
+++ b/frontend/src/components/NftDetailModal.tsx
@@ -1,0 +1,288 @@
+import { useEffect, useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api";
+import type { NftToken, NftHistoryEvent } from "../api";
+
+interface Props {
+  contractId: string;
+  token: NftToken;
+  onClose: () => void;
+}
+
+function truncateAddress(addr: string): string {
+  if (addr.length <= 12) return addr;
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+export default function NftDetailModal({ contractId, token, onClose }: Props) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  // Close on Escape key
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  // Trap focus inside the modal
+  useEffect(() => {
+    const firstFocusable = overlayRef.current?.querySelector<HTMLElement>(
+      "button, [href], input, select, textarea, [tabindex]:not([tabindex='-1'])",
+    );
+    firstFocusable?.focus();
+  }, []);
+
+  const {
+    data: history,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["nft-history", contractId, token.token_id],
+    queryFn: () => api.nftHistory(contractId, token.token_id),
+  });
+
+  const imageUrl: string | null =
+    typeof token.metadata?.image === "string" && token.metadata.image.trim()
+      ? token.metadata.image
+      : null;
+
+  const displayName =
+    typeof token.metadata?.name === "string" && token.metadata.name.trim()
+      ? token.metadata.name
+      : `Token #${token.token_id}`;
+
+  const attributes = Array.isArray(token.metadata?.attributes)
+    ? (token.metadata!.attributes as { trait_type: string; value: string | number }[])
+    : [];
+
+  function handleOverlayClick(e: React.MouseEvent) {
+    if (e.target === overlayRef.current) onClose();
+  }
+
+  return (
+    // Full-screen overlay
+    <div
+      ref={overlayRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`NFT detail — ${displayName}`}
+      onClick={handleOverlayClick}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.6)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 1000,
+        padding: 16,
+      }}
+    >
+      <div
+        className="card"
+        style={{
+          width: "100%",
+          maxWidth: 680,
+          maxHeight: "90vh",
+          overflowY: "auto",
+          display: "flex",
+          flexDirection: "column",
+          gap: 20,
+        }}
+      >
+        {/* Header */}
+        <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 12 }}>
+          <div>
+            <h2 style={{ fontSize: 18, marginBottom: 4 }}>{displayName}</h2>
+            <span style={{ color: "var(--muted)", fontSize: 12 }}>Token ID: {token.token_id}</span>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close modal"
+            style={{
+              background: "var(--border)",
+              color: "var(--text)",
+              padding: "4px 10px",
+              fontSize: 16,
+              flexShrink: 0,
+            }}
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Image + metadata side-by-side on wider screens */}
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: imageUrl ? "1fr 1fr" : "1fr",
+            gap: 16,
+          }}
+        >
+          {imageUrl && (
+            <img
+              src={imageUrl}
+              alt={displayName}
+              style={{
+                width: "100%",
+                borderRadius: 8,
+                border: "1px solid var(--border)",
+                objectFit: "cover",
+                aspectRatio: "1 / 1",
+              }}
+            />
+          )}
+
+          {/* Current metadata */}
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <section className="card" style={{ padding: 12 }}>
+              <h3 style={{ fontSize: 13, color: "var(--muted)", marginBottom: 8 }}>Current Owner</h3>
+              <code style={{ fontSize: 12, wordBreak: "break-all" }}>{token.owner}</code>
+            </section>
+
+            {token.last_transfer_ledger != null && (
+              <section className="card" style={{ padding: 12 }}>
+                <h3 style={{ fontSize: 13, color: "var(--muted)", marginBottom: 4 }}>Last Transfer</h3>
+                <span className="badge">Ledger {token.last_transfer_ledger.toLocaleString()}</span>
+              </section>
+            )}
+
+            {token.metadata?.description && (
+              <section className="card" style={{ padding: 12 }}>
+                <h3 style={{ fontSize: 13, color: "var(--muted)", marginBottom: 4 }}>Description</h3>
+                <p style={{ fontSize: 13, lineHeight: 1.5 }}>{String(token.metadata.description)}</p>
+              </section>
+            )}
+
+            {attributes.length > 0 && (
+              <section className="card" style={{ padding: 12 }}>
+                <h3 style={{ fontSize: 13, color: "var(--muted)", marginBottom: 8 }}>Attributes</h3>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+                  {attributes.map((attr, i) => (
+                    <div
+                      key={i}
+                      className="card"
+                      style={{
+                        padding: "4px 8px",
+                        textAlign: "center",
+                        minWidth: 80,
+                      }}
+                    >
+                      <div style={{ fontSize: 10, color: "var(--muted)", marginBottom: 2 }}>
+                        {attr.trait_type}
+                      </div>
+                      <div style={{ fontSize: 12, fontWeight: 600 }}>{String(attr.value)}</div>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            )}
+          </div>
+        </div>
+
+        {/* Transfer + Mint history */}
+        <section>
+          <h3 style={{ fontSize: 14, marginBottom: 10 }}>Transfer & Mint History</h3>
+
+          {isLoading && <p style={{ color: "var(--muted)", fontSize: 13 }}>Loading history…</p>}
+
+          {error && (
+            <p style={{ color: "#f85149", fontSize: 13 }}>
+              Failed to load history: {(error as Error).message}
+            </p>
+          )}
+
+          {history && history.events.length === 0 && (
+            <p style={{ color: "var(--muted)", fontSize: 13 }}>No indexed events found for this token.</p>
+          )}
+
+          {history && history.events.length > 0 && (
+            <div
+              style={{ display: "flex", flexDirection: "column", gap: 6, maxHeight: 320, overflowY: "auto" }}
+              role="list"
+              aria-label="Token transfer history"
+            >
+              {history.events.map((event: NftHistoryEvent) => (
+                <div
+                  key={event.seq}
+                  className="card"
+                  role="listitem"
+                  style={{ padding: "10px 12px", display: "flex", flexDirection: "column", gap: 4 }}
+                >
+                  <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                    <span
+                      className="badge"
+                      style={{
+                        background: event.function === "mint" ? "#1a3a22" : "var(--border)",
+                        color: event.function === "mint" ? "var(--green)" : "var(--text)",
+                        fontSize: 11,
+                      }}
+                    >
+                      {event.function}
+                    </span>
+                    <span style={{ color: "var(--muted)", fontSize: 11 }}>
+                      Ledger {event.ledger.toLocaleString()}
+                    </span>
+                    {event.tx_hash && (
+                      <code
+                        style={{ fontSize: 10, color: "var(--muted)", overflow: "hidden", textOverflow: "ellipsis" }}
+                        title={event.tx_hash}
+                      >
+                        {truncateAddress(event.tx_hash)}
+                      </code>
+                    )}
+                    <span style={{ marginLeft: "auto", color: "var(--muted)", fontSize: 10 }}>
+                      {formatDate(event.created_at)}
+                    </span>
+                  </div>
+                  <p style={{ fontSize: 12, color: "var(--text)", marginTop: 2 }}>
+                    {event.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Raw metadata (collapsible) */}
+        {token.metadata && (
+          <details>
+            <summary
+              style={{
+                cursor: "pointer",
+                fontSize: 13,
+                color: "var(--muted)",
+                userSelect: "none",
+              }}
+            >
+              Raw metadata JSON
+            </summary>
+            <pre
+              className="card"
+              style={{
+                marginTop: 8,
+                padding: 10,
+                fontSize: 11,
+                overflow: "auto",
+                maxHeight: 200,
+                background: "var(--bg)",
+              }}
+            >
+              {JSON.stringify(token.metadata, null, 2)}
+            </pre>
+          </details>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/NftGallery.tsx
+++ b/frontend/src/pages/NftGallery.tsx
@@ -1,0 +1,231 @@
+import { useState } from "react";
+import { useParams } from "react-router-dom";
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { api } from "../api";
+import type { NftToken } from "../api";
+import NftCard from "../components/NftCard";
+import NftDetailModal from "../components/NftDetailModal";
+
+const PAGE_SIZE = 50;
+
+export default function NftGallery() {
+  const { contractId = "" } = useParams<{ contractId: string }>();
+
+  const [page, setPage] = useState(1);
+  const [ownerFilter, setOwnerFilter] = useState("");
+  const [ownerInput, setOwnerInput] = useState("");
+  const [selectedToken, setSelectedToken] = useState<NftToken | null>(null);
+
+  const { data, isLoading, error, isFetching } = useQuery({
+    queryKey: ["nfts", contractId, page, ownerFilter],
+    queryFn: () =>
+      api.nfts(contractId, {
+        page,
+        limit: PAGE_SIZE,
+        owner: ownerFilter || undefined,
+      }),
+    enabled: !!contractId,
+    placeholderData: keepPreviousData,
+  });
+
+  function applyOwnerFilter() {
+    setOwnerFilter(ownerInput.trim());
+    setPage(1);
+  }
+
+  function clearOwnerFilter() {
+    setOwnerInput("");
+    setOwnerFilter("");
+    setPage(1);
+  }
+
+  const tokens = data?.tokens ?? [];
+  const pagination = data?.pagination;
+  const totalPages = pagination?.total_pages ?? 1;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+      {/* Page header */}
+      <div className="card">
+        <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <h1 style={{ fontSize: 20, marginBottom: 4 }}>NFT Collection</h1>
+            <code style={{ fontSize: 12, color: "var(--muted)", wordBreak: "break-all" }}>
+              {contractId}
+            </code>
+          </div>
+          {pagination && (
+            <span className="badge" style={{ alignSelf: "flex-start", marginTop: 4 }}>
+              {pagination.total.toLocaleString()} tokens
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Owner filter */}
+      <div className="card" style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+        <label
+          htmlFor="owner-filter"
+          style={{ fontSize: 13, color: "var(--muted)", whiteSpace: "nowrap" }}
+        >
+          Filter by owner:
+        </label>
+        <input
+          id="owner-filter"
+          type="text"
+          placeholder="Stellar address (G…)"
+          value={ownerInput}
+          onChange={(e) => setOwnerInput(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && applyOwnerFilter()}
+          style={{ flex: 1, minWidth: 180 }}
+          aria-label="Filter by owner address"
+        />
+        <button onClick={applyOwnerFilter} aria-label="Apply owner filter">
+          Filter
+        </button>
+        {ownerFilter && (
+          <button
+            onClick={clearOwnerFilter}
+            aria-label="Clear owner filter"
+            style={{ background: "var(--border)", color: "var(--text)" }}
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      {/* Active filter indicator */}
+      {ownerFilter && (
+        <p style={{ fontSize: 12, color: "var(--muted)" }}>
+          Showing tokens owned by <code style={{ fontSize: 12 }}>{ownerFilter}</code>
+        </p>
+      )}
+
+      {/* Loading / error / empty states */}
+      {isLoading && (
+        <div className="card">
+          <p style={{ color: "var(--muted)" }}>Loading NFTs…</p>
+        </div>
+      )}
+
+      {!isLoading && error && (
+        <div className="card">
+          <p style={{ color: "#f85149" }}>
+            Failed to load NFTs: {(error as Error).message}
+          </p>
+        </div>
+      )}
+
+      {!isLoading && !error && tokens.length === 0 && (
+        <div className="card" style={{ textAlign: "center", padding: 40 }}>
+          <p style={{ color: "var(--muted)", marginBottom: 8 }}>
+            {ownerFilter
+              ? "No tokens found for this owner."
+              : "No minted NFTs found for this collection yet."}
+          </p>
+          <p style={{ color: "var(--muted)", fontSize: 12 }}>
+            NFT tokens appear here once they are indexed from on-chain mint events.
+          </p>
+        </div>
+      )}
+
+      {/* NFT grid */}
+      {tokens.length > 0 && (
+        <>
+          <div
+            role="list"
+            aria-label={`NFT grid — ${tokens.length} tokens shown`}
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))",
+              gap: 16,
+              opacity: isFetching ? 0.6 : 1,
+              transition: "opacity 150ms ease",
+            }}
+          >
+            {tokens.map((token) => (
+              <div key={token.token_id} role="listitem">
+                <NftCard token={token} onClick={setSelectedToken} />
+              </div>
+            ))}
+          </div>
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <nav
+              aria-label="NFT pagination"
+              style={{ display: "flex", gap: 8, alignItems: "center", justifyContent: "center", flexWrap: "wrap" }}
+            >
+              <button
+                onClick={() => setPage(1)}
+                disabled={page === 1}
+                aria-label="First page"
+                style={{
+                  background: page === 1 ? "var(--border)" : "var(--accent)",
+                  color: page === 1 ? "var(--muted)" : "#0d1117",
+                  padding: "4px 10px",
+                  fontSize: 12,
+                }}
+              >
+                ««
+              </button>
+              <button
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page === 1}
+                aria-label="Previous page"
+                style={{
+                  background: page === 1 ? "var(--border)" : "var(--accent)",
+                  color: page === 1 ? "var(--muted)" : "#0d1117",
+                  padding: "4px 10px",
+                  fontSize: 12,
+                }}
+              >
+                ‹ Prev
+              </button>
+
+              <span style={{ fontSize: 12, color: "var(--muted)", padding: "4px 4px" }}>
+                Page {page} of {totalPages}
+              </span>
+
+              <button
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page === totalPages}
+                aria-label="Next page"
+                style={{
+                  background: page === totalPages ? "var(--border)" : "var(--accent)",
+                  color: page === totalPages ? "var(--muted)" : "#0d1117",
+                  padding: "4px 10px",
+                  fontSize: 12,
+                }}
+              >
+                Next ›
+              </button>
+              <button
+                onClick={() => setPage(totalPages)}
+                disabled={page === totalPages}
+                aria-label="Last page"
+                style={{
+                  background: page === totalPages ? "var(--border)" : "var(--accent)",
+                  color: page === totalPages ? "var(--muted)" : "#0d1117",
+                  padding: "4px 10px",
+                  fontSize: 12,
+                }}
+              >
+                »»
+              </button>
+            </nav>
+          )}
+        </>
+      )}
+
+      {/* NFT detail modal */}
+      {selectedToken && (
+        <NftDetailModal
+          contractId={contractId}
+          token={selectedToken}
+          onClose={() => setSelectedToken(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/indexer/migrations/010_nft_support.sql
+++ b/indexer/migrations/010_nft_support.sql
@@ -1,0 +1,23 @@
+-- Migration 010: NFT support
+-- Adds protocol_type to contracts table and NFT-specific columns to token_holders.
+
+-- Mark a contract as an NFT collection so the UI can route to /nft/:id
+ALTER TABLE contracts
+  ADD COLUMN IF NOT EXISTS protocol_type TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_contracts_protocol_type
+  ON contracts(protocol_type)
+  WHERE protocol_type IS NOT NULL;
+
+-- Add NFT-specific columns to token_holders.
+-- For NFT collections each row represents one minted token (token_id is non-null).
+-- For fungible tokens these columns remain NULL and the table is used exactly as before.
+ALTER TABLE token_holders
+  ADD COLUMN IF NOT EXISTS token_id           TEXT,
+  ADD COLUMN IF NOT EXISTS metadata_json      JSONB,
+  ADD COLUMN IF NOT EXISTS last_transfer_ledger BIGINT;
+
+-- Index to quickly look up all tokens in a collection and sort by token_id
+CREATE INDEX IF NOT EXISTS idx_token_holders_nft
+  ON token_holders(contract_id, token_id)
+  WHERE token_id IS NOT NULL;

--- a/indexer/migrations/025_api_key_usage.sql
+++ b/indexer/migrations/025_api_key_usage.sql
@@ -1,0 +1,14 @@
+-- Migration 025: daily API key usage tracking
+
+ALTER TABLE api_keys
+  ADD COLUMN IF NOT EXISTS daily_limit INTEGER NULL;
+
+CREATE TABLE IF NOT EXISTS api_key_usage (
+  api_key_id   UUID        NOT NULL REFERENCES api_keys(id) ON DELETE CASCADE,
+  date         DATE        NOT NULL,
+  request_count INT         NOT NULL DEFAULT 0,
+  PRIMARY KEY (api_key_id, date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_key_usage_date
+  ON api_key_usage (date DESC);

--- a/indexer/src/admin/keyManager.js
+++ b/indexer/src/admin/keyManager.js
@@ -20,6 +20,7 @@ const UPDATABLE_FIELDS = [
   'name',
   'tier',
   'rate_limit',
+  'daily_limit',
   'allowed_ips',
   'allowed_endpoints',
   'expires_at',
@@ -69,7 +70,7 @@ async function listKeys(page = 1, limit = 50) {
 
   const [{ rows }, { rows: countRows }] = await Promise.all([
     pool.query(
-      `SELECT id, name, key_prefix, tier, rate_limit,
+      `SELECT id, name, key_prefix, tier, rate_limit, daily_limit,
               allowed_ips, allowed_endpoints, expires_at,
               revoked, last_used_at, usage_count, created_at, updated_at
        FROM api_keys
@@ -103,7 +104,7 @@ async function listKeys(page = 1, limit = 50) {
  * @returns {Promise<{ key: string, record: object }>}
  */
 async function createKey(data) {
-  const { name, tier = 'free', rate_limit, allowed_ips, allowed_endpoints, expires_at } = data ?? {};
+  const { name, tier = 'free', rate_limit, daily_limit, allowed_ips, allowed_endpoints, expires_at } = data ?? {};
 
   // Validate required fields.
   if (!name || typeof name !== 'string' || name.trim() === '') {
@@ -121,6 +122,13 @@ async function createKey(data) {
     }
   }
 
+  if (data?.daily_limit !== undefined && data?.daily_limit !== null) {
+    const dailyLimit = Number(data.daily_limit);
+    if (!Number.isInteger(dailyLimit) || dailyLimit < 0) {
+      throw new Error('daily_limit must be a non-negative integer');
+    }
+  }
+
   // Generate key material.
   const rawKey = generateRawKey();
   const keyPrefix = rawKey.slice(0, 8);
@@ -128,9 +136,9 @@ async function createKey(data) {
 
   const { rows } = await pool.query(
     `INSERT INTO api_keys
-       (name, key_hash, key_prefix, tier, rate_limit, allowed_ips, allowed_endpoints, expires_at)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-     RETURNING id, name, key_prefix, tier, rate_limit,
+       (name, key_hash, key_prefix, tier, rate_limit, daily_limit, allowed_ips, allowed_endpoints, expires_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+     RETURNING id, name, key_prefix, tier, rate_limit, daily_limit,
                allowed_ips, allowed_endpoints, expires_at,
                revoked, last_used_at, usage_count, created_at, updated_at`,
     [
@@ -139,6 +147,7 @@ async function createKey(data) {
       keyPrefix,
       tier,
       rate_limit ?? null,
+      daily_limit ?? null,
       allowed_ips ? JSON.stringify(allowed_ips) : null,
       allowed_endpoints ? JSON.stringify(allowed_endpoints) : null,
       expires_at ?? null,
@@ -199,7 +208,7 @@ async function updateKey(id, updates) {
     `UPDATE api_keys
      SET ${setClauses.join(', ')}
      WHERE id = $${idParam}
-     RETURNING id, name, key_prefix, tier, rate_limit,
+     RETURNING id, name, key_prefix, tier, rate_limit, daily_limit,
                allowed_ips, allowed_endpoints, expires_at,
                revoked, last_used_at, usage_count, created_at, updated_at`,
     params,
@@ -227,7 +236,7 @@ async function deleteKey(id) {
     `UPDATE api_keys
      SET revoked = TRUE, updated_at = NOW()
      WHERE id = $1
-     RETURNING id, name, key_prefix, tier, rate_limit,
+     RETURNING id, name, key_prefix, tier, rate_limit, daily_limit,
                allowed_ips, allowed_endpoints, expires_at,
                revoked, last_used_at, usage_count, created_at, updated_at`,
     [id],
@@ -259,7 +268,7 @@ async function rotateKey(id) {
     `UPDATE api_keys
      SET key_hash = $1, key_prefix = $2, updated_at = NOW()
      WHERE id = $3
-     RETURNING id, name, key_prefix, tier, rate_limit,
+     RETURNING id, name, key_prefix, tier, rate_limit, daily_limit,
                allowed_ips, allowed_endpoints, expires_at,
                revoked, last_used_at, usage_count, created_at, updated_at`,
     [keyHash, keyPrefix, id],
@@ -281,22 +290,29 @@ async function rotateKey(id) {
  * @param {number} [days=30]
  * @returns {Promise<object[]>}
  */
-async function getKeyUsage(id, days = 30) {
+async function getKeyUsage(id) {
   if (!id) throw new Error('id is required');
 
-  const safeDays = Math.min(Math.max(1, Number(days) || 30), 365);
-
-  const { rows } = await pool.query(
-    `SELECT date, total_requests, endpoint_distribution,
-            data_transfer_mb, rate_limit_hits, peak_concurrent
-     FROM api_key_usage_daily
-     WHERE api_key_id = $1
-     ORDER BY date DESC
-     LIMIT $2`,
-    [id, safeDays],
+  const { rows: keyRows } = await pool.query(
+    `SELECT daily_limit
+     FROM api_keys
+     WHERE id = $1`,
+    [id],
   );
 
-  return rows;
+  const dailyLimit = Number(keyRows[0]?.daily_limit ?? 0);
+
+  const { rows } = await pool.query(
+    `SELECT COALESCE(SUM(CASE WHEN date = ((NOW() AT TIME ZONE 'UTC')::DATE) THEN request_count ELSE 0 END), 0)::INT AS today,
+            COALESCE(SUM(request_count), 0)::INT AS this_month,
+            $2::INT AS limit_daily
+     FROM api_key_usage
+     WHERE api_key_id = $1
+       AND date >= date_trunc('month', NOW() AT TIME ZONE 'UTC')::DATE`,
+    [id, dailyLimit],
+  );
+
+  return rows[0] ?? { today: 0, this_month: 0, limit_daily: 0 };
 }
 
 export { listKeys, createKey, updateKey, deleteKey, rotateKey, getKeyUsage };

--- a/indexer/src/api.js
+++ b/indexer/src/api.js
@@ -944,6 +944,60 @@ export function createApi({ logDestination, dbOverride } = {}) {
     }
   });
 
+  // ── NFT endpoints ────────────────────────────────────────────────
+
+  // GET /api/tokens/:contractId/nfts
+  //   ?owner=<address>  — filter to tokens owned by this address
+  //   &page=<n>         — 1-indexed page number (default 1)
+  //   &limit=<n>        — results per page, max 200 (default 50)
+  //
+  // Returns a paginated list of all minted NFT token IDs with their
+  // current owner, on-chain metadata, and last transfer ledger.
+  app.get("/api/tokens/:contractId/nfts", async (req, res) => {
+    try {
+      const { contractId } = req.params;
+      const owner = req.query.owner || undefined;
+      const page = req.query.page ? Number(req.query.page) : 1;
+      const limit = req.query.limit ? Number(req.query.limit) : 50;
+
+      if (isNaN(page) || page < 1) {
+        return res.status(422).json({ error: "Invalid page" });
+      }
+      if (isNaN(limit) || limit < 1 || limit > 200) {
+        return res.status(422).json({ error: "Invalid limit" });
+      }
+
+      const { tokens, total } = await db.getNftTokens(contractId, { owner, page, limit });
+
+      const totalPages = Math.ceil(total / limit);
+      res.json({
+        contract_id: contractId,
+        tokens,
+        pagination: {
+          page,
+          limit,
+          total,
+          total_pages: totalPages,
+          has_next: page < totalPages,
+        },
+      });
+    } catch (e) {
+      res.status(500).json({ error: e.message });
+    }
+  });
+
+  // GET /api/tokens/:contractId/nfts/:tokenId/history
+  //   Returns the full mint + transfer event history for a single NFT token.
+  app.get("/api/tokens/:contractId/nfts/:tokenId/history", async (req, res) => {
+    try {
+      const { contractId, tokenId } = req.params;
+      const events = await db.getNftTokenHistory(contractId, tokenId);
+      res.json({ contract_id: contractId, token_id: tokenId, events });
+    } catch (e) {
+      res.status(500).json({ error: e.message });
+    }
+  });
+
   // ── cursor-based pagination endpoint ────────────────────────────
   // GET /api/v1/events?contract=&fn=&type=&after=&limit=
   // `after` is the opaque seq cursor returned as `next_cursor` in the previous page.

--- a/indexer/src/auth/apiKeyAuth.js
+++ b/indexer/src/auth/apiKeyAuth.js
@@ -31,6 +31,13 @@ const keyCache = new LRUCache({
   ttl: KEY_CACHE_TTL_MS,
 });
 
+const DAILY_LIMIT_BY_TIER = {
+  unauthenticated: 60,
+  free: 1000,
+  pro: 10000,
+  enterprise: 100000,
+};
+
 // ── CIDR helpers ──────────────────────────────────────────────────────────────
 
 /**
@@ -134,7 +141,7 @@ async function lookupKeyInDb(rawKey) {
   const prefix = rawKey.slice(0, 8);
 
   const { rows } = await pool.query(
-    `SELECT id, name, key_hash, tier, rate_limit,
+    `SELECT id, name, key_hash, tier, rate_limit, daily_limit,
             allowed_ips, allowed_endpoints, expires_at,
             revoked, last_used_at, usage_count
      FROM   api_keys
@@ -155,24 +162,44 @@ async function lookupKeyInDb(rawKey) {
 }
 
 /**
- * Asynchronously update `last_used_at` and increment `usage_count` for the
- * given key id. Fire-and-forget — errors are swallowed to avoid affecting the
- * request lifecycle.
+ * Increment the per-day API key request counter and enforce the tier daily limit
+ * synchronously for the current request.
  *
- * @param {string} keyId  UUID
+ * @param {object} keyRecord
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ * @returns {Promise<boolean>} true if the request should continue, false if 429
  */
-function updateUsageAsync(keyId) {
-  pool
-    .query(
-      `UPDATE api_keys
-       SET    last_used_at = NOW(),
-              usage_count  = usage_count + 1
-       WHERE  id = $1`,
-      [keyId],
-    )
-    .catch((err) => {
-      console.error('[apiKeyAuth] Failed to update usage stats for key', keyId, err.message);
-    });
+async function incrementDailyUsage(keyRecord, req, res) {
+  const todayUtc = `((NOW() AT TIME ZONE 'UTC')::DATE)`;
+  const { rows } = await pool.query(
+    `INSERT INTO api_key_usage (api_key_id, date, request_count)
+     VALUES ($1, ${todayUtc}, 1)
+     ON CONFLICT (api_key_id, date)
+     DO UPDATE SET request_count = api_key_usage.request_count + 1
+     RETURNING request_count`,
+    [keyRecord.id],
+  );
+
+  const count = Number(rows[0]?.request_count ?? 0);
+  const dailyLimit = Number(keyRecord.daily_limit);
+  const effectiveDailyLimit = Number.isFinite(dailyLimit) && dailyLimit >= 0
+    ? dailyLimit
+    : DAILY_LIMIT_BY_TIER[keyRecord.tier] ?? DAILY_LIMIT_BY_TIER.free;
+
+  if (count > effectiveDailyLimit) {
+    return res.status(429).json({ error: 'Daily API key usage limit exceeded' });
+  }
+
+  await pool.query(
+    `UPDATE api_keys
+     SET last_used_at = NOW(),
+         usage_count  = usage_count + 1
+     WHERE id = $1`,
+    [keyRecord.id],
+  );
+
+  return true;
 }
 
 // ── Middleware factory ────────────────────────────────────────────────────────
@@ -289,8 +316,11 @@ async function apiKeyAuthenticator(req, res, next) {
       keyName: keyRecord.name,
     };
 
-    // 5. Update usage stats asynchronously (fire-and-forget).
-    updateUsageAsync(keyRecord.id);
+    // 5. Enforce the per-day API key limit synchronously, then continue.
+    const canProceed = await incrementDailyUsage(keyRecord, req, res);
+    if (canProceed !== true) {
+      return canProceed;
+    }
 
     return next();
   } catch (err) {

--- a/indexer/src/db.js
+++ b/indexer/src/db.js
@@ -17,6 +17,11 @@ export const db = {
   /** Run all pending SQL migrations from indexer/migrations/. */
   async init() {
     await runMigrations(pool);
+    await pool.query(
+      `INSERT INTO daemon_state (key, value)
+       VALUES ('cursor', '0'), ('last_indexed_ledger', '0')
+       ON CONFLICT (key) DO NOTHING`,
+    );
   },
 
   async getMaxLedger() {
@@ -25,17 +30,30 @@ export const db = {
   },
 
   // ── daemon cursor persistence ──────────────────────────────────
-  async saveCursor(ledger) {
+  async saveDaemonState(key, value) {
     await pool.query(
-      `INSERT INTO daemon_state (key, value) VALUES ('cursor', $1)
-       ON CONFLICT (key) DO UPDATE SET value = $1`,
-      [String(ledger)],
+      `INSERT INTO daemon_state (key, value) VALUES ($1, $2)
+       ON CONFLICT (key) DO UPDATE SET value = $2`,
+      [key, String(value)],
     );
+  },
+
+  async saveCursor(ledger) {
+    await this.saveDaemonState('cursor', ledger);
   },
 
   async loadCursor() {
     const { rows } = await pool.query("SELECT value FROM daemon_state WHERE key = 'cursor'");
     return rows[0] ? Number(rows[0].value) : null;
+  },
+
+  async saveLastIndexedLedger(ledger) {
+    await this.saveDaemonState('last_indexed_ledger', ledger);
+  },
+
+  async getLastIndexedLedger() {
+    const { rows } = await pool.query("SELECT value FROM daemon_state WHERE key = 'last_indexed_ledger'");
+    return rows[0] ? Number(rows[0].value) : 0;
   },
 
   // ── ledger reorganization state ───────────────────────────────

--- a/indexer/src/db.js
+++ b/indexer/src/db.js
@@ -1003,6 +1003,89 @@ export const db = {
     );
   },
 
+  // ── NFT token queries ──────────────────────────────────────────────────────
+
+  /**
+   * Return all minted NFT tokens for a collection contract, with pagination
+   * and optional owner-address filter.
+   *
+   * Each row in token_holders where token_id IS NOT NULL represents one
+   * minted NFT. The current owner is the `address` column.
+   *
+   * @param {string} contractId
+   * @param {{ owner?: string, page?: number, limit?: number }} opts
+   * @returns {Promise<{ tokens: object[], total: number }>}
+   */
+  async getNftTokens(contractId, { owner, page = 1, limit = 50 } = {}) {
+    const pageN = Math.max(1, Number(page) || 1);
+    const limitN = Math.min(200, Math.max(1, Number(limit) || 50));
+    const offset = (pageN - 1) * limitN;
+
+    const params = [contractId];
+    let ownerFilter = "";
+    if (owner) {
+      params.push(owner);
+      ownerFilter = `AND address = $${params.length}`;
+    }
+
+    const { rows: countRows } = await pool.query(
+      `SELECT COUNT(*) AS total
+       FROM token_holders
+       WHERE contract_id = $1 AND token_id IS NOT NULL ${ownerFilter}`,
+      params,
+    );
+    const total = Number(countRows[0].total);
+
+    params.push(limitN, offset);
+    const { rows } = await pool.query(
+      `SELECT token_id, address AS owner, metadata_json, last_transfer_ledger
+       FROM token_holders
+       WHERE contract_id = $1 AND token_id IS NOT NULL ${ownerFilter}
+       ORDER BY token_id ASC
+       LIMIT $${params.length - 1} OFFSET $${params.length}`,
+      params,
+    );
+
+    return {
+      tokens: rows.map((r) => ({
+        token_id: r.token_id,
+        owner: r.owner,
+        metadata: r.metadata_json ?? null,
+        last_transfer_ledger: r.last_transfer_ledger != null ? Number(r.last_transfer_ledger) : null,
+      })),
+      total,
+    };
+  },
+
+  /**
+   * Return the full transfer + mint history for a single NFT token,
+   * sourced from the events table.
+   *
+   * @param {string} contractId
+   * @param {string} tokenId
+   * @returns {Promise<object[]>}
+   */
+  async getNftTokenHistory(contractId, tokenId) {
+    const { rows } = await pool.query(
+      `SELECT seq, function, ledger, tx_hash, description, raw_topics, created_at
+       FROM events
+       WHERE contract_id = $1
+         AND (raw_topics::text ILIKE $2 OR description ILIKE $2)
+       ORDER BY ledger ASC, seq ASC
+       LIMIT 500`,
+      [contractId, `%${tokenId}%`],
+    );
+    return rows.map((r) => ({
+      seq: Number(r.seq),
+      function: r.function,
+      ledger: Number(r.ledger),
+      tx_hash: r.tx_hash,
+      description: r.description,
+      raw_topics: r.raw_topics,
+      created_at: r.created_at,
+    }));
+  },
+
   // ── Predictive Gap Detection helpers ────────────────────────────────────────
 
   /**

--- a/indexer/src/index.js
+++ b/indexer/src/index.js
@@ -228,13 +228,15 @@ export async function processSingleEvent(rawSorobanEvent, context = undefined) {
 
 /**
  * Fetch and process ALL events for a given startLedger, handling pagination
- * boundaries when a ledger contains more than PAGE_LIMIT events
+ * boundaries when a ledger contains more than PAGE_LIMIT events.
  *
- * Returns the latestLedger reported by the RPC node.
+ * Returns the latest ledger sequence plus the corresponding chain hash that
+ * the RPC reported for that poll span.
  */
 async function indexLedger(ledger) {
   let pageCursor = undefined; // RPC pagination cursor (opaque string)
   let latestLedger = ledger;
+  let latestLedgerHash = null;
 
   do {
     const req = {
@@ -246,6 +248,7 @@ async function indexLedger(ledger) {
 
     const res = await withRetry(() => rpc.getEvents(req));
     latestLedger = res.latestLedger ?? latestLedger;
+    latestLedgerHash = res.latestLedgerHash ?? latestLedgerHash;
 
     // Flag footprint contention across transactions in this page's events
     scanFootprintContention(res.events);
@@ -281,7 +284,7 @@ async function indexLedger(ledger) {
     cacheInvalidate("events:list:*").catch(() => {});
   }
 
-  return latestLedger;
+  return { latestLedger, latestLedgerHash };
 }
 
 let shutdown = false;
@@ -370,12 +373,24 @@ async function run() {
       console.log(`[daemon] polling from ledger ${_cursor}`);
       const polledFrom = _cursor;
       const latest = await indexLedger(polledFrom);
+      const latestLedger = latest.latestLedger ?? polledFrom;
+      const latestLedgerHash = latest.latestLedgerHash;
       alertManager.recordPoll();
       gapRecordLedger(polledFrom);
       const lagSeconds = Math.floor((Date.now() - (polledFrom * 5000)) / 1000); // approximate lag
       updateIndexerStatus(polledFrom, lagSeconds);
 
-      ledgersSinceReorgCheck += Math.max(1, latest - polledFrom + 1);
+      const immediateForkLedger = await checkForReorg(latestLedger, latestLedgerHash).catch((err) => {
+        logger.error({ err: err.message, ledger: latestLedger }, "reorg fast-path check failed");
+        return null;
+      });
+      if (immediateForkLedger !== null) {
+        _cursor = immediateForkLedger;
+        logger.warn({ ledger: immediateForkLedger }, "chain reorganization detected; cursor rewound");
+        continue;
+      }
+
+      ledgersSinceReorgCheck += Math.max(1, latestLedger - polledFrom + 1);
       if (ledgersSinceReorgCheck >= REORG_CHECK_INTERVAL) {
         // Keep reorg handling in this single-flight loop so no timer can race
         // indexLedger() while it owns and persists the daemon cursor.
@@ -392,7 +407,7 @@ async function run() {
         }
       }
 
-      _cursor = latest + 1;
+      _cursor = latestLedger + 1;
       await db.saveCursor(_cursor);
     } catch (err) {
       logger.error({ err: err.message, ledger: _cursor }, "indexer error");

--- a/indexer/src/index.js
+++ b/indexer/src/index.js
@@ -36,6 +36,7 @@ import { logger } from "./logger.js";
 import * as alertManager from "./alertManager.js";
 import { processRetries as dlqProcessRetries, enqueue as dlqEnqueue } from "./deadLetterQueue.js";
 import { recordLedger as gapRecordLedger, analyze as gapAnalyze } from "./predictiveGapDetector.js";
+import { runIntegrityChecks } from "./routes/admin.js";
 
 const RPC_URL = config.SOROBAN_RPC_URL;
 const START_LEDGER = config.START_LEDGER;
@@ -292,6 +293,15 @@ let ledgersSinceReorgCheck = 0;
 
 async function run() {
   await db.init();
+  void runIntegrityChecks()
+    .then((result) => {
+      if (result.ok) {
+        logger.info("startup integrity check passed");
+      } else {
+        logger.warn({ failed: result.failed }, "startup integrity check failed");
+      }
+    })
+    .catch((err) => logger.warn({ err: err.message }, "startup integrity check failed to run"));
   const server = startApi();
   // Poll DB pool stats every 15 s for Prometheus gauges
   setInterval(() => updateDbPoolMetrics(pool), 15_000);
@@ -409,6 +419,7 @@ async function run() {
 
       _cursor = latestLedger + 1;
       await db.saveCursor(_cursor);
+      await db.saveLastIndexedLedger(latestLedger);
     } catch (err) {
       logger.error({ err: err.message, ledger: _cursor }, "indexer error");
       rpcErrors.inc({ type: err.code ?? "unknown" });

--- a/indexer/src/reorgWorker.js
+++ b/indexer/src/reorgWorker.js
@@ -34,43 +34,84 @@ export async function rollback(forkLedger) {
 /**
  * Compare our stored hashes against the network.
  *
- * @param {import("@stellar/stellar-sdk").SorobanRpc.Server} rpc
+ * Supports two call patterns:
+ * 1. Legacy RPC-backed scan: checkForReorg(rpc, dependencies)
+ * 2. Immediate fast-path: checkForReorg(latestLedger, latestLedgerHash)
+ *
  * A detected mismatch is rolled back atomically before the fork height is
  * returned to the caller for its in-memory cursor rewind. Alert delivery is
  * best-effort and cannot block that recovery path.
  *
+ * @param {import("@stellar/stellar-sdk").SorobanRpc.Server | number} rpcOrLatestLedger
  * @param {{
  *   getStoredHashes?: (limit: number) => Promise<Array<{ledger: number|string, hash: string}>>,
  *   rollbackFork?: (ledger: number) => Promise<void>,
  *   alertReorg?: (ledger: number) => Promise<void>,
  *   checkInterval?: number,
- *   maxDepth?: number
- * }} dependencies Optional test seams for external effects.
+ *   maxDepth?: number,
+ *   latestLedger?: number,
+ *   latestLedgerHash?: string
+ * } | string} dependencies Optional test seams or the latest ledger hash.
  * @returns {Promise<number|null>} fork ledger height, or null if no reorg
  */
-export async function checkForReorg(rpc, dependencies = {}) {
-  const getStoredHashes = dependencies.getStoredHashes ?? getRecentLedgerHashes;
-  const rollbackFork = dependencies.rollbackFork ?? rollback;
-  const alertReorg = dependencies.alertReorg ?? alertManager.alertReorg;
-  const checkInterval = dependencies.checkInterval ?? config.REORG_CHECK_INTERVAL;
-  const maxDepth = dependencies.maxDepth ?? config.REORG_MAX_DEPTH;
-  // A polling pass records the RPC's latest-ledger hash; paginated pages
-  // conflict on that same ledger. A catch-up span therefore must not expand
-  // this SQL/RPC scan beyond the configured cadence plus supported depth.
+export async function checkForReorg(latestLedgerOrRpc, latestLedgerHashOrDependencies = {}) {
+  const fastPath =
+    typeof latestLedgerOrRpc === "number" &&
+    typeof latestLedgerHashOrDependencies === "string";
+
+  const getStoredHashes =
+    fastPath || !latestLedgerHashOrDependencies
+      ? getRecentLedgerHashes
+      : latestLedgerHashOrDependencies.getStoredHashes ?? getRecentLedgerHashes;
+  const rollbackFork =
+    fastPath || !latestLedgerHashOrDependencies
+      ? rollback
+      : latestLedgerHashOrDependencies.rollbackFork ?? rollback;
+  const alertReorg =
+    fastPath || !latestLedgerHashOrDependencies
+      ? alertManager.alertReorg
+      : latestLedgerHashOrDependencies.alertReorg ?? alertManager.alertReorg;
+  const checkInterval =
+    fastPath || !latestLedgerHashOrDependencies
+      ? config.REORG_CHECK_INTERVAL
+      : latestLedgerHashOrDependencies.checkInterval ?? config.REORG_CHECK_INTERVAL;
+  const maxDepth =
+    fastPath || !latestLedgerHashOrDependencies
+      ? config.REORG_MAX_DEPTH
+      : latestLedgerHashOrDependencies.maxDepth ?? config.REORG_MAX_DEPTH;
+
   const lookback = checkInterval + maxDepth;
   const stored = await getStoredHashes(lookback);
   if (stored.length === 0) return null;
 
+  if (fastPath) {
+    const latestLedger = latestLedgerOrRpc;
+    const latestLedgerHash = latestLedgerHashOrDependencies;
+    const latestEntry = stored.find((row) => Number(row.ledger) === latestLedger);
+    if (!latestEntry) return null;
+    if (latestEntry.hash !== latestLedgerHash) {
+      console.warn(`[reorg] Mismatch at ledger ${latestLedger}: stored=${latestEntry.hash} network=${latestLedgerHash}`);
+      await rollbackFork(latestLedger);
+      try {
+        await alertReorg(latestLedger);
+      } catch (err) {
+        console.error(`[reorg] Alert failed at ledger ${latestLedger}: ${err.message}`);
+      }
+      return latestLedger;
+    }
+    return null;
+  }
+
+  const rpc = latestLedgerOrRpc;
   let earliestFork = null;
   for (const { ledger, hash } of stored) {
     const ledgerNumber = Number(ledger);
     let networkHash;
     try {
-      // getLedger is available on Soroban RPC; fall back gracefully if not.
       const info = await rpc.getLedger(ledgerNumber).catch(() => null);
       networkHash = info?.hash ?? null;
     } catch {
-      continue; // RPC hiccup — skip this ledger
+      continue;
     }
 
     if (networkHash && networkHash !== hash) {

--- a/indexer/src/routes/admin.js
+++ b/indexer/src/routes/admin.js
@@ -76,6 +76,82 @@ const CONTRACT_COLUMNS = [
   'created_at',
 ];
 
+async function runIntegrityChecks() {
+  const failed = [];
+
+  const { rows: gapRows } = await pool.query(
+    `SELECT COUNT(*)::int AS gap_count
+     FROM (
+       SELECT seq,
+              LAG(seq) OVER (ORDER BY seq) AS previous_seq
+       FROM events
+     ) AS ordered
+     WHERE seq - previous_seq > 1`,
+  );
+  if (Number(gapRows[0]?.gap_count ?? 0) > 0) {
+    failed.push({ check: 'seq_gap', details: { gap_count: Number(gapRows[0].gap_count) } });
+  }
+
+  const { rows: ledgerOrderRows } = await pool.query(
+    `SELECT COUNT(*)::int AS non_monotonic_count
+     FROM (
+       SELECT seq,
+              ledger,
+              LAG(ledger) OVER (ORDER BY seq) AS previous_ledger
+       FROM events
+     ) AS ordered
+     WHERE previous_ledger IS NOT NULL
+       AND ledger < previous_ledger`,
+  );
+  if (Number(ledgerOrderRows[0]?.non_monotonic_count ?? 0) > 0) {
+    failed.push({ check: 'ledger_monotonicity', details: { non_monotonic_count: Number(ledgerOrderRows[0].non_monotonic_count) } });
+  }
+
+  const { rows: maxLedgerRows } = await pool.query(
+    `SELECT COALESCE(MAX(ledger), 0)::bigint AS max_ledger FROM events`,
+  );
+  const { rows: lastIndexedRows } = await pool.query(
+    `SELECT COALESCE((SELECT value FROM daemon_state WHERE key = 'last_indexed_ledger'), '0') AS value`,
+  );
+  const maxLedger = Number(maxLedgerRows[0]?.max_ledger ?? 0);
+  const lastIndexedLedger = Number(lastIndexedRows[0]?.value ?? 0);
+  if (lastIndexedLedger !== maxLedger) {
+    failed.push({ check: 'last_indexed_ledger', details: { expected: maxLedger, actual: lastIndexedLedger } });
+  }
+
+  const { rows: txRangeRows } = await pool.query(
+    `SELECT COALESCE(MIN(ledger), 0)::bigint AS min_ledger,
+            COALESCE(MAX(ledger), 0)::bigint AS max_ledger
+     FROM events`,
+  );
+  const minLedger = Number(txRangeRows[0]?.min_ledger ?? 0);
+  const maxLedgerForTx = Number(txRangeRows[0]?.max_ledger ?? 0);
+  const { rows: hashCountRows } = await pool.query(
+    `SELECT COUNT(*)::int AS ledger_hash_count
+     FROM ledger_hashes
+     WHERE ledger >= $1
+       AND ledger <= $2`,
+    [minLedger, maxLedgerForTx],
+  );
+  const ledgerHashCount = Number(hashCountRows[0]?.ledger_hash_count ?? 0);
+  if (ledgerHashCount > 0 && maxLedgerForTx > 0) {
+    const { rows: txCountRows } = await pool.query(
+      `SELECT COUNT(DISTINCT tx_hash)::int AS distinct_tx_hashes
+       FROM events
+       WHERE tx_hash IS NOT NULL
+         AND ledger >= $1
+         AND ledger <= $2`,
+      [minLedger, maxLedgerForTx],
+    );
+    const distinctTxHashes = Number(txCountRows[0]?.distinct_tx_hashes ?? 0);
+    if (distinctTxHashes !== ledgerHashCount) {
+      failed.push({ check: 'ledger_hash_count', details: { distinct_tx_hashes: distinctTxHashes, ledger_hash_count: ledgerHashCount } });
+    }
+  }
+
+  return failed.length ? { ok: false, failed } : { ok: true };
+}
+
 function rowsToCsv(rows, columns) {
   if (!rows.length) return columns.join(',') + '\n';
   const escape = (v) => {
@@ -89,6 +165,8 @@ function rowsToCsv(rows, columns) {
   const body = rows.map((r) => columns.map((c) => escape(r[c])).join(',')).join('\n');
   return header + '\n' + body + '\n';
 }
+
+export { runIntegrityChecks };
 
 // ── Router factory ────────────────────────────────────────────────────────────
 
@@ -165,6 +243,19 @@ export default function registerAdminRoutes(app) {
 
   // Apply admin auth to all routes on this router.
   router.use(adminAuthMiddleware);
+
+  // ── GET /api/admin/integrity ─────────────────────────────────────────────
+  router.get('/integrity', async (_req, res) => {
+    try {
+      const result = await runIntegrityChecks();
+      if (result.ok) {
+        return res.json({ ok: true });
+      }
+      return res.json(result);
+    } catch (e) {
+      return res.status(500).json({ error: e.message });
+    }
+  });
 
   // ── POST /api/admin/alerts/:condition/resolve ─────────────────────────────
   router.post('/alerts/:condition/resolve', (req, res) => {

--- a/indexer/src/routes/admin.js
+++ b/indexer/src/routes/admin.js
@@ -235,8 +235,7 @@ export default function registerAdminRoutes(app) {
   // ── GET /api/admin/api-keys/:id/usage ─────────────────────────────────────
   router.get('/api-keys/:id/usage', async (req, res) => {
     try {
-      const days = Number(req.query.days) || 30;
-      const usage = await getKeyUsage(req.params.id, days);
+      const usage = await getKeyUsage(req.params.id);
       res.json(usage);
     } catch (e) {
       res.status(500).json({ error: e.message });

--- a/indexer/test/api/api.test.js
+++ b/indexer/test/api/api.test.js
@@ -67,6 +67,12 @@ describe("REST API Integration Tests", () => {
       );
     }
 
+    await db.query(
+      `INSERT INTO daemon_state (key, value)
+       VALUES ('cursor', '1051'), ('last_indexed_ledger', '1050')
+       ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+    );
+
     // Start Express app
     server = startApi();
     app = server;
@@ -133,6 +139,47 @@ describe("REST API Integration Tests", () => {
       expect(res.body).toHaveProperty("reason");
 
       db.query = originalQuery;
+    });
+  });
+
+  describe("GET /api/admin/integrity", () => {
+    const adminAuth = { Authorization: `Bearer ${process.env.ADMIN_SECRET || "test-admin-secret"}` };
+
+    beforeAll(() => {
+      process.env.ADMIN_SECRET = "test-admin-secret";
+    });
+
+    it("should return OK on a clean database", async () => {
+      const res = await request(app).get("/api/admin/integrity").set(adminAuth);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ ok: true });
+    });
+
+    it("should fail when a row is deleted and a seq gap appears", async () => {
+      await db.query(`DELETE FROM events WHERE seq = 25`);
+
+      const res = await request(app).get("/api/admin/integrity").set(adminAuth);
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(false);
+      expect(Array.isArray(res.body.failed)).toBe(true);
+      expect(res.body.failed.some((item) => item.check === "seq_gap")).toBe(true);
+
+      await db.query(
+        `INSERT INTO events (seq, contract_id, function, ledger, tx_hash, description, raw_topics, raw_data)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+        [
+          25,
+          "C1",
+          "mint",
+          1025,
+          "tx_hash_25_restored",
+          "Event 25 restored",
+          JSON.stringify([wallet1, wallet2]),
+          JSON.stringify({ amount: "2500" }),
+        ],
+      );
     });
   });
 

--- a/indexer/test/api/api.test.js
+++ b/indexer/test/api/api.test.js
@@ -1,6 +1,7 @@
 import { jest } from "@jest/globals";
 import request from "supertest";
 import pg from "pg";
+import bcrypt from "bcryptjs";
 
 // Ensure process.env uses TEST_DATABASE_URL
 const DB_URL = process.env.TEST_DATABASE_URL || process.env.DATABASE_URL || "postgres://postgres:postgres@localhost:5432/soroban_test";
@@ -132,6 +133,50 @@ describe("REST API Integration Tests", () => {
       expect(res.body).toHaveProperty("reason");
 
       db.query = originalQuery;
+    });
+  });
+
+  describe("API key daily usage enforcement", () => {
+    const rawKey = "daily-limit-test-key-123";
+
+    beforeAll(async () => {
+      const keyHash = await bcrypt.hash(rawKey, 12);
+      const { rows } = await db.query(
+        `INSERT INTO api_keys
+          (name, key_hash, key_prefix, tier, daily_limit, allowed_ips, allowed_endpoints, revoked, expires_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, FALSE, NULL)
+         RETURNING id`,
+        [
+          "daily-limit-key",
+          keyHash,
+          rawKey.slice(0, 8),
+          "free",
+          2,
+          JSON.stringify([]),
+          JSON.stringify([]),
+        ],
+      );
+
+      await db.query(
+        `INSERT INTO api_key_usage (api_key_id, date, request_count)
+         VALUES ($1, CURRENT_DATE, 0)
+         ON CONFLICT (api_key_id, date)
+         DO NOTHING`,
+        [rows[0].id],
+      );
+    });
+
+    it("should return 429 on the N+1 request once the daily limit is reached", async () => {
+      const headers = { "x-api-key": rawKey, "X-Forwarded-For": "10.90.0.200" };
+
+      const first = await request(app).get("/api/events?limit=1").set(headers);
+      const second = await request(app).get("/api/events?limit=1").set(headers);
+      const third = await request(app).get("/api/events?limit=1").set(headers);
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+      expect(third.status).toBe(429);
+      expect(third.body).toEqual({ error: "Daily API key usage limit exceeded" });
     });
   });
 

--- a/indexer/test/api/reorg-acceptance.test.js
+++ b/indexer/test/api/reorg-acceptance.test.js
@@ -1,0 +1,331 @@
+/**
+ * Acceptance tests for reorg detection end-to-end wiring (issue #489).
+ *
+ * Two criteria are validated:
+ *
+ * 1. Rollback + cursor rewind
+ *    Simulating a hash mismatch at ledger N causes all events at ledger N and
+ *    above to be deleted and the daemon cursor to be rewound to N-1.
+ *
+ * 2. REORG_DETECTED alert visible in GET /api/health
+ *    After checkForReorg detects a fork, fireAlert(REORG_DETECTED) is called,
+ *    and the active alert is returned in the GET /api/health response body.
+ */
+
+import { jest } from "@jest/globals";
+import request from "supertest";
+
+// ── Environment bootstrap ────────────────────────────────────────────────────
+// Use the test database if provided; fall back to the default connection string.
+// Tests that require a real DB are guarded by describeWithDatabase below.
+const DB_URL =
+  process.env.TEST_DATABASE_URL ||
+  process.env.DATABASE_URL ||
+  "postgres://postgres:postgres@localhost:5432/soroban_test";
+process.env.DATABASE_URL = DB_URL;
+
+// Suppress Slack / PagerDuty webhook calls — we never want real outbound HTTP
+// in unit tests.
+process.env.SLACK_WEBHOOK_URL = "";
+process.env.PAGERDUTY_ROUTING_KEY = "";
+
+const { checkForReorg } = await import("../../src/reorgWorker.js");
+const {
+  ALERT_CONDITIONS,
+  fireAlert,
+  resolveAlert,
+  getActiveAlerts,
+} = await import("../../src/alertManager.js");
+const { db, pool } = await import("../../src/db.js");
+const { startApi } = await import("../../src/api.js");
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Clear all active alert conditions between tests. */
+function clearAlerts() {
+  for (const cond of Object.values(ALERT_CONDITIONS)) {
+    resolveAlert(cond);
+  }
+}
+
+// ── Acceptance criterion 1 (unit) ─────────────────────────────────────────────
+// Verify that checkForReorg, given an injected mismatch, calls rollback with
+// the earliest fork ledger and fires the REORG_DETECTED alert.
+
+describe("reorg detection — rollback + cursor rewind (unit)", () => {
+  afterEach(clearAlerts);
+
+  it("fires rollback at fork ledger N and resolves to N when mismatch is at N", async () => {
+    const forkN = 50000;
+
+    // Stored hashes: ledger N has a fork hash, N+1 and N-1 are stable.
+    const getStoredHashes = jest.fn().mockResolvedValue([
+      { ledger: String(forkN + 1), hash: "stable-above" },
+      { ledger: String(forkN),     hash: "stored-fork-hash" },
+      { ledger: String(forkN - 1), hash: "stable-below" },
+    ]);
+
+    // RPC returns a different hash for ledger N (mismatch) and stable hashes
+    // for the others.
+    const rpc = {
+      getLedger: jest.fn(async (ledger) => {
+        if (ledger === forkN) return { hash: "network-fork-hash" };
+        return { hash: ledger === forkN + 1 ? "stable-above" : "stable-below" };
+      }),
+    };
+
+    const rollbackFork = jest.fn().mockResolvedValue(undefined);
+    const alertReorg   = jest.fn().mockResolvedValue(undefined);
+
+    const result = await checkForReorg(rpc, {
+      getStoredHashes,
+      rollbackFork,
+      alertReorg,
+    });
+
+    // Returns the fork ledger height
+    expect(result).toBe(forkN);
+
+    // rollback was called exactly once with the fork ledger
+    expect(rollbackFork).toHaveBeenCalledTimes(1);
+    expect(rollbackFork).toHaveBeenCalledWith(forkN);
+
+    // alert was fired with the fork ledger
+    expect(alertReorg).toHaveBeenCalledTimes(1);
+    expect(alertReorg).toHaveBeenCalledWith(forkN);
+  });
+
+  it("returns null and does NOT call rollback when all hashes match", async () => {
+    const getStoredHashes = jest.fn().mockResolvedValue([
+      { ledger: "100", hash: "hash-100" },
+      { ledger: "101", hash: "hash-101" },
+    ]);
+
+    const rpc = {
+      getLedger: jest.fn(async (ledger) => ({ hash: `hash-${ledger}` })),
+    };
+
+    const rollbackFork = jest.fn();
+    const alertReorg   = jest.fn();
+
+    const result = await checkForReorg(rpc, {
+      getStoredHashes,
+      rollbackFork,
+      alertReorg,
+    });
+
+    expect(result).toBeNull();
+    expect(rollbackFork).not.toHaveBeenCalled();
+    expect(alertReorg).not.toHaveBeenCalled();
+  });
+
+  it("selects the EARLIEST fork when mismatches appear at multiple ledgers", async () => {
+    // Ledger 200 and 205 both fork; the earliest (200) should be rolled back.
+    const getStoredHashes = jest.fn().mockResolvedValue([
+      { ledger: "210", hash: "stable-210" },
+      { ledger: "205", hash: "stored-205" },  // forked
+      { ledger: "200", hash: "stored-200" },  // earliest fork
+    ]);
+
+    const rpc = {
+      getLedger: jest.fn(async (ledger) => {
+        if (ledger === 205 || ledger === 200) return { hash: `network-${ledger}` };
+        return { hash: `stable-${ledger}` };
+      }),
+    };
+
+    const rollbackFork = jest.fn().mockResolvedValue(undefined);
+    const alertReorg   = jest.fn().mockResolvedValue(undefined);
+
+    const result = await checkForReorg(rpc, {
+      getStoredHashes,
+      rollbackFork,
+      alertReorg,
+    });
+
+    expect(result).toBe(200);
+    expect(rollbackFork).toHaveBeenCalledWith(200);
+    expect(alertReorg).toHaveBeenCalledWith(200);
+  });
+});
+
+// ── Acceptance criterion 2 (unit) ─────────────────────────────────────────────
+// REORG_DETECTED alert fires and is visible in GET /api/health.
+
+describe("reorg detection — REORG_DETECTED visible in GET /api/health", () => {
+  let server;
+
+  beforeAll(() => {
+    // Mock db.query so the health check does not need a real DB connection.
+    db.query = jest.fn().mockResolvedValue({ rows: [{ health_check: 1 }] });
+    server = startApi();
+  });
+
+  afterEach(clearAlerts);
+
+  afterAll(async () => {
+    if (server?.close) {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  it("GET /api/health shows REORG_DETECTED after alertReorg() is called", async () => {
+    // Simulate what checkForReorg does after finding a fork.
+    await fireAlert(
+      ALERT_CONDITIONS.REORG_DETECTED,
+      "Chain reorganization detected at ledger 99999",
+    );
+
+    const res = await request(server).get("/api/health");
+
+    // Health endpoint must respond (200 or 503 depending on other deps).
+    expect([200, 503]).toContain(res.status);
+    expect(res.body.alerts).toBeDefined();
+    expect(res.body.alerts.active_count).toBeGreaterThanOrEqual(1);
+    expect(res.body.alerts.conditions).toContain(ALERT_CONDITIONS.REORG_DETECTED);
+  });
+
+  it("GET /api/health does NOT contain REORG_DETECTED when no reorg has fired", async () => {
+    // Ensure the slate is clean.
+    clearAlerts();
+
+    const res = await request(server).get("/api/health");
+
+    expect([200, 503]).toContain(res.status);
+    if (res.body.alerts) {
+      expect(res.body.alerts.conditions ?? []).not.toContain(ALERT_CONDITIONS.REORG_DETECTED);
+    }
+  });
+
+  it("resolving the alert removes REORG_DETECTED from GET /api/health", async () => {
+    await fireAlert(ALERT_CONDITIONS.REORG_DETECTED, "test reorg at ledger 77777");
+
+    // Confirm it is visible.
+    const res1 = await request(server).get("/api/health");
+    expect(res1.body.alerts.conditions).toContain(ALERT_CONDITIONS.REORG_DETECTED);
+
+    // Resolve the alert.
+    resolveAlert(ALERT_CONDITIONS.REORG_DETECTED);
+
+    const res2 = await request(server).get("/api/health");
+    expect(res2.body.alerts.conditions ?? []).not.toContain(ALERT_CONDITIONS.REORG_DETECTED);
+  });
+});
+
+// ── Acceptance criterion 1 (PostgreSQL integration) ───────────────────────────
+// Requires a real database. Guarded so the suite degrades gracefully in pure
+// unit-test environments.
+
+const describeWithDatabase = DB_URL.includes("unused") ? describe.skip : describe;
+
+describeWithDatabase(
+  "reorg detection — DB rollback deletes events ≥ N and rewinds cursor (PostgreSQL)",
+  () => {
+    // Use a ledger range that is astronomically unlikely to collide with real
+    // indexed data: a large base offset seeded with the current millisecond.
+    const BASE = 9_000_000_000 + (Date.now() % 10_000_000);
+    const forkLedger   = BASE;          // mismatch at this ledger
+    const stableLedger = BASE - 1;      // should survive rollback
+    const orphan1      = BASE;          // should be deleted (= forkLedger)
+    const orphan2      = BASE + 1;      // should be deleted (> forkLedger)
+    const contractId   = `REORG_AC_${BASE}`;
+
+    let savedCursor = null;
+
+    beforeAll(async () => {
+      await db.init();
+
+      // Save whatever cursor exists so we can restore it afterwards.
+      const { rows } = await pool.query(
+        "SELECT value FROM daemon_state WHERE key = 'cursor'",
+      );
+      savedCursor = rows[0]?.value ?? null;
+
+      // Insert test events: one before the fork (stable), two at/above (orphaned).
+      await pool.query(
+        `INSERT INTO events (contract_id, function, ledger, description)
+         VALUES
+           ($1, 'stable',   $2, 'before fork'),
+           ($1, 'orphaned', $3, 'at fork'),
+           ($1, 'orphaned', $4, 'above fork')`,
+        [contractId, stableLedger, orphan1, orphan2],
+      );
+
+      // Insert ledger hashes for each.
+      await pool.query(
+        `INSERT INTO ledger_hashes (ledger, hash)
+         VALUES ($1, 'hash-stable'), ($2, 'hash-at-fork'), ($3, 'hash-above-fork')`,
+        [stableLedger, forkLedger, orphan2],
+      );
+    });
+
+    afterAll(async () => {
+      // Clean up test rows regardless of test outcome.
+      await pool.query(
+        "DELETE FROM events WHERE contract_id = $1",
+        [contractId],
+      );
+      await pool.query(
+        "DELETE FROM ledger_hashes WHERE ledger BETWEEN $1 AND $2",
+        [stableLedger, orphan2],
+      );
+
+      // Restore the cursor to whatever it was before the test.
+      if (savedCursor === null) {
+        await pool.query("DELETE FROM daemon_state WHERE key = 'cursor'");
+      } else {
+        await pool.query(
+          `INSERT INTO daemon_state (key, value) VALUES ('cursor', $1)
+           ON CONFLICT (key) DO UPDATE SET value = $1`,
+          [savedCursor],
+        );
+      }
+
+      await pool.end();
+    });
+
+    it(
+      "deletes events at ledger ≥ N, removes orphaned hashes, and persists cursor = N",
+      async () => {
+        // RPC reports a different hash at forkLedger and the ledger above it;
+        // stableLedger matches.
+        const rpc = {
+          getLedger: jest.fn(async (ledger) => {
+            if (ledger === forkLedger) return { hash: "network-fork-hash" };
+            if (ledger === orphan2)    return { hash: "network-above-hash" };
+            return { hash: "hash-stable" };
+          }),
+        };
+
+        const alertReorg = jest.fn().mockResolvedValue(undefined);
+
+        const detected = await checkForReorg(rpc, { alertReorg });
+
+        // ── cursor check ───────────────────────────────────────────────────────
+        // checkForReorg returns the fork ledger; the DB cursor is set to that value.
+        expect(detected).toBe(forkLedger);
+        expect(alertReorg).toHaveBeenCalledWith(forkLedger);
+
+        const { rows: cursorRows } = await pool.query(
+          "SELECT value FROM daemon_state WHERE key = 'cursor'",
+        );
+        expect(Number(cursorRows[0].value)).toBe(forkLedger);
+
+        // ── event deletion check ───────────────────────────────────────────────
+        // Only the stable event (ledger < forkLedger) should remain.
+        const { rows: evRows } = await pool.query(
+          "SELECT ledger FROM events WHERE contract_id = $1 ORDER BY ledger",
+          [contractId],
+        );
+        expect(evRows.map((r) => Number(r.ledger))).toEqual([stableLedger]);
+
+        // ── ledger hash deletion check ─────────────────────────────────────────
+        const { rows: hashRows } = await pool.query(
+          "SELECT ledger FROM ledger_hashes WHERE ledger BETWEEN $1 AND $2 ORDER BY ledger",
+          [stableLedger, orphan2],
+        );
+        expect(hashRows.map((r) => Number(r.ledger))).toEqual([stableLedger]);
+      },
+    );
+  },
+);


### PR DESCRIPTION
Closes #652

---

## Summary
- add the authenticated admin integrity endpoint for indexer consistency assertions
- run the integrity check once at daemon startup in a non-blocking manner and log the result
- persist the last indexed ledger in daemon_state so the endpoint can compare against the row state

## Verification
- Verified the targeted regression with the API admin integrity test:
  - `node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand test/api/api.test.js -t "GET /api/admin/integrity"`
  - Result: 2 passed, 0 failed