### PR TITLE
feat: windowed list rendering for EventTable

### DIFF
--- a/frontend/src/components/EventTable.tsx
+++ b/frontend/src/components/EventTable.tsx
@@ -1,5 +1,7 @@
+import { useRef } from "react";
 import { Link } from "react-router-dom";
 import type { DecodedEvent } from "../api";
+import { useVirtualList, ROW_HEIGHT } from "../hooks/useVirtualList";
 import FiatValue from "./FiatValue";
 import { getGasAlert } from "./GasLimitAlert";
 import { addressRoute, truncateAddress, isAccountAddress, isContractAddress, isMuxedAddress } from "../utils/strkey";
@@ -171,7 +173,83 @@ function FactoryDeploymentBadge({ deployment }: { deployment: NonNullable<Decode
   );
 }
 
+/** Render a single event row (extracted so it can be reused in both modes). */
+function EventRow({ ev }: { ev: DecodedEvent }) {
+  return (
+    <>
+      <td style={td}>
+        <Link to={`/event/${ev.seq}`}>#{ev.seq}</Link>
+      </td>
+      <td style={td}>{ev.ledger.toLocaleString()}</td>
+      <td style={td}>
+        <FunctionBadge fn={ev.function} />
+      </td>
+      <td
+        style={{
+          ...td,
+          maxWidth: 480,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {ev.is_clawback && (
+          <span className="badge clawback" style={{ marginRight: 6 }} title="Mandatory authority intervention">
+            ⚠ COMPLIANCE: CLAWBACK
+          </span>
+        )}
+        {getGasAlert(ev) && (
+          <span
+            style={{
+              display: "inline-block",
+              marginRight: 6,
+              padding: "1px 6px",
+              background: "rgba(245,158,11,0.15)",
+              border: "1px solid #f59e0b",
+              borderRadius: 4,
+              fontSize: 11,
+              color: "#f59e0b",
+              verticalAlign: "middle",
+            }}
+            title="High gas usage — >80% of network limit"
+          >
+            ⚠ High Gas
+          </span>
+        )}
+        {ev.ttl_extension && <TTLExtensionBadge ext={ev.ttl_extension} />}
+        {ev.factory_deployment && <FactoryDeploymentBadge deployment={ev.factory_deployment} />}
+        {ev.sac_side_effect && <SacSideEffectBadge kind={ev.sac_side_effect} />}
+        <LinkedDescription text={ev.description} />
+        {ev.function === "transfer" &&
+          (() => {
+            const t = parseTransfer(ev.description);
+            return t ? <FiatValue amount={t.amount} symbol={t.symbol} /> : null;
+          })()}
+        {ev.function === "swap" &&
+          (() => {
+            const path = ev.swap_path ?? parseSwapPath(ev.description);
+            return path ? (
+              <span
+                style={{
+                  marginLeft: 6,
+                  color: "var(--accent)",
+                  fontSize: 12,
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {path.join(" → ")}
+              </span>
+            ) : null;
+          })()}
+      </td>
+    </>
+  );
+}
+
 export default function EventTable({ events }: Props) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const { totalHeight, visibleItems } = useVirtualList(events, scrollContainerRef);
+
   if (!events.length)
     return (
       <p data-testid="empty-state" style={{ color: "var(--muted)" }}>
@@ -195,78 +273,39 @@ export default function EventTable({ events }: Props) {
             <th style={th}>Description</th>
           </tr>
         </thead>
-        <tbody>
-          {events.map((ev) => (
-            <tr key={ev.seq} style={{ borderBottom: "1px solid var(--border)" }}>
-              <td style={td}>
-                <Link to={`/event/${ev.seq}`}>#{ev.seq}</Link>
-              </td>
-              <td style={td}>{ev.ledger.toLocaleString()}</td>
-              <td style={td}>
-                <FunctionBadge fn={ev.function} />
-              </td>
-              <td
+      </table>
+
+      {/* Virtualized scroll area — rows are position:absolute inside here */}
+      <div
+        ref={scrollContainerRef}
+        data-testid="virtual-scroll-container"
+        style={{
+          overflowY: "auto",
+          maxHeight: 600,
+          position: "relative",
+        }}
+      >
+        {/* Spacer div creates the full scrollable height */}
+        <div style={{ height: totalHeight, position: "relative" }}>
+          {visibleItems.map(({ item, style }) => (
+            <div key={item.seq} style={style}>
+              <table
                 style={{
-                  ...td,
-                  maxWidth: 480,
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
+                  width: "100%",
+                  borderCollapse: "collapse",
+                  tableLayout: "fixed",
                 }}
               >
-                {ev.is_clawback && (
-                  <span className="badge clawback" style={{ marginRight: 6 }} title="Mandatory authority intervention">
-                    ⚠ COMPLIANCE: CLAWBACK
-                  </span>
-                )}
-                {getGasAlert(ev) && (
-                  <span
-                    style={{
-                      display: "inline-block",
-                      marginRight: 6,
-                      padding: "1px 6px",
-                      background: "rgba(245,158,11,0.15)",
-                      border: "1px solid #f59e0b",
-                      borderRadius: 4,
-                      fontSize: 11,
-                      color: "#f59e0b",
-                      verticalAlign: "middle",
-                    }}
-                    title="High gas usage — >80% of network limit"
-                  >
-                    ⚠ High Gas
-                  </span>
-                )}
-                {ev.ttl_extension && <TTLExtensionBadge ext={ev.ttl_extension} />}
-                {ev.factory_deployment && <FactoryDeploymentBadge deployment={ev.factory_deployment} />}
-                {ev.sac_side_effect && <SacSideEffectBadge kind={ev.sac_side_effect} />}
-                <LinkedDescription text={ev.description} />
-                {ev.function === "transfer" &&
-                  (() => {
-                    const t = parseTransfer(ev.description);
-                    return t ? <FiatValue amount={t.amount} symbol={t.symbol} /> : null;
-                  })()}
-                {ev.function === "swap" &&
-                  (() => {
-                    const path = ev.swap_path ?? parseSwapPath(ev.description);
-                    return path ? (
-                      <span
-                        style={{
-                          marginLeft: 6,
-                          color: "var(--accent)",
-                          fontSize: 12,
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        {path.join(" → ")}
-                      </span>
-                    ) : null;
-                  })()}
-              </td>
-            </tr>
+                <tbody>
+                  <tr style={{ borderBottom: "1px solid var(--border)" }}>
+                    <EventRow ev={item} />
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           ))}
-        </tbody>
-      </table>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/hooks/useVirtualList.ts
+++ b/frontend/src/hooks/useVirtualList.ts
@@ -1,0 +1,85 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+
+/**
+ * Fixed row height in pixels for the virtualized event list.
+ * Every row MUST be exactly this height so that absolute positioning
+ * produces a seamless scroll experience. If row content overflows,
+ * it is clipped with text-overflow: ellipsis.
+ */
+export const ROW_HEIGHT = 60;
+
+/** Number of rows to render above / below the visible viewport. */
+const OVERSCAN = 5;
+
+/**
+ * useVirtualList — lightweight windowed-list hook.
+ *
+ * Given an array of items and a scrollable container ref, returns only the
+ * slice of items that should be rendered (plus an overscan buffer) along
+ * with the absolute top-position for each visible row.
+ *
+ * The container element must have `overflow-y: auto` (or scroll) and a
+ * fixed height so that the browser manages the scrollbar.
+ */
+export function useVirtualList<T>(
+  items: T[],
+  containerRef: React.RefObject<HTMLElement | null>,
+) {
+  const [scrollTop, setScrollTop] = useState(0);
+  const [viewportHeight, setViewportHeight] = useState(0);
+  const rafId = useRef(0);
+
+  // ---------- scroll / resize listeners ----------
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const onScroll = () => {
+      // Use rAF to coalesce rapid scroll events into a single paint.
+      if (rafId.current) cancelAnimationFrame(rafId.current);
+      rafId.current = requestAnimationFrame(() => {
+        setScrollTop(el.scrollTop);
+      });
+    };
+
+    const onResize = () => {
+      setViewportHeight(el.clientHeight);
+    };
+
+    // Initial measurements
+    setScrollTop(el.scrollTop);
+    setViewportHeight(el.clientHeight);
+
+    el.addEventListener("scroll", onScroll, { passive: true });
+    const ro = new ResizeObserver(onResize);
+    ro.observe(el);
+
+    return () => {
+      el.removeEventListener("scroll", onScroll);
+      ro.disconnect();
+      if (rafId.current) cancelAnimationFrame(rafId.current);
+    };
+  }, [containerRef]);
+
+  // ---------- derived values ----------
+  const totalHeight = items.length * ROW_HEIGHT;
+
+  const startIndex = Math.max(0, Math.floor(scrollTop / ROW_HEIGHT) - OVERSCAN);
+  const endIndex = Math.min(
+    items.length,
+    Math.ceil((scrollTop + viewportHeight) / ROW_HEIGHT) + OVERSCAN,
+  );
+
+  const visibleItems = items.slice(startIndex, endIndex).map((item, i) => ({
+    item,
+    index: startIndex + i,
+    style: {
+      position: "absolute" as const,
+      top: (startIndex + i) * ROW_HEIGHT,
+      width: "100%",
+      height: ROW_HEIGHT,
+    },
+  }));
+
+  return { totalHeight, visibleItems };
+}

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -2,6 +2,15 @@ import '@testing-library/jest-dom';
 import { afterEach } from 'vitest';
 import { cleanup } from '@testing-library/react';
 
+// Polyfill ResizeObserver — jsdom does not provide it natively.
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
 afterEach(() => {
   cleanup();
 });


### PR DESCRIPTION
## Summary

Adds windowed/virtual list rendering to `EventTable` using CSS `position: absolute` with a fixed row height of 60px. Only the visible rows plus a 5-row overscan buffer are rendered into the DOM at any time, dramatically reducing node count for wallets and contracts with hundreds of events.

### Changes

**New file** — `frontend/src/hooks/useVirtualList.ts`
- `useVirtualList<T>` hook: tracks scroll position via `requestAnimationFrame`, computes visible slice
- `ROW_HEIGHT = 60` constant documented with comment explaining the fixed-height constraint
- `OVERSCAN = 5` rows rendered above/below viewport for smooth scrolling
- Uses `ResizeObserver` to react to container size changes

**Modified** — `frontend/src/components/EventTable.tsx`
- Scrollable container with `max-height: 600px` and `position: relative`
- Spacer div creates the full scroll height so the browser manages the scrollbar
- Each visible row is `position: absolute` at `top: index * ROW_HEIGHT`
- Table header stays fixed; only `<tbody>` rows are virtualized
- Non-virtualized rendering preserved for the empty-state path

**Modified** — `frontend/vitest.setup.ts`
- Added `ResizeObserver` polyfill for jsdom (not available natively)

### Why 60px fixed row height

Every row must be exactly 60px so that absolute `top` positioning produces a seamless scroll without visual gaps or misalignment. Long description text is clipped with `text-overflow: ellipsis`.

### Verification

- `npm test` — all 129 tests pass
- `npx tsc --noEmit` — no type errors  
- `npm run build` — build succeeds

Closes #574
Closes #575
Closes #576
Closes #577