### PR TITLE
test: WalletPage tests for events, address validation, empty state, and XLM balance

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -214,6 +214,20 @@ export interface SearchResponse {
   suggestions: SearchSuggestion[];
 }
 
+export interface HorizonBalance {
+  asset_type: string;
+  asset_code?: string;
+  asset_issuer?: string;
+  balance: string;
+}
+
+export interface HorizonAccount {
+  id: string;
+  account_id: string;
+  sequence: string;
+  balances: HorizonBalance[];
+}
+
 export interface BurnAlert {
   contractId: string;
   ledger: number;
@@ -448,7 +462,8 @@ export const api = {
   },
   burnAlerts: (contract: string) => get<BurnAlert[]>(`/burn-alerts?contract=${contract}`),
   migrationStatus: (id: string) => get<MigrationStatus>(`/contracts/${id}/migration-status`),
-  wallet: (address: string) => get<DecodedEvent[]>(`/wallet/${address}`),
+  wallet: (address: string) =>
+    get<{ events: DecodedEvent[]; horizon_account: HorizonAccount | null }>(`/wallet/${address}`),
   roles: (id: string) => get<PrivilegedRole[]>(`/contracts/${id}/roles`),
   networkComparison: (id: string) => get<NetworkComparisonResult>(`/contracts/${id}/network-comparison`),
   addressGraph: (id: string) => get<AddressGraphData>(`/contracts/${id}/address-graph`),

--- a/frontend/src/pages/WalletPage.tsx
+++ b/frontend/src/pages/WalletPage.tsx
@@ -3,14 +3,45 @@ import { useQuery } from "@tanstack/react-query";
 import { api } from "../api";
 import EventTable from "../components/EventTable";
 
+const VALID_ADDRESS_RE = /^G[A-Z2-7]{55}$/;
+
 export default function WalletPage() {
   const { address = "" } = useParams();
 
-  const { data: events = [], isLoading } = useQuery({
+  const isValidAddress = VALID_ADDRESS_RE.test(address);
+
+  const { data, isLoading } = useQuery({
     queryKey: ["wallet", address],
     queryFn: () => api.wallet(address),
-    enabled: !!address,
+    enabled: !!address && isValidAddress,
   });
+
+  const events = data?.events ?? [];
+  const horizonAccount = data?.horizon_account ?? null;
+  const xlmBalance = horizonAccount?.balances?.find((b) => b.asset_type === "native");
+
+  if (address && !isValidAddress) {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+        <div className="card">
+          <h2 style={{ marginBottom: 4 }}>Wallet History</h2>
+          <code
+            style={{
+              fontSize: 12,
+              color: "var(--muted)",
+              wordBreak: "break-all",
+            }}
+          >
+            {address}
+          </code>
+        </div>
+
+        <div className="card">
+          <p style={{ color: "#ef4444" }}>Invalid wallet address format</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
@@ -26,6 +57,13 @@ export default function WalletPage() {
           {address}
         </code>
       </div>
+
+      {xlmBalance && (
+        <div className="card">
+          <h3 style={{ marginBottom: 4 }}>XLM Balance</h3>
+          <p style={{ fontSize: 18, fontWeight: 600 }}>{xlmBalance.balance} XLM</p>
+        </div>
+      )}
 
       <div className="card">
         {isLoading ? (

--- a/frontend/test/WalletPage.test.tsx
+++ b/frontend/test/WalletPage.test.tsx
@@ -1,20 +1,34 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import WalletPage from "../src/pages/WalletPage";
 
-vi.mock("react-router-dom", () => ({
-  useParams: () => ({ address: "GA3X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X" }),
-}));
+const VALID_ADDR = "GA5ZSEJYB37FRCONJ3LQUMTZHKWZ6BIGZU3U2XHRJHXBVWMGHMV36TJQ";
+
+const mockWallet = vi.fn();
 
 vi.mock("../src/api", () => ({
   api: {
-    wallet: vi.fn().mockResolvedValue([]),
+    wallet: (...args: unknown[]) => mockWallet(...args),
   },
 }));
 
-function Wrapper({ children }: { children: React.ReactNode }) {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+function makeQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function renderWalletPage(address: string) {
+  const qc = makeQueryClient();
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[`/wallet/${address}`]}>
+        <Routes>
+          <Route path="/wallet/:address" element={<WalletPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
 }
 
 describe("WalletPage", () => {
@@ -26,23 +40,82 @@ describe("WalletPage", () => {
     vi.restoreAllMocks();
   });
 
-  it("renders with empty-state message when no events", async () => {
-    const WalletPage = (await import("../src/pages/WalletPage")).default;
-    render(
-      <Wrapper>
-        <WalletPage />
-      </Wrapper>
-    );
-    expect(await screen.findByText("No Soroban interactions found for this address")).toBeDefined();
+  it("renders events from a mock API response", async () => {
+    const mockEvents = [
+      {
+        seq: 1001,
+        contract_id: "CCEMOFO5TE7FGOAJXR3RDHPC6RWO4FM2GOPUKI5N6KJQ4MOLOFPFJN6B",
+        function: "transfer",
+        ledger: 2500000,
+        description: "Transferred 100.00 USDC to GDQOE2JFBXYKIYLJBNUDRZI2FHLX5TLXHMDNUE7KPK5I2YA5TSB6Z4LD",
+        raw_topics: ["transfer"],
+        tx_hash: "abc123def456abc123def456abc123def456abc123def456abc123def4561234",
+      },
+      {
+        seq: 1002,
+        contract_id: "CDLZFC3SYJYDZT7K67VZ75HRJDTIKI7BF6RQD7MFPK5QERZUTXX7YV7V",
+        function: "swap",
+        ledger: 2500005,
+        description: "Swapped 50.00 XLM to 420.00 USDC",
+        raw_topics: ["swap"],
+        tx_hash: "def789abc123def789abc123def789abc123def789abc123def789abc1231234",
+      },
+    ];
+
+    mockWallet.mockResolvedValue({ events: mockEvents, horizon_account: null });
+
+    renderWalletPage(VALID_ADDR);
+
+    const seqLink = await screen.findByText("#1001");
+    expect(seqLink).toBeDefined();
+    expect(screen.getByText("#1002")).toBeDefined();
+    expect(screen.getByText("2,500,000")).toBeDefined();
+    expect(screen.getByText("2,500,005")).toBeDefined();
+    expect(screen.getByText("transfer")).toBeDefined();
+    expect(screen.getByText("swap")).toBeDefined();
   });
 
-  it("shows address in page heading even with no events", async () => {
-    const WalletPage = (await import("../src/pages/WalletPage")).default;
-    render(
-      <Wrapper>
-        <WalletPage />
-      </Wrapper>
-    );
-    expect(await screen.findByText("GA3X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X")).toBeDefined();
+  it("shows 'invalid address' error for GFOO", async () => {
+    renderWalletPage("GFOO");
+
+    const errorEl = await screen.findByText("Invalid wallet address format");
+    expect(errorEl).toBeDefined();
+
+    expect(mockWallet).not.toHaveBeenCalled();
+  });
+
+  it("shows empty state when the events array is empty", async () => {
+    mockWallet.mockResolvedValue({ events: [], horizon_account: null });
+
+    renderWalletPage(VALID_ADDR);
+
+    const emptyMsg = await screen.findByText("No Soroban interactions found for this address");
+    expect(emptyMsg).toBeDefined();
+  });
+
+  it("renders XLM balance when horizon_account is present in the response", async () => {
+    mockWallet.mockResolvedValue({
+      events: [],
+      horizon_account: {
+        id: VALID_ADDR,
+        account_id: VALID_ADDR,
+        sequence: "123456789",
+        balances: [
+          { asset_type: "native", balance: "1250.0000000" },
+          {
+            asset_type: "credit_alphanum4",
+            asset_code: "USDC",
+            asset_issuer: "GDQOE2JFBXYKIYLJBNUDRZI2FHLX5TLXHMDNUE7KPK5I2YA5TSB6Z4LD",
+            balance: "500.0000000",
+          },
+        ],
+      },
+    });
+
+    renderWalletPage(VALID_ADDR);
+
+    const xlmHeading = await screen.findByText("XLM Balance");
+    expect(xlmHeading).toBeDefined();
+    expect(screen.getByText("1250.0000000 XLM")).toBeDefined();
   });
 });

--- a/indexer/src/api.js
+++ b/indexer/src/api.js
@@ -879,16 +879,22 @@ export function createApi({ logDestination, dbOverride } = {}) {
   });
 
   // GET /api/wallet/:address — events involving a Stellar/Soroban wallet.
-  // Returns 200 with { events: [...] } (empty array for an unknown address) and
-  // 400 when the address is not a well-formed Stellar public key (G... base32).
+  // Returns 200 with { events: [...], horizon_account?: {...} } (empty array for an
+  // unknown address) and 400 when the address is not a well-formed Stellar public key
+  // (G... base32). When Horizon is reachable, includes the account's native XLM balance.
   app.get("/api/wallet/:address", async (req, res) => {
     try {
       const address = req.params.address;
       if (!/^G[A-Z2-7]{55}$/.test(address)) {
         return res.status(400).json({ error: "Invalid wallet address format" });
       }
-      const events = await db.getWalletEvents(address);
-      res.json({ events });
+      const [events, horizon_account] = await Promise.all([
+        db.getWalletEvents(address),
+        fetch(`${config.HORIZON_URL}/accounts/${address}`)
+          .then((r) => (r.ok ? r.json() : null))
+          .catch(() => null),
+      ]);
+      res.json({ events, horizon_account: horizon_account ?? null });
     } catch (e) {
       res.status(500).json({ error: e.message });
     }


### PR DESCRIPTION
## Summary

Adds comprehensive tests for the WalletPage component covering four key scenarios, along with the supporting feature changes needed to make them work.

### Changes

**Backend** (`indexer/src/api.js`):
- Enhanced `GET /api/wallet/:address` to fetch Horizon account data in parallel with events
- Returns `{ events, horizon_account }` shape including native XLM balance when available

**Frontend** (`frontend/src/api.ts`):
- Added `HorizonBalance` and `HorizonAccount` TypeScript interfaces
- Updated `wallet()` return type to match the new backend response shape (`{ events, horizon_account }`)

**Frontend** (`frontend/src/pages/WalletPage.tsx`):
- Added Stellar address validation (matches `^G[A-Z2-7]{55}$`)
- Shows "Invalid wallet address format" error for malformed addresses (e.g. `GFOO`)
- Displays XLM balance card when `horizon_account` with native balance is present

**Tests** (`frontend/test/WalletPage.test.tsx`):
- Renders events from a mock API response (verifies seq links, ledger, function badges)
- Shows "invalid address" error for `GFOO` and does not call the API
- Shows empty state message when the events array is empty
- Renders XLM balance when `horizon_account` is present in the response

### Verification

- `npm test` — all 131 tests pass (including 4 new WalletPage tests)
- `npx tsc --noEmit` — no type errors
- `npm run build` — build succeeds

Closes #578
Closes #579
Closes #580
Closes #581