### PR TITLE
feat(decoder): include raw XDR topics/data as JSON in fallback description

### DIFF
--- a/indexer/src/decoder.js
+++ b/indexer/src/decoder.js
@@ -250,10 +250,10 @@ export async function decode(ev, { currentAbi = false } = {}) {
   // Fall back to standard decoders
   if (!description) {
     description = vaultMeta
-      ? vaultDescription(fnName, topics.slice(1), data, contractLabel, vaultMeta)
+      ? vaultDescription(fnName, topics.slice(1), data, contractLabel, vaultMeta, topics)
       : fnAbi
-        ? buildDescription(fnName, topics.slice(1), data, contractLabel)
-        : genericDescription(fnName, topics.slice(1), data, contractLabel);
+        ? buildDescription(fnName, topics.slice(1), data, contractLabel, topics)
+        : genericDescription(fnName, topics.slice(1), data, contractLabel, topics);
   }
 
   // Attach heuristic params when no ABI was available
@@ -405,7 +405,7 @@ function fmtClassicAmount(amount) {
   return isNaN(n) ? String(amount) : n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 7 });
 }
 
-function vaultDescription(fn, args, data, contractName, vaultMeta) {
+function vaultDescription(fn, args, data, contractName, vaultMeta, fullTopics = null) {
   const assetLabel = vaultMeta.underlying_asset
     ? `asset ${vaultMeta.underlying_asset.slice(0, 6)}…${vaultMeta.underlying_asset.slice(-4)}`
     : "underlying asset";
@@ -423,7 +423,7 @@ function vaultDescription(fn, args, data, contractName, vaultMeta) {
       return `Burned ${String(shr)} shares → withdrew ${String(amt)} ${assetLabel} from ${fmt(from ?? admin ?? to)} on ${contractName}`;
     }
     default:
-      return genericDescription(fn, args, data, contractName);
+      return genericDescription(fn, args, data, contractName, fullTopics);
   }
 }
 
@@ -434,7 +434,7 @@ function vaultDescription(fn, args, data, contractName, vaultMeta) {
  *   "Address {short-from} transferred {amount} {token} to {short-to} on {contractName}"
  * where short addresses are truncated to "AAAAAA…ZZZZ" (6 + 4 chars).
  */
-export function buildDescription(fn, args, data, contractName) {
+export function buildDescription(fn, args, data, contractName, fullTopics = null) {
   switch (fn) {
     case "swap":
     case "swap_exact_tokens_for_tokens": {
@@ -477,6 +477,27 @@ export function buildDescription(fn, args, data, contractName) {
       }
       return `${fmt(addr)} unstaked ${fmtXlm(amt)} XLM on ${contractName}`;
     }
+    // SEP-41 allowance functions (issue #561)
+    case "approve":
+    case "set_allowance":
+    case "increase_allowance":
+    case "decrease_allowance": {
+      return buildAllowanceDescription(fn, args, data, contractName);
+    }
+    // NFT functions (issue #562)
+    case "mint_nft":
+    case "burn_nft":
+    case "create":
+    case "list_nft": {
+      return buildNftDescription(fn, args, data, contractName);
+    }
+    // AMM liquidity functions (issue #563)
+    case "add_liquidity":
+    case "provide_liquidity":
+    case "remove_liquidity":
+    case "withdraw_liquidity": {
+      return buildLiquidityDescription(fn, args, data, contractName);
+    }
     default:
       // NFT transfer detection: transfer event that carries a token_id field
       // (u64 / number) is treated as an NFT transfer rather than a fungible
@@ -491,7 +512,7 @@ export function buildDescription(fn, args, data, contractName) {
         }
         return `Address ${fmt(from)} transferred ${amount} ${token ?? ""} to ${fmt(to)} on ${contractName}`;
       }
-      return genericDescription(fn, args, data, contractName);
+      return genericDescription(fn, args, data, contractName, fullTopics);
   }
 }
 
@@ -796,9 +817,17 @@ export function blendDescription(fn, args, data, ledger) {
   return null;
 }
 
-function genericDescription(fn, args, data, contractId) {
+function genericDescription(fn, args, data, contractId, fullTopics = null) {
   const argStr = args.map(String).join(", ");
-  return `${fn}(${argStr}) called on ${contractId}`;
+  let description = `${fn}(${argStr}) called on ${contractId}`;
+  if (fullTopics != null || data != null) {
+    const raw = {
+      topics: fullTopics ?? [fn, ...args],
+      data,
+    };
+    description += ` | raw: ${safeStringify(raw)}`;
+  }
+  return description;
 }
 
 function fmt(addr) {


### PR DESCRIPTION
When decoder.js cannot match a function name to any known decoder, use scValToNative to convert raw XDR topics and data to a JSON-like string.

## Changes
- genericDescription() now accepts optional fullTopics parameter and appends raw topics/data as JSON when available
- vaultDescription() and buildDescription() pass through fullTopics  
- buildDescription() now handles SEP-41 allowance, NFT, and AMM liquidity functions via existing helper functions
- decode() passes full topics array to all description builders

## Testing
All 97 decoder tests pass including:
- SEP-41 transfer/mint/burn tests
- Stage-2 decoder tests (swap, transfer, mint, burn, stake)
- Slippage annotation tests
- Allowance tests (approve, set_allowance, increase_allowance, decrease_allowance)
- NFT tests (mint_nft, burn_nft, create, list_nft)
- AMM liquidity tests (add_liquidity, remove_liquidity)
- Stake/unstake tests
- StellarSwap and Blend protocol tests
- Batch description tests

Closes #565
Closes #566
Closes #567
Closes #568