### PR TITLE
fix: add request_body_hash to audit log for state-changing API calls

### DIFF
--- a/indexer/migrations/026_audit_request_body_hash.sql
+++ b/indexer/migrations/026_audit_request_body_hash.sql
@@ -1,0 +1,9 @@
+-- Migration 026: Add request_body_hash to audit log for security audit trail
+--
+-- Captures SHA256 hash of request bodies for all state-changing API calls
+-- (POST/PUT/PATCH/DELETE) to enable non-repudiation and forensic analysis.
+
+ALTER TABLE api_audit_log ADD COLUMN IF NOT EXISTS request_body_hash TEXT;
+
+COMMENT ON COLUMN api_audit_log.request_body_hash IS
+  'SHA256 hex digest of the request body (JSON.stringify of parsed body). NULL for GET/HEAD/OPTIONS and bodiless requests.';

--- a/indexer/src/audit/auditLogger.js
+++ b/indexer/src/audit/auditLogger.js
@@ -14,6 +14,7 @@
  *     month's partition and drops partitions older than 90 days.
  */
 
+import crypto from 'crypto';
 import cron from 'node-cron';
 import { pool } from '../db.js';
 
@@ -52,8 +53,8 @@ async function _flushQueue() {
   try {
     // Build a multi-row VALUES clause.
     const valuePlaceholders = batch.map((_, i) => {
-      const base = i * 11;
-      return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}::INET, $${base + 6}, $${base + 7}, $${base + 8}, $${base + 9}, $${base + 10}, $${base + 11})`;
+      const base = i * 12;
+      return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}::INET, $${base + 6}, $${base + 7}, $${base + 8}, $${base + 9}, $${base + 10}, $${base + 11}, $${base + 12})`;
     });
 
     const params = batch.flatMap((e) => [
@@ -68,12 +69,14 @@ async function _flushQueue() {
       e.response_time_ms ?? 0,
       e.rate_limit_remaining ?? null,
       e.user_agent ?? null,
+      e.request_body_hash ?? null,
     ]);
 
     await pool.query(
       `INSERT INTO api_audit_log
          (timestamp, api_key_id, key_name, tier, ip, method, endpoint,
-          status_code, response_time_ms, rate_limit_remaining, user_agent)
+          status_code, response_time_ms, rate_limit_remaining, user_agent,
+          request_body_hash)
        VALUES ${valuePlaceholders.join(', ')}`,
       params,
     );
@@ -122,6 +125,16 @@ function auditLoggerMiddleware(req, res, next) {
         ? String(forwarded).split(',')[0].trim()
         : req.socket?.remoteAddress ?? '0.0.0.0';
 
+      let request_body_hash = null;
+      if (req.body && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)) {
+        try {
+          const bodyStr = JSON.stringify(req.body);
+          request_body_hash = crypto.createHash('sha256').update(bodyStr).digest('hex');
+        } catch {
+          // Non-serializable body — leave hash as null
+        }
+      }
+
       createAuditLogEntry({
         timestamp: new Date(),
         api_key_id: req.rateContext?.keyId ?? null,
@@ -134,6 +147,7 @@ function auditLoggerMiddleware(req, res, next) {
         response_time_ms: Date.now() - req._startTime,
         rate_limit_remaining: req.rateLimitState?.remaining ?? null,
         user_agent: req.headers['user-agent'] ?? null,
+        request_body_hash,
       });
     } catch (err) {
       // Never let audit logging affect the request lifecycle.

--- a/indexer/src/routes/admin.js
+++ b/indexer/src/routes/admin.js
@@ -48,6 +48,7 @@ const AUDIT_LOG_COLUMNS = [
   'response_time_ms',
   'rate_limit_remaining',
   'user_agent',
+  'request_body_hash',
 ];
 
 const EVENT_COLUMNS = [
@@ -383,7 +384,8 @@ export default function registerAdminRoutes(app) {
 
       const { rows } = await pool.query(
         `SELECT id, timestamp, api_key_id, key_name, tier, ip, method,
-                endpoint, status_code, response_time_ms, rate_limit_remaining, user_agent
+                endpoint, status_code, response_time_ms, rate_limit_remaining,
+                user_agent, request_body_hash
          FROM api_audit_log
          ${where}
          ORDER BY timestamp DESC
@@ -448,7 +450,8 @@ export default function registerAdminRoutes(app) {
 
       const { rows } = await pool.query(
         `SELECT id, timestamp, api_key_id, key_name, tier, ip, method,
-                endpoint, status_code, response_time_ms, rate_limit_remaining, user_agent
+                endpoint, status_code, response_time_ms, rate_limit_remaining,
+                user_agent, request_body_hash
          FROM api_audit_log
          ${where}
          ORDER BY timestamp DESC


### PR DESCRIPTION
Closes #616

Adds SHA256 request body hash capture to the global audit logger middleware, a database migration for the new column, and includes the field in audit-log query/export endpoints.

## Changes
- \uditLogger.js\: compute sha256 hash of req.body for POST/PUT/PATCH/DELETE
- \migrations/026_audit_request_body_hash.sql\: ALTER TABLE api_audit_log ADD COLUMN request_body_hash
- \dmin.js\: include request_body_hash in SELECT and CSV columns