### PR TITLE
fix(contracts): use stellar CLI in deploy.sh

### DIFF
--- a/contracts/deploy.sh
+++ b/contracts/deploy.sh
@@ -29,7 +29,7 @@ echo "✅ WASM found"
 if [ "${NETWORK}" = "testnet" ]; then
     echo ""
     echo "💰 Funding deployer via Friendbot..."
-    ADDR=$(soroban config identity address "${IDENTITY}")
+    ADDR=$(stellar keys address "${IDENTITY}")
     curl -sf "https://friendbot.stellar.org?addr=${ADDR}" > /dev/null
     echo "   ✅ Friendbot request sent"
     
@@ -41,7 +41,7 @@ fi
 echo ""
 echo "🔍 Verifying balance..."
 if [ "${NETWORK}" = "testnet" ]; then
-    ADDR=$(soroban config identity address "${IDENTITY}")
+    ADDR=$(stellar keys address "${IDENTITY}")
     BALANCE=$(curl -sf "https://horizon-testnet.stellar.org/accounts/${ADDR}" | jq -r '.balances[] | select(.asset_type=="native") | .balance')
 else
     BALANCE=$(stellar account show "${IDENTITY}" --network "${NETWORK}" | grep -E 'XLM\s+' | awk '{print $2}')
@@ -59,7 +59,7 @@ echo "   ✅ Sufficient balance"
 # 4. Deploy contract
 echo ""
 echo "📦 Deploying contract..."
-DEPLOY_OUTPUT=$(soroban contract deploy \
+DEPLOY_OUTPUT=$(stellar contract deploy \
     --wasm "${WASM_PATH}" \
     --source "${IDENTITY}" \
     --network "${NETWORK}")


### PR DESCRIPTION
## Summary
- `contracts/deploy.sh` called the legacy `soroban` binary (`soroban config identity address`, `soroban contract deploy`). The current tooling ships `stellar-cli`, which does not provide a `soroban` command, so the script could not run the exact deploy invocation described in #442.
- Updated the identity-lookup and deploy invocations to use `stellar keys address` / `stellar contract deploy`, matching the command in the issue and in `docs/testnet-deployment.md`.

## Scope note
This PR only fixes the tooling so the deploy command in #442 can actually be run. It does not perform the live testnet deployment — that still requires a funded `deployer` identity and network access, and should be run and its CONTRACT_ID recorded separately.

closes #442 