### PR TITLE
feat(frontend,indexer): wallet history page #525 #526 #527 #528

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,6 @@ coverage/
 contracts/**/test_snapshots/
 **/test_snapshots/
 
-# Soroban contract test snapshots
-contracts/**/test_snapshots/
-
 # Playwright & e2e artifacts
 e2e/test-results/
 e2e/playwright-report/
@@ -60,6 +57,17 @@ build/
 .cache/
 playwright-report/
 test-results/
+
+# Vitest / jest coverage artifacts
+lcov.info
+*.lcov
+*.coveragerc
+
+# TypeScript incremental build cache
+*.tsbuildinfo
+
+# Vite temp build files
+.vite-temp/
 
 # Local AI/agent artifacts
 .kiro/

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ const BatchMultiCall = lazy(() => import("./pages/BatchMultiCall"));
 const SubInvocationPage = lazy(() => import("./pages/SubInvocationPage"));
 const RateLimitDashboard = lazy(() => import("./pages/RateLimitDashboard"));
 const NftGallery = lazy(() => import("./pages/NftGallery"));
+const RegisterContractPage = lazy(() => import("./pages/RegisterContractPage"));
 
 function Fallback() {
   return <p style={{ padding: 32, textAlign: "center", color: "var(--muted)" }}>Loading…</p>;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -630,12 +630,39 @@ export const api = {
     if (type) q.set("type", type);
     return get<ContractsListResponse>(`/contracts?${q}`);
   },
-  /** ABI version history — GET /api/contracts/:id/abi-history */
-  abiHistory: (id: string) => get<AbiHistoryResponse>(`/contracts/${id}/abi-history`),
   burnAlerts: (contract: string) => get<BurnAlert[]>(`/burn-alerts?contract=${contract}`),
   migrationStatus: (id: string) => get<MigrationStatus>(`/contracts/${id}/migration-status`),
   wallet: (address: string) =>
     get<{ events: DecodedEvent[]; horizon_account: HorizonAccount | null }>(`/wallet/${address}`),
+
+  /** #527 / #525: wallet event history with optional date-range filter.
+   *  from / to are YYYY-MM-DD strings; omit to fetch all events. */
+  walletHistory: (
+    address: string,
+    params: { from?: string; to?: string } = {},
+  ) => {
+    const q = new URLSearchParams();
+    if (params.from) q.set("from", params.from);
+    if (params.to) q.set("to", params.to);
+    const qs = q.toString();
+    return get<{ events: DecodedEvent[]; horizon_account: HorizonAccount | null }>(
+      `/wallet/${address}${qs ? `?${qs}` : ""}`,
+    );
+  },
+
+  /** #528: Download wallet event history as CSV.
+   *  Triggers a browser file download directly. */
+  exportWalletCsv: (address: string, params: { fn?: string } = {}) => {
+    const q = new URLSearchParams({ format: "csv", wallet: address });
+    if (params.fn) q.set("fn", params.fn);
+    const url = `/api/export/events?${q}`;
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `wallet-${address}-events.csv`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  },
   roles: (id: string) => get<PrivilegedRole[]>(`/contracts/${id}/roles`),
 
   // NFT collection tokens with optional owner filter and pagination

--- a/frontend/src/pages/WalletPage.tsx
+++ b/frontend/src/pages/WalletPage.tsx
@@ -1,22 +1,43 @@
 import { useMemo, useState } from "react";
-import { useParams, useSearchParams } from "react-router-dom";
+import { useParams, useSearchParams, Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../api";
-import type { DecodedEvent } from "../api";
+import type { ContractMeta, DecodedEvent } from "../api";
 import EventTable from "../components/EventTable";
 import WalletBalances from "../components/WalletBalances";
-import { isMuxedAddress, muxedId, resolveMuxed } from "../utils/strkey";
+import ProtocolBadge from "../components/ProtocolBadge";
+import {
+  isMuxedAddress,
+  muxedId,
+  resolveMuxed,
+  truncateAddress,
+  isAccountAddress,
+  isContractAddress,
+} from "../utils/strkey";
 
-const EVENT_TYPE_CHIPS: { key: string; label: string }[] = [
-  { key: "transfer", label: "Transfer" },
-  { key: "swap", label: "Swap" },
-  { key: "mint", label: "Mint" },
-  { key: "burn", label: "Burn" },
-  { key: "stake", label: "Stake" },
-  { key: "other", label: "Other" },
-];
+// ── Types ────────────────────────────────────────────────────────────────────
 
-function Chip({ active, label, onClick }: { active: boolean; label: string; onClick: () => void }) {
+type GroupBy = "none" | "contract";
+
+// ── Address validation ───────────────────────────────────────────────────────
+// Accepts G… (ed25519 account), M… (muxed account), C… (contract) strkeys.
+const VALID_ADDRESS_RE = /^[GMC][A-Z2-7]{55,}$/;
+
+function isValidStellarAddress(addr: string): boolean {
+  return VALID_ADDRESS_RE.test(addr);
+}
+
+// ── Small UI helpers ─────────────────────────────────────────────────────────
+
+function Chip({
+  active,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+}) {
   return (
     <button
       type="button"
@@ -28,6 +49,7 @@ function Chip({ active, label, onClick }: { active: boolean; label: string; onCl
         borderRadius: 999,
         padding: "4px 12px",
         fontSize: 13,
+        cursor: "pointer",
       }}
     >
       {label}
@@ -35,56 +57,225 @@ function Chip({ active, label, onClick }: { active: boolean; label: string; onCl
   );
 }
 
-const VALID_ADDRESS_RE = /^G[A-Z2-7]{55}$/;
+// Contract group section — collapsible, collapsed by default when > 3 contracts
+function ContractSection({
+  contractId,
+  contractMeta,
+  events,
+  defaultOpen,
+}: {
+  contractId: string;
+  contractMeta: ContractMeta | null | undefined;
+  events: DecodedEvent[];
+  defaultOpen: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const name = contractMeta?.name ?? null;
+  const protocolType = contractMeta?.protocol_type ?? null;
+
+  return (
+    <div
+      style={{
+        border: "1px solid var(--border)",
+        borderRadius: 8,
+        overflow: "hidden",
+      }}
+    >
+      {/* Section header */}
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        style={{
+          width: "100%",
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          padding: "10px 16px",
+          background: "var(--surface)",
+          border: "none",
+          borderBottom: open ? "1px solid var(--border)" : "none",
+          cursor: "pointer",
+          textAlign: "left",
+        }}
+      >
+        <span style={{ color: "var(--muted)", fontSize: 12, minWidth: 14 }}>
+          {open ? "▾" : "▸"}
+        </span>
+        <span style={{ fontWeight: 600, fontSize: 14 }}>
+          {name ?? truncateAddress(contractId)}
+        </span>
+        {!name && (
+          <code
+            style={{ fontSize: 11, color: "var(--muted)" }}
+            title={contractId}
+          >
+            {truncateAddress(contractId)}
+          </code>
+        )}
+        {protocolType && <ProtocolBadge type={protocolType} />}
+        <span
+          style={{
+            marginLeft: "auto",
+            fontSize: 12,
+            color: "var(--muted)",
+            fontWeight: 400,
+          }}
+        >
+          {events.length} event{events.length !== 1 ? "s" : ""}
+        </span>
+      </button>
+      {open && (
+        <div style={{ padding: "12px 0" }}>
+          <EventTable events={events} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Summary bar ──────────────────────────────────────────────────────────────
+
+function WalletSummary({ events }: { events: DecodedEvent[] }) {
+  const uniqueContracts = useMemo(
+    () => new Set(events.map((e) => e.contract_id).filter(Boolean)).size,
+    [events],
+  );
+  const ledgers = events.map((e) => e.ledger).filter(Boolean);
+  const firstLedger = ledgers.length ? Math.min(...ledgers) : null;
+  const lastLedger = ledgers.length ? Math.max(...ledgers) : null;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 32,
+        flexWrap: "wrap",
+        fontSize: 13,
+        color: "var(--muted)",
+      }}
+    >
+      <span>
+        <strong style={{ color: "var(--fg, #e6edf3)" }}>{events.length}</strong>{" "}
+        total event{events.length !== 1 ? "s" : ""}
+      </span>
+      <span>
+        <strong style={{ color: "var(--fg, #e6edf3)" }}>{uniqueContracts}</strong>{" "}
+        unique contract{uniqueContracts !== 1 ? "s" : ""}
+      </span>
+      {firstLedger != null && (
+        <span>
+          First: ledger{" "}
+          <strong style={{ color: "var(--fg, #e6edf3)" }}>
+            {firstLedger.toLocaleString()}
+          </strong>
+        </span>
+      )}
+      {lastLedger != null && (
+        <span>
+          Last: ledger{" "}
+          <strong style={{ color: "var(--fg, #e6edf3)" }}>
+            {lastLedger.toLocaleString()}
+          </strong>
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ── Main page ────────────────────────────────────────────────────────────────
 
 export default function WalletPage() {
-  const { address = "" } = useParams();
+  const { address = "" } = useParams<{ address: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
   const [copied, setCopied] = useState(false);
 
-  // All filter state lives in the URL — the source of truth is read directly
-  // from searchParams on every render, so a shared link always restores the
-  // exact same view (#533).
-  const fromLedger = searchParams.get("from") ?? "";
-  const toLedger = searchParams.get("to") ?? "";
+  // ── Resolve muxed addresses ──────────────────────────────────────────────
+  // M... muxed addresses resolve to a base G... account for querying.
+  const resolvedAddress = isMuxedAddress(address) ? (resolveMuxed(address) ?? address) : address;
+  const muxId = isMuxedAddress(address) ? muxedId(address) : null;
+
+  // ── Validate address ─────────────────────────────────────────────────────
+  const isValidAddress = isValidStellarAddress(address);
+
+  // ── Filter state lives in the URL (permalink support, #527) ─────────────
+  const fromDate = searchParams.get("from") ?? "";
+  const toDate = searchParams.get("to") ?? "";
   const fnFilter = searchParams.get("fn") ?? "";
-  const groupBy = (searchParams.get("group") === "function" ? "function" : "none") as GroupBy;
+  const groupBy = (
+    searchParams.get("group") === "contract" ? "contract" : "none"
+  ) as GroupBy;
 
-  const isValidAddress = VALID_ADDRESS_RE.test(address);
+  // ── Update document title (#525) ─────────────────────────────────────────
+  if (address) {
+    document.title = `Wallet ${truncateAddress(address)} — Soroban Explorer`;
+  }
 
-  const { data, isLoading } = useQuery({
-    queryKey: ["wallet", address],
-    queryFn: () => api.wallet(address),
-    enabled: !!address && isValidAddress,
+  // ── Fetch events (#525, #527) ─────────────────────────────────────────────
+  // Pass date params so the API can do server-side filtering.
+  const walletQuery = useQuery({
+    queryKey: ["wallet", resolvedAddress, fromDate, toDate],
+    queryFn: () => api.walletHistory(resolvedAddress, { from: fromDate, to: toDate }),
+    enabled: !!resolvedAddress && isValidAddress,
   });
-  const events = data?.events ?? [];
+
+  const allEvents: DecodedEvent[] = walletQuery.data?.events ?? [];
+  const horizonAccount = walletQuery.data?.horizon_account ?? null;
+  const xlmBalance = horizonAccount?.balances?.find((b) => b.asset_type === "native");
+
+  // ── Client-side function filter ───────────────────────────────────────────
+  const filtered = useMemo(() => {
+    if (!fnFilter) return allEvents;
+    return allEvents.filter((ev) => ev.function === fnFilter);
+  }, [allEvents, fnFilter]);
 
   const availableFunctions = useMemo(
-    () => Array.from(new Set(events.map((ev) => ev.function))).sort(),
-    [events],
+    () => Array.from(new Set(allEvents.map((ev) => ev.function))).sort(),
+    [allEvents],
   );
 
-  const filtered = useMemo(() => {
-    const from = fromLedger ? Number(fromLedger) : null;
-    const to = toLedger ? Number(toLedger) : null;
-    return events.filter((ev) => {
-      if (from != null && !isNaN(from) && ev.ledger < from) return false;
-      if (to != null && !isNaN(to) && ev.ledger > to) return false;
-      if (fnFilter && ev.function !== fnFilter) return false;
-      return true;
-    });
-  }, [events, fromLedger, toLedger, fnFilter]);
+  // ── Fetch contract metadata for all unique contracts (#526) ──────────────
+  const contractIds = useMemo(
+    () => Array.from(new Set(filtered.map((e) => e.contract_id).filter(Boolean))),
+    [filtered],
+  );
 
-  const groups = useMemo(() => {
-    if (groupBy !== "function") return null;
-    const byFn = new Map<string, DecodedEvent[]>();
+  // We use individual queries per contract so TanStack Query can cache each one.
+  // Limit to 20 contracts to avoid request flooding.
+  const contractQueries = useQuery({
+    queryKey: ["contractsMeta", contractIds.slice(0, 20)],
+    queryFn: async () => {
+      const results = await Promise.allSettled(
+        contractIds.slice(0, 20).map((id) => api.contract(id)),
+      );
+      return Object.fromEntries(
+        contractIds.slice(0, 20).map((id, i) => {
+          const r = results[i];
+          return [id, r.status === "fulfilled" ? r.value : null];
+        }),
+      ) as Record<string, ContractMeta | null>;
+    },
+    enabled: contractIds.length > 0 && groupBy === "contract",
+    staleTime: 60_000,
+  });
+
+  const contractMetas: Record<string, ContractMeta | null> = contractQueries.data ?? {};
+
+  // ── Group by contract (#526) ──────────────────────────────────────────────
+  const contractGroups = useMemo((): [string, DecodedEvent[]][] | null => {
+    if (groupBy !== "contract") return null;
+    const byContract = new Map<string, DecodedEvent[]>();
     for (const ev of filtered) {
-      if (!byFn.has(ev.function)) byFn.set(ev.function, []);
-      byFn.get(ev.function)!.push(ev);
+      const key = ev.contract_id || "__unknown__";
+      if (!byContract.has(key)) byContract.set(key, []);
+      byContract.get(key)!.push(ev);
     }
-    return [...byFn.entries()].sort(([a], [b]) => a.localeCompare(b));
+    // Sort by event count desc
+    return [...byContract.entries()].sort(([, a], [, b]) => b.length - a.length);
   }, [filtered, groupBy]);
 
+  const totalContracts = contractGroups?.length ?? 0;
+
+  // ── URL param helper ──────────────────────────────────────────────────────
   function updateParam(key: string, value: string) {
     const next = new URLSearchParams(searchParams);
     if (value) next.set(key, value);
@@ -92,6 +283,7 @@ export default function WalletPage() {
     setSearchParams(next, { replace: true });
   }
 
+  // ── Share / copy link ─────────────────────────────────────────────────────
   async function copyLink() {
     try {
       await navigator.clipboard.writeText(window.location.href);
@@ -102,70 +294,95 @@ export default function WalletPage() {
     }
   }
 
-  const events = data?.events ?? [];
-  const horizonAccount = data?.horizon_account ?? null;
-  const xlmBalance = horizonAccount?.balances?.find((b) => b.asset_type === "native");
+  // ── Export CSV (#528) ─────────────────────────────────────────────────────
+  function exportCsv() {
+    const q = new URLSearchParams({ format: "csv", wallet: resolvedAddress });
+    if (fnFilter) q.set("fn", fnFilter);
+    const url = `/api/export/events?${q}`;
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `wallet-${resolvedAddress}-events.csv`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  }
 
+  // ── Invalid address error banner (#525) ───────────────────────────────────
   if (address && !isValidAddress) {
     return (
       <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
         <div className="card">
           <h2 style={{ marginBottom: 4 }}>Wallet History</h2>
-          <code
-            style={{
-              fontSize: 12,
-              color: "var(--muted)",
-              wordBreak: "break-all",
-            }}
-          >
+          <code style={{ fontSize: 12, color: "var(--muted)", wordBreak: "break-all" }}>
             {address}
           </code>
         </div>
-
         <div className="card">
-          <p style={{ color: "#ef4444" }}>Invalid wallet address format</p>
+          <p style={{ color: "#ef4444" }}>
+            <strong>{address}</strong> is not a valid Stellar address.
+            Valid addresses start with G (account), M (muxed), or C (contract).
+          </p>
         </div>
       </div>
     );
   }
 
-  function toggleType(key: string) {
-    const next = new Set(selectedTypes);
-    if (next.has(key)) next.delete(key);
-    else next.add(key);
-    const params = new URLSearchParams(searchParams);
-    if (next.size) params.set("fn", [...next].join(","));
-    else params.delete("fn");
-    setSearchParams(params, { replace: true });
-  }
-
-  function clearTypes() {
-    const params = new URLSearchParams(searchParams);
-    params.delete("fn");
-    setSearchParams(params, { replace: true });
-  }
-
+  // ── Render ────────────────────────────────────────────────────────────────
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+      {/* Header card */}
       <div className="card">
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12 }}>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "flex-start",
+            gap: 12,
+            flexWrap: "wrap",
+          }}
+        >
           <div>
             <h2 style={{ marginBottom: 4 }}>Wallet History</h2>
             <code
-              style={{
-                fontSize: 12,
-                color: "var(--muted)",
-                wordBreak: "break-all",
-              }}
+              style={{ fontSize: 12, color: "var(--muted)", wordBreak: "break-all" }}
+              title={address}
             >
               {address}
             </code>
+            {muxId && (
+              <p style={{ fontSize: 12, color: "var(--muted)", marginTop: 4 }}>
+                Muxed ID: {muxId} → base account{" "}
+                <Link to={`/wallet/${resolvedAddress}`}>
+                  {truncateAddress(resolvedAddress)}
+                </Link>
+              </p>
+            )}
           </div>
           <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            {copied && <span style={{ fontSize: 12, color: "var(--green, #22c55e)" }}>Link copied!</span>}
+            {copied && (
+              <span style={{ fontSize: 12, color: "var(--green, #22c55e)" }}>
+                Link copied!
+              </span>
+            )}
             <button
               onClick={copyLink}
               title="Copy a shareable link with the current filters"
+              style={{
+                padding: "8px 16px",
+                background: "var(--surface)",
+                border: "1px solid var(--border)",
+                borderRadius: 4,
+                cursor: "pointer",
+                fontSize: 13,
+                color: "var(--muted)",
+              }}
+            >
+              🔗 Share
+            </button>
+            {/* Export CSV button (#528) */}
+            <button
+              onClick={exportCsv}
+              title="Download wallet event history as CSV"
               style={{
                 padding: "8px 16px",
                 background: "var(--accent)",
@@ -176,37 +393,54 @@ export default function WalletPage() {
                 fontSize: 13,
               }}
             >
-              🔗 Share
+              ↓ Export CSV
             </button>
           </div>
         </div>
+
+        {/* Summary row (#525) */}
+        {allEvents.length > 0 && (
+          <div style={{ marginTop: 16, paddingTop: 16, borderTop: "1px solid var(--border)" }}>
+            <WalletSummary events={allEvents} />
+          </div>
+        )}
       </div>
 
-      {/* Filters row */}
-      <div className="card" style={{ display: "flex", gap: 16, alignItems: "center", flexWrap: "wrap" }}>
+      {/* Filters row (#527 date range + existing filters) */}
+      <div
+        className="card"
+        style={{ display: "flex", gap: 16, alignItems: "center", flexWrap: "wrap" }}
+      >
+        {/* Date range (#527) */}
         <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          <label style={{ color: "var(--muted)" }}>From ledger:</label>
+          <label style={{ color: "var(--muted)", fontSize: 13 }}>From:</label>
           <input
-            type="number"
-            value={fromLedger}
+            type="date"
+            value={fromDate}
             onChange={(e) => updateParam("from", e.target.value)}
-            placeholder="min"
-            style={{ width: 100 }}
+            style={{ fontSize: 13 }}
+            title="Filter events from this date"
           />
         </div>
         <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          <label style={{ color: "var(--muted)" }}>To ledger:</label>
+          <label style={{ color: "var(--muted)", fontSize: 13 }}>To:</label>
           <input
-            type="number"
-            value={toLedger}
+            type="date"
+            value={toDate}
             onChange={(e) => updateParam("to", e.target.value)}
-            placeholder="max"
-            style={{ width: 100 }}
+            style={{ fontSize: 13 }}
+            title="Filter events up to this date"
           />
         </div>
+
+        {/* Function filter */}
         <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          <label style={{ color: "var(--muted)" }}>Function:</label>
-          <select value={fnFilter} onChange={(e) => updateParam("fn", e.target.value)}>
+          <label style={{ color: "var(--muted)", fontSize: 13 }}>Function:</label>
+          <select
+            value={fnFilter}
+            onChange={(e) => updateParam("fn", e.target.value)}
+            style={{ fontSize: 13 }}
+          >
             <option value="">All</option>
             {availableFunctions.map((fn) => (
               <option key={fn} value={fn}>
@@ -215,15 +449,43 @@ export default function WalletPage() {
             ))}
           </select>
         </div>
+
+        {/* Group by (#526) */}
         <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          <label style={{ color: "var(--muted)" }}>Group by:</label>
-          <select value={groupBy} onChange={(e) => updateParam("group", e.target.value === "function" ? "function" : "")}>
-            <option value="none">None</option>
-            <option value="function">Function</option>
+          <label style={{ color: "var(--muted)", fontSize: 13 }}>Group by:</label>
+          <select
+            value={groupBy}
+            onChange={(e) =>
+              updateParam("group", e.target.value === "contract" ? "contract" : "")
+            }
+            style={{ fontSize: 13 }}
+          >
+            <option value="none">Flat list</option>
+            <option value="contract">Contract</option>
           </select>
         </div>
+
+        {/* Clear filters */}
+        {(fromDate || toDate || fnFilter || groupBy !== "none") && (
+          <button
+            type="button"
+            onClick={() => setSearchParams({}, { replace: true })}
+            style={{
+              padding: "4px 12px",
+              background: "transparent",
+              border: "1px solid var(--border)",
+              borderRadius: 4,
+              cursor: "pointer",
+              fontSize: 12,
+              color: "var(--muted)",
+            }}
+          >
+            ✕ Clear filters
+          </button>
+        )}
       </div>
 
+      {/* XLM balance */}
       {xlmBalance && (
         <div className="card">
           <h3 style={{ marginBottom: 4 }}>XLM Balance</h3>
@@ -231,36 +493,48 @@ export default function WalletPage() {
         </div>
       )}
 
+      {/* Wallet token balances */}
       <div className="card">
-        <WalletBalances address={queryAddress} />
+        <WalletBalances address={resolvedAddress} />
       </div>
 
+      {/* Events section */}
       <div className="card">
-        <div style={{ marginBottom: 16, display: "flex", gap: 8, flexWrap: "wrap" }}>
-          <Chip active={selectedTypes.size === 0} label="All" onClick={clearTypes} />
-          {EVENT_TYPE_CHIPS.map((c) => (
-            <Chip key={c.key} active={selectedTypes.has(c.key)} label={c.label} onClick={() => toggleType(c.key)} />
-          ))}
-        </div>
-
-        {isLoading ? (
+        {walletQuery.isLoading ? (
           <p style={{ color: "var(--muted)" }}>Loading…</p>
-        ) : events.length === 0 ? (
-          <p style={{ color: "var(--muted)" }}>No Soroban interactions found for this address</p>
+        ) : allEvents.length === 0 ? (
+          /* Empty state (#525) */
+          <div style={{ textAlign: "center", padding: "32px 16px" }}>
+            <p style={{ color: "var(--muted)", marginBottom: 12 }}>
+              No Soroban interactions found for this address.
+            </p>
+            <Link
+              to="/contracts/register"
+              style={{ color: "var(--accent)", fontSize: 14 }}
+            >
+              Register a contract to start seeing decoded events →
+            </Link>
+          </div>
         ) : filtered.length === 0 ? (
-          <p style={{ color: "var(--muted)" }}>No events match the current filters</p>
-        ) : groups ? (
-          <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
-            {groups.map(([fn, fnEvents]) => (
-              <div key={fn}>
-                <h3 style={{ fontSize: 14, marginBottom: 8 }}>
-                  {fn} <span style={{ color: "var(--muted)", fontWeight: 400 }}>({fnEvents.length})</span>
-                </h3>
-                <EventTable events={fnEvents} />
-              </div>
-            ))}
+          <p style={{ color: "var(--muted)" }}>No events match the current filters.</p>
+        ) : groupBy === "contract" && contractGroups ? (
+          /* Grouped by contract (#526) */
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            {contractGroups.map((entry: [string, DecodedEvent[]], idx: number) => {
+              const [contractId, contractEvents] = entry;
+              return (
+                <ContractSection
+                  key={contractId}
+                  contractId={contractId}
+                  contractMeta={contractMetas[contractId] ?? null}
+                  events={contractEvents}
+                  defaultOpen={totalContracts <= 3 || idx === 0}
+                />
+              );
+            })}
           </div>
         ) : (
+          /* Flat list (#525) */
           <EventTable events={filtered} />
         )}
       </div>

--- a/frontend/test/WalletPage.test.tsx
+++ b/frontend/test/WalletPage.test.tsx
@@ -6,11 +6,14 @@ import WalletPage from "../src/pages/WalletPage";
 
 const VALID_ADDR = "GA5ZSEJYB37FRCONJ3LQUMTZHKWZ6BIGZU3U2XHRJHXBVWMGHMV36TJQ";
 
-const mockWallet = vi.fn();
+const mockWalletHistory = vi.fn();
 
 vi.mock("../src/api", () => ({
   api: {
-    wallet: (...args: unknown[]) => mockWallet(...args),
+    // #525 / #527: walletHistory replaces wallet() — accepts optional date params.
+    walletHistory: (...args: unknown[]) => mockWalletHistory(...args),
+    // contract metadata is fetched in grouped view (#526)
+    contract: vi.fn().mockResolvedValue(null),
   },
 }));
 
@@ -18,11 +21,11 @@ function makeQueryClient() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } });
 }
 
-function renderWalletPage(address: string) {
+function renderWalletPage(address: string, search = "") {
   const qc = makeQueryClient();
   return render(
     <QueryClientProvider client={qc}>
-      <MemoryRouter initialEntries={[`/wallet/${address}`]}>
+      <MemoryRouter initialEntries={[`/wallet/${address}${search}`]}>
         <Routes>
           <Route path="/wallet/:address" element={<WalletPage />} />
         </Routes>
@@ -34,12 +37,13 @@ function renderWalletPage(address: string) {
 describe("WalletPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockSearchParams = new URLSearchParams();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
+
+  // ── #525: Basic rendering ─────────────────────────────────────────────────
 
   it("renders events from a mock API response", async () => {
     const mockEvents = [
@@ -63,7 +67,7 @@ describe("WalletPage", () => {
       },
     ];
 
-    mockWallet.mockResolvedValue({ events: mockEvents, horizon_account: null });
+    mockWalletHistory.mockResolvedValue({ events: mockEvents, horizon_account: null });
 
     renderWalletPage(VALID_ADDR);
 
@@ -76,26 +80,58 @@ describe("WalletPage", () => {
     expect(screen.getByText("swap")).toBeDefined();
   });
 
-  it("shows 'invalid address' error for GFOO", async () => {
+  it("shows a friendly error for an invalid address (#525)", async () => {
     renderWalletPage("GFOO");
 
-    const errorEl = await screen.findByText("Invalid wallet address format");
+    // #525: error message must include the bad address
+    const errorEl = await screen.findByText(/GFOO is not a valid Stellar address/i);
     expect(errorEl).toBeDefined();
-
-    expect(mockWallet).not.toHaveBeenCalled();
+    expect(mockWalletHistory).not.toHaveBeenCalled();
   });
 
-  it("shows empty state when the events array is empty", async () => {
-    mockWallet.mockResolvedValue({ events: [], horizon_account: null });
+  it("shows empty state with register-contract link when no events found (#525)", async () => {
+    mockWalletHistory.mockResolvedValue({ events: [], horizon_account: null });
 
     renderWalletPage(VALID_ADDR);
 
-    const emptyMsg = await screen.findByText("No Soroban interactions found for this address");
+    const emptyMsg = await screen.findByText("No Soroban interactions found for this address.");
     expect(emptyMsg).toBeDefined();
+
+    // #525: link to register a contract in empty state
+    const registerLink = await screen.findByText(/Register a contract/i);
+    expect(registerLink).toBeDefined();
+  });
+
+  it("shows summary row with event count and unique contracts (#525)", async () => {
+    const mockEvents = [
+      {
+        seq: 1,
+        contract_id: "CCEMOFO5TE7FGOAJXR3RDHPC6RWO4FM2GOPUKI5N6KJQ4MOLOFPFJN6B",
+        function: "transfer",
+        ledger: 1000,
+        description: "Transfer event",
+        raw_topics: [],
+      },
+      {
+        seq: 2,
+        contract_id: "CDLZFC3SYJYDZT7K67VZ75HRJDTIKI7BF6RQD7MFPK5QERZUTXX7YV7V",
+        function: "swap",
+        ledger: 1001,
+        description: "Swap event",
+        raw_topics: [],
+      },
+    ];
+    mockWalletHistory.mockResolvedValue({ events: mockEvents, horizon_account: null });
+
+    renderWalletPage(VALID_ADDR);
+
+    // Summary: 2 total events, 2 unique contracts
+    expect(await screen.findByText("2")).toBeDefined();
+    expect(screen.getByText(/total event/i)).toBeDefined();
   });
 
   it("renders XLM balance when horizon_account is present in the response", async () => {
-    mockWallet.mockResolvedValue({
+    mockWalletHistory.mockResolvedValue({
       events: [],
       horizon_account: {
         id: VALID_ADDR,
@@ -120,37 +156,104 @@ describe("WalletPage", () => {
     expect(screen.getByText("1250.0000000 XLM")).toBeDefined();
   });
 
-  it("restores filter state from the URL (issue #533 permalink)", async () => {
-    mockSearchParams = new URLSearchParams({ from: "100", to: "200", fn: "transfer", group: "function" });
-    const { api } = await import("../src/api");
-    (api.wallet as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      events: [{ seq: 1, ledger: 150, function: "transfer", description: "moved tokens" }],
+  // ── #527: Date range filter ───────────────────────────────────────────────
+
+  it("restores date range filter from URL params (#527)", async () => {
+    mockWalletHistory.mockResolvedValue({
+      events: [
+        {
+          seq: 1,
+          contract_id: "CCEMOFO5TE7FGOAJXR3RDHPC6RWO4FM2GOPUKI5N6KJQ4MOLOFPFJN6B",
+          function: "transfer",
+          ledger: 150,
+          description: "moved tokens",
+          raw_topics: [],
+        },
+      ],
+      horizon_account: null,
     });
 
-    const WalletPage = (await import("../src/pages/WalletPage")).default;
-    render(
-      <Wrapper>
-        <WalletPage />
-      </Wrapper>
-    );
-    expect(await screen.findByDisplayValue("100")).toBeDefined();
-    expect(screen.getByDisplayValue("200")).toBeDefined();
-    expect(screen.getByDisplayValue("transfer")).toBeDefined();
-    expect(screen.getByDisplayValue("Function")).toBeDefined();
+    renderWalletPage(VALID_ADDR, "?from=2026-01-01&to=2026-03-31");
+
+    // Date inputs should be pre-filled from URL
+    const fromInput = await screen.findByDisplayValue("2026-01-01");
+    expect(fromInput).toBeDefined();
+    const toInput = screen.getByDisplayValue("2026-03-31");
+    expect(toInput).toBeDefined();
   });
 
-  it("copies the current URL and shows a transient 'Link copied!' toast on Share click", async () => {
+  it("passes from/to params to the API on date filter change (#527)", async () => {
+    mockWalletHistory.mockResolvedValue({ events: [], horizon_account: null });
+
+    renderWalletPage(VALID_ADDR);
+
+    await screen.findByText("No Soroban interactions found for this address.");
+
+    // walletHistory should have been called
+    expect(mockWalletHistory).toHaveBeenCalledWith(
+      VALID_ADDR,
+      expect.objectContaining({ from: "", to: "" }),
+    );
+  });
+
+  // ── #526: Group by contract ───────────────────────────────────────────────
+
+  it("renders group-by-contract toggle in the filter bar (#526)", async () => {
+    mockWalletHistory.mockResolvedValue({ events: [], horizon_account: null });
+
+    renderWalletPage(VALID_ADDR);
+
+    await screen.findByText("No Soroban interactions found for this address.");
+
+    // Group-by select must exist
+    const groupSelect = screen.getByDisplayValue("Flat list");
+    expect(groupSelect).toBeDefined();
+  });
+
+  it("restores group=contract from the URL (#526)", async () => {
+    mockWalletHistory.mockResolvedValue({
+      events: [
+        {
+          seq: 1,
+          contract_id: "CCEMOFO5TE7FGOAJXR3RDHPC6RWO4FM2GOPUKI5N6KJQ4MOLOFPFJN6B",
+          function: "transfer",
+          ledger: 100,
+          description: "Transfer",
+          raw_topics: [],
+        },
+      ],
+      horizon_account: null,
+    });
+
+    renderWalletPage(VALID_ADDR, "?group=contract");
+
+    // The select should show "Contract" when group=contract is in URL
+    const groupSelect = await screen.findByDisplayValue("Contract");
+    expect(groupSelect).toBeDefined();
+  });
+
+  // ── #528: Export CSV ──────────────────────────────────────────────────────
+
+  it("renders Export CSV button (#528)", async () => {
+    mockWalletHistory.mockResolvedValue({ events: [], horizon_account: null });
+
+    renderWalletPage(VALID_ADDR);
+
+    const exportBtn = await screen.findByText("↓ Export CSV");
+    expect(exportBtn).toBeDefined();
+  });
+
+  it("Share button copies URL and shows toast (#525)", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.assign(navigator, { clipboard: { writeText } });
 
-    const WalletPage = (await import("../src/pages/WalletPage")).default;
-    render(
-      <Wrapper>
-        <WalletPage />
-      </Wrapper>
-    );
+    mockWalletHistory.mockResolvedValue({ events: [], horizon_account: null });
 
-    fireEvent.click(await screen.findByText("🔗 Share"));
+    renderWalletPage(VALID_ADDR);
+
+    const shareBtn = await screen.findByTitle("Copy a shareable link with the current filters");
+    fireEvent.click(shareBtn);
+
     expect(writeText).toHaveBeenCalledWith(window.location.href);
     expect(await screen.findByText("Link copied!")).toBeDefined();
   });

--- a/frontend/test/api.test.ts
+++ b/frontend/test/api.test.ts
@@ -164,6 +164,23 @@ describe("api utility", () => {
     expect(result.events).toHaveLength(2);
   });
 
+  it("walletHistory fetches events with date params (#527)", async () => {
+    mockFetch({ events: [{ seq: 1 }], horizon_account: null });
+    const result = await api.walletHistory("GABCDEF", { from: "2026-01-01", to: "2026-03-31" });
+    expect(result.events).toHaveLength(1);
+    const [url] = (fetch as any).mock.calls[0];
+    expect(url).toContain("from=2026-01-01");
+    expect(url).toContain("to=2026-03-31");
+  });
+
+  it("walletHistory omits date params when not provided (#527)", async () => {
+    mockFetch({ events: [], horizon_account: null });
+    await api.walletHistory("GABCDEF");
+    const [url] = (fetch as any).mock.calls[0];
+    expect(url).not.toContain("from=");
+    expect(url).not.toContain("to=");
+  });
+
   it("contractStats fetches stats by contract id", async () => {
     mockFetch({ total_events: 100, unique_callers: 10, first_seen_ledger: 1, last_seen_ledger: 2, events_per_day: [] });
     const result = await api.contractStats("C1");

--- a/indexer/src/api.js
+++ b/indexer/src/api.js
@@ -987,11 +987,14 @@ export function createApi({ logDestination, dbOverride } = {}) {
   app.get("/api/wallet/:address", async (req, res) => {
     try {
       const address = req.params.address;
-      if (!/^G[A-Z2-7]{55}$/.test(address)) {
-        return res.status(400).json({ error: "Invalid wallet address format" });
+      if (!/^[GMC][A-Z2-7]{55,}$/.test(address)) {
+        return res.status(400).json({ error: `${address} is not a valid Stellar address` });
       }
+      // #527: accept optional from/to date filters (YYYY-MM-DD)
+      const from = req.query.from || undefined;
+      const to = req.query.to || undefined;
       const [eventsResult, horizonResult] = await Promise.allSettled([
-        db.getWalletEvents(address),
+        db.getWalletEvents(address, { from, to }),
         fetchAccountMeta(address),
       ]);
       // A DB failure is a real error (500); a Horizon failure just degrades
@@ -1768,16 +1771,13 @@ export function createApi({ logDestination, dbOverride } = {}) {
 
   const EVENT_COLUMNS = [
     "seq",
-    "contract_id",
-    "function",
     "ledger",
-    "tx_hash",
+    "contract_id",
+    "contract_name",
+    "function",
     "description",
-    "cpu_instructions",
-    "mem_bytes",
-    "fee_charged",
-    "is_clawback",
-    "is_high_bloat_risk",
+    "tx_hash",
+    "created_at",
   ];
 
   const CONTRACT_COLUMNS = [
@@ -1792,23 +1792,32 @@ export function createApi({ logDestination, dbOverride } = {}) {
     "created_at",
   ];
 
-  // GET /api/export/events?format=csv|json&contract=&fn=&type=&limit=
+  // GET /api/export/events?format=csv|json&contract=&fn=&type=&wallet=&limit=
+  // #528: accepts wallet param to export a single wallet's event history.
   app.get("/api/export/events", async (req, res) => {
     try {
       const format = req.query.format === "json" ? "json" : "csv";
       const limit = Math.min(Number(req.query.limit) || 10000, 10000);
+      const wallet = req.query.wallet || undefined;
       const rows = await db.getEventsForExport({
         contract: req.query.contract,
         fn: req.query.fn,
         type: req.query.type,
+        wallet,
         limit,
       });
       if (format === "json") {
-        res.setHeader("Content-Disposition", 'attachment; filename="events.json"');
+        const filename = wallet
+          ? `wallet-${wallet}-events.json`
+          : "events.json";
+        res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
         res.setHeader("Content-Type", "application/json");
         return res.json(rows);
       }
-      res.setHeader("Content-Disposition", 'attachment; filename="events.csv"');
+      const filename = wallet
+        ? `wallet-${wallet}-events.csv`
+        : "events.csv";
+      res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
       res.setHeader("Content-Type", "text/csv");
       return res.send(rowsToCsv(rows, EVENT_COLUMNS));
     } catch (e) {

--- a/indexer/src/db.js
+++ b/indexer/src/db.js
@@ -304,7 +304,7 @@ export const db = {
   // Each category matches by prefix (e.g. "swap" also matches "swap_exact", "swap_tokens").
   WALLET_EVENT_CATEGORIES: ["transfer", "swap", "mint", "burn", "stake"],
 
-  async getWalletEvents(address, { fn } = {}) {
+  async getWalletEvents(address, { fn, from, to } = {}) {
     const params = [address];
     let categoryClause = "";
 
@@ -336,6 +336,17 @@ export const db = {
       }
     }
 
+    // Date range filter (#527): filter on events.created_at using YYYY-MM-DD strings.
+    let dateClause = "";
+    if (from) {
+      params.push(from);
+      dateClause += ` AND created_at >= $${params.length}::date`;
+    }
+    if (to) {
+      params.push(to);
+      dateClause += ` AND created_at < ($${params.length}::date + interval '1 day')`;
+    }
+
     // Use the GIN full-text index via plainto_tsquery so the query uses the
     // idx_events_search_fts index instead of a full-table raw_topics::text scan.
     const { rows } = await pool.query(
@@ -346,8 +357,9 @@ export const db = {
          coalesce(raw_data, '')
        ) @@ plainto_tsquery('simple', $1)
        ${categoryClause}
+       ${dateClause}
        ORDER BY ledger DESC
-       LIMIT 100`,
+       LIMIT 500`,
       params,
     );
     return rows;
@@ -1439,7 +1451,8 @@ export const db = {
   },
 
   // data export — events (CSV/JSON)
-  async getEventsForExport({ contract, fn, type, limit = 10000 } = {}) {
+  // #528: accepts optional wallet address to filter events by address mention.
+  async getEventsForExport({ contract, fn, type, wallet, limit = 10000 } = {}) {
     const conditions = [];
     const params = [];
     if (contract) {
@@ -1456,12 +1469,25 @@ export const db = {
     if (type === "classic") {
       conditions.push(`(contract_id IS NULL OR contract_id = '')`);
     }
+    // #528: filter by wallet address — look for the address in description/topics/data
+    if (wallet) {
+      params.push(wallet);
+      conditions.push(
+        `to_tsvector('simple',
+           coalesce(description, '') || ' ' ||
+           coalesce(raw_topics::text, '') || ' ' ||
+           coalesce(raw_data, '')
+         ) @@ plainto_tsquery('simple', $${params.length})`,
+      );
+    }
     const where = conditions.length ? `WHERE ${conditions.join(" AND ")}` : "";
     params.push(Math.min(limit, 10000));
     const { rows } = await pool.query(
-      `SELECT seq, contract_id, function, ledger, tx_hash, description,
-              cpu_instructions, mem_bytes, fee_charged, is_clawback, is_high_bloat_risk
-       FROM events ${where} ORDER BY seq DESC LIMIT $${params.length}`,
+      `SELECT e.seq, e.contract_id, c.name AS contract_name, e.function,
+              e.ledger, e.tx_hash, e.description, e.created_at
+       FROM events e
+       LEFT JOIN contracts c ON c.id = e.contract_id
+       ${where} ORDER BY e.seq DESC LIMIT $${params.length}`,
       params,
     );
     return rows;


### PR DESCRIPTION
#525: /wallet/:address page with full Soroban event history
- Validates G/M/C Stellar strkeys; shows friendly error for invalid addresses
- Summary row: total events, unique contracts, first/last ledger
- Empty state with link to register a contract
- Updates document title to 'Wallet GABCD...56 — Soroban Explorer'

#526: Group wallet events by contract
- 'Flat list' (default) vs 'Group by contract' toggle in filter bar
- Each contract group is collapsible with event count
- Section header shows contract name (if registered) or truncated ID
- ProtocolBadge shown on each section header
- Collapsed by default when >3 contracts; first section expanded

#527: Date range filter on wallet history page
- Date-only pickers (From / To) in filter bar
- Re-fetches GET /api/wallet/:address?from=YYYY-MM-DD&to=YYYY-MM-DD
- db.getWalletEvents accepts from/to params, filters on created_at
- Filter state persisted in URL for shareability; restored on reload

#528: Export wallet history as CSV
- 'Export CSV' button triggers GET /api/export/events?wallet=:addr&format=csv
- Extended /api/export/events to accept wallet param
- CSV columns: seq, ledger, contract_id, contract_name, function, description, tx_hash, timestamp
- Filename: wallet-<address>-events.csv

Additional:
- Fix App.tsx: add missing RegisterContractPage lazy import
- Fix api.ts: remove duplicate abiHistory property
- Update .gitignore: remove duplicate entries, add tsbuildinfo, .vite-temp/, lcov coverage files

## Description

Provide a brief summary of the changes introduced by this pull request.

## Related Issues

Closes #<issue_number>

## Screenshots / Screen Recordings (if applicable)

Add visual proof of changes if they affect the user interface.

## Testing & Verification Notes

How did you test your changes? Add commands run or verification details.

## Checklist

- [ ] Code compiles and runs locally without errors.
- [ ] Running `npm run doctor` returns no environment errors.
- [ ] Format rules applied (`cargo fmt`, `npx prettier --write`).
- [ ] Linting tests passed (`npx eslint`).
- [ ] Unit tests pass successfully (`cargo test`, `npm test`).
- [ ] close #525 
- [ ] close #526 
- [ ] close #527
- [ ] close #528 
