### PR TITLE
feat: stake/unstake decoder descriptions (#558, #559, #560, #573)

### DIFF
--- a/indexer/src/decoder.js
+++ b/indexer/src/decoder.js
@@ -294,6 +294,25 @@ export function buildDescription(fn, args, data, contractName) {
       const [admin, from, amount, token] = args;
       return `CLAWBACK: ${amount} ${token ?? ""} recovered from ${fmt(from)} by authority ${fmt(admin)} on ${contractName}`;
     }
+    case "stake":
+    case "lock":
+    case "deposit_stake": {
+      const [addr, amount, duration] = args;
+      const amt = amount ?? data;
+      if (duration != null && duration !== 0) {
+        return `${fmt(addr)} staked ${fmtXlm(amt)} XLM for ${duration} days on ${contractName}`;
+      }
+      return `${fmt(addr)} staked ${fmtXlm(amt)} XLM on ${contractName}`;
+    }
+    case "unstake":
+    case "unlock": {
+      const [addr, amount, rewards] = args;
+      const amt = amount ?? data;
+      if (rewards != null && rewards !== 0) {
+        return `${fmt(addr)} unstaked ${fmtXlm(amt)} XLM + ${fmtXlm(rewards)} XLM rewards on ${contractName}`;
+      }
+      return `${fmt(addr)} unstaked ${fmtXlm(amt)} XLM on ${contractName}`;
+    }
     default:
       return genericDescription(fn, args, data, contractName);
   }

--- a/indexer/test/decoder.stake.test.js
+++ b/indexer/test/decoder.stake.test.js
@@ -1,0 +1,128 @@
+/**
+ * Unit tests: decoder.js stake / unstake / lock / unlock / deposit_stake.
+ * Closes #560, #559, #558, #573
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildDescription } from "../src/decoder.js";
+
+const ADDR = "G" + "A".repeat(55);
+const CONTRACT = "StakeVault";
+const AMOUNT = 100000000000n; // 10,000 XLM in stroops
+const REWARDS = 235000000n;   // 23.5 XLM in stroops
+const DURATION = 30;
+
+// ── stake / lock / deposit_stake with duration ─────────────────────────────
+
+describe("decoder — stake with duration", () => {
+  it("stake includes duration", () => {
+    const desc = buildDescription("stake", [ADDR, AMOUNT, DURATION], null, CONTRACT);
+    assert.ok(desc.includes("staked"), `expected "staked" in "${desc}"`);
+    assert.ok(desc.includes("30 days"), `expected "30 days" in "${desc}"`);
+  });
+
+  it("lock includes duration", () => {
+    const desc = buildDescription("lock", [ADDR, AMOUNT, DURATION], null, CONTRACT);
+    assert.ok(desc.includes("staked"), `expected "staked" in "${desc}"`);
+    assert.ok(desc.includes("30 days"), `expected "30 days" in "${desc}"`);
+  });
+
+  it("deposit_stake includes duration", () => {
+    const desc = buildDescription("deposit_stake", [ADDR, AMOUNT, DURATION], null, CONTRACT);
+    assert.ok(desc.includes("staked"), `expected "staked" in "${desc}"`);
+    assert.ok(desc.includes("30 days"), `expected "30 days" in "${desc}"`);
+  });
+
+  it("stake contains the amount", () => {
+    const desc = buildDescription("stake", [ADDR, AMOUNT, DURATION], null, CONTRACT);
+    assert.ok(desc.includes("10,000"), `expected formatted amount in "${desc}"`);
+  });
+
+  it("stake contains the contract name", () => {
+    const desc = buildDescription("stake", [ADDR, AMOUNT, DURATION], null, CONTRACT);
+    assert.ok(desc.includes(CONTRACT), `expected "${CONTRACT}" in "${desc}"`);
+  });
+
+  it("stake contains the address", () => {
+    const desc = buildDescription("stake", [ADDR, AMOUNT, DURATION], null, CONTRACT);
+    assert.ok(desc.includes("GAAAAA…AAAA"), `expected truncated address in "${desc}"`);
+  });
+});
+
+// ── stake / lock / deposit_stake without duration ──────────────────────────
+
+describe("decoder — stake without duration", () => {
+  it("stake without duration omits duration clause", () => {
+    const desc = buildDescription("stake", [ADDR, AMOUNT], null, CONTRACT);
+    assert.ok(desc.includes("staked"), `expected "staked" in "${desc}"`);
+    assert.ok(!desc.includes("days"), `should not contain "days" in "${desc}"`);
+  });
+
+  it("lock without duration omits duration clause", () => {
+    const desc = buildDescription("lock", [ADDR, AMOUNT], null, CONTRACT);
+    assert.ok(desc.includes("staked"), `expected "staked" in "${desc}"`);
+    assert.ok(!desc.includes("days"), `should not contain "days" in "${desc}"`);
+  });
+
+  it("deposit_stake without duration omits duration clause", () => {
+    const desc = buildDescription("deposit_stake", [ADDR, AMOUNT], null, CONTRACT);
+    assert.ok(desc.includes("staked"), `expected "staked" in "${desc}"`);
+    assert.ok(!desc.includes("days"), `should not contain "days" in "${desc}"`);
+  });
+
+  it("stake with duration=0 omits duration clause", () => {
+    const desc = buildDescription("stake", [ADDR, AMOUNT, 0], null, CONTRACT);
+    assert.ok(!desc.includes("days"), `should not contain "days" in "${desc}"`);
+  });
+
+  it("stake without duration still contains the amount", () => {
+    const desc = buildDescription("stake", [ADDR, AMOUNT], null, CONTRACT);
+    assert.ok(desc.includes("10,000"), `expected formatted amount in "${desc}"`);
+  });
+});
+
+// ── unstake / unlock ───────────────────────────────────────────────────────
+
+describe("decoder — unstake with rewards", () => {
+  it("unstake includes rewards", () => {
+    const desc = buildDescription("unstake", [ADDR, AMOUNT, REWARDS], null, CONTRACT);
+    assert.ok(desc.includes("unstaked"), `expected "unstaked" in "${desc}"`);
+    assert.ok(desc.includes("23.5"), `expected "23.5" in "${desc}"`);
+    assert.ok(desc.includes("rewards"), `expected "rewards" in "${desc}"`);
+  });
+
+  it("unlock includes rewards", () => {
+    const desc = buildDescription("unlock", [ADDR, AMOUNT, REWARDS], null, CONTRACT);
+    assert.ok(desc.includes("unstaked"), `expected "unstaked" in "${desc}"`);
+    assert.ok(desc.includes("rewards"), `expected "rewards" in "${desc}"`);
+  });
+
+  it("unstake contains the amount", () => {
+    const desc = buildDescription("unstake", [ADDR, AMOUNT, REWARDS], null, CONTRACT);
+    assert.ok(desc.includes("10,000"), `expected formatted amount in "${desc}"`);
+  });
+
+  it("unstake contains the contract name", () => {
+    const desc = buildDescription("unstake", [ADDR, AMOUNT, REWARDS], null, CONTRACT);
+    assert.ok(desc.includes(CONTRACT), `expected "${CONTRACT}" in "${desc}"`);
+  });
+});
+
+describe("decoder — unstake without rewards", () => {
+  it("unstake without rewards omits rewards clause", () => {
+    const desc = buildDescription("unstake", [ADDR, AMOUNT], null, CONTRACT);
+    assert.ok(desc.includes("unstaked"), `expected "unstaked" in "${desc}"`);
+    assert.ok(!desc.includes("rewards"), `should not contain "rewards" in "${desc}"`);
+  });
+
+  it("unlock without rewards omits rewards clause", () => {
+    const desc = buildDescription("unlock", [ADDR, AMOUNT], null, CONTRACT);
+    assert.ok(desc.includes("unstaked"), `expected "unstaked" in "${desc}"`);
+    assert.ok(!desc.includes("rewards"), `should not contain "rewards" in "${desc}"`);
+  });
+
+  it("unstake with rewards=0 omits rewards clause", () => {
+    const desc = buildDescription("unstake", [ADDR, AMOUNT, 0], null, CONTRACT);
+    assert.ok(!desc.includes("rewards"), `should not contain "rewards" in "${desc}"`);
+  });
+});


### PR DESCRIPTION
Closes #558
Closes #559
Closes #560
Closes #573

## Summary

Adds human-readable decoder descriptions for staking and unstaking functions in the Soroban event decoder.

### Stake functions (`stake`, `lock`, `deposit_stake`)

- **With duration:** `GA… staked 10,000 XLM for 30 days on StakeVault`
- **Without duration:** `GA… staked 10,000 XLM on StakeVault`

### Unstake functions (`unstake`, `unlock`)

- **With rewards:** `GA… unstaked 10,000 XLM + 23.5 XLM rewards on StakeVault`
- **Without rewards:** `GA… unstaked 10,000 XLM on StakeVault`

### Behaviour

- Duration clause is omitted when no duration parameter is provided or when duration is 0
- Rewards clause is omitted when no rewards parameter is provided or when rewards is 0
- Amounts are formatted from stroops using the existing `fmtXlm()` helper (10,000,000,000 stroops → 10,000 XLM)
- Addresses are truncated to `GAAAAA…ZZZZ` format (6 + 4 chars)

## Tests

18 new unit tests in `indexer/test/decoder.stake.test.js`:
- 6 tests for stake/lock/deposit_stake **with** duration
- 5 tests for stake/lock/deposit_stake **without** duration (including duration=0 edge case)
- 4 tests for unstake/unlock **with** rewards
- 3 tests for unstake/unlock **without** rewards (including rewards=0 edge case)

All existing SEP-41 tests continue to pass (9/9).