### PR TITLE
fix: get CI fully green — API-key auth bug, CSRF gap, broken schema validation, real test bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,9 +275,23 @@ jobs:
         with:
           node-version: 20
 
-      - name: Smoke test — health endpoint
+      # This job doesn't start a server itself — it's meant to smoke test a
+      # real deployed testnet indexer. Without the secret configured there's
+      # nothing to test against, so skip rather than fail CI on every push.
+      - name: Check testnet URL is configured
+        id: check
         run: |
-          TESTNET_URL="${{ secrets.TESTNET_INDEXER_URL || 'http://localhost:3001' }}"
+          if [ -z "${{ secrets.TESTNET_INDEXER_URL }}" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::TESTNET_INDEXER_URL secret not configured — skipping testnet smoke tests"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Smoke test — health endpoint
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          TESTNET_URL="${{ secrets.TESTNET_INDEXER_URL }}"
           echo "Testing health endpoint at $TESTNET_URL/api/health"
           
           RESPONSE=$(curl -s -w "\n%{http_code}" "$TESTNET_URL/api/health")
@@ -295,8 +309,9 @@ jobs:
           echo "✓ Health endpoint returned $HTTP_CODE"
 
       - name: Smoke test — events endpoint
+        if: steps.check.outputs.skip != 'true'
         run: |
-          TESTNET_URL="${{ secrets.TESTNET_INDEXER_URL || 'http://localhost:3001' }}"
+          TESTNET_URL="${{ secrets.TESTNET_INDEXER_URL }}"
           echo "Testing events endpoint at $TESTNET_URL/api/events"
           
           RESPONSE=$(curl -s "$TESTNET_URL/api/events?limit=1")
@@ -313,8 +328,9 @@ jobs:
           echo "✓ Events endpoint returned $EVENT_COUNT events"
 
       - name: Smoke test — response time check
+        if: steps.check.outputs.skip != 'true'
         run: |
-          TESTNET_URL="${{ secrets.TESTNET_INDEXER_URL || 'http://localhost:3001' }}"
+          TESTNET_URL="${{ secrets.TESTNET_INDEXER_URL }}"
           echo "Testing response time at $TESTNET_URL/api/health"
           
           START=$(date +%s%N)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,6 @@ on:
     branches: [main]
     paths:
       - "docs/**"
-      - "indexer/openapi.yaml"
       - "indexer/src/**"
       - "contracts/**"
       - "CONTRIBUTING.md"
@@ -45,7 +44,7 @@ jobs:
           node -e "
             const fs = require('fs');
             const YAML = require('./indexer/node_modules/yaml');
-            const doc = YAML.parse(fs.readFileSync('indexer/openapi.yaml', 'utf8'));
+            const doc = YAML.parse(fs.readFileSync('docs/api/openapi.yaml', 'utf8'));
             fs.writeFileSync('docs/api/openapi.json', JSON.stringify(doc, null, 2) + '\n');
             console.log('openapi.json regenerated');
           "

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -21,8 +21,9 @@ jobs:
 
       - name: Check branch name convention
         continue-on-error: true
+        env:
+          BRANCH: ${{ github.head_ref }}
         run: |
-          BRANCH="${{ github.head_ref }}"
           if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
             echo "Branch '$BRANCH' is exempt from the naming convention check."
             exit 0

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -730,11 +730,30 @@ paths:
                     type: boolean
                     example: true
         "400":
-          description: Invalid input or ABI verification failed
+          description: >-
+            Invalid input. Body-schema failures (AJV) return `{ errors: [...] }`
+            with one entry per violation; ABI verification failures return
+            `{ error, details }`.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                oneOf:
+                  - type: object
+                    required: [errors]
+                    properties:
+                      errors:
+                        type: array
+                        items:
+                          type: object
+                          required: [path, message]
+                          properties:
+                            path:
+                              type: string
+                              example: "/functions"
+                            message:
+                              type: string
+                              example: "must have required property 'functions'"
+                  - $ref: "#/components/schemas/ErrorResponse"
         "403":
           description: CSRF token missing or mismatch (browser clients without x-api-key)
           content:
@@ -3992,6 +4011,429 @@ components:
         error:
           type: string
           example: "Detailed error message"
+
+    TransactionStatus:
+      type: object
+      required: [tx_hash, status, ledger, error]
+      properties:
+        tx_hash:
+          type: string
+          example: "a3f1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1"
+        status:
+          type: string
+          enum: [pending, success, error]
+          example: "success"
+        ledger:
+          type: integer
+          nullable: true
+          description: Ledger sequence the transaction was included in, or null while pending.
+          example: 1050320
+        error:
+          type: string
+          nullable: true
+          description: Error detail when status is "error", otherwise null.
+          example: null
+
+    WasmBuildMetadata:
+      type: object
+      required: [wasm_hash]
+      properties:
+        wasm_hash:
+          type: string
+          example: "abc123"
+        contract_id:
+          type: string
+          nullable: true
+        size_bytes:
+          type: integer
+          nullable: true
+          example: 204800
+        sdk_version:
+          type: string
+          nullable: true
+          example: "21.0.0"
+        compiler:
+          type: string
+          nullable: true
+          example: "rustc 1.78.0"
+        optimizer:
+          type: string
+          nullable: true
+        repository:
+          type: string
+          nullable: true
+        commit:
+          type: string
+          nullable: true
+        producers:
+          type: object
+          nullable: true
+          additionalProperties:
+            type: string
+        ledger:
+          type: integer
+          nullable: true
+        tx_hash:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+
+    ContractAbi:
+      type: object
+      description: Standardised ABI JSON combining on-chain spec with registered metadata.
+      required: [id, functions]
+      properties:
+        id:
+          type: string
+          example: "CC4VM2DTTR4QO4J4E5K2YUXM"
+        name:
+          type: string
+        description:
+          type: string
+        functions:
+          type: array
+          items:
+            $ref: "#/components/schemas/FunctionSpec"
+        wasm_hash:
+          type: string
+          nullable: true
+
+    ContractSpecFull:
+      type: object
+      required: [functions, types]
+      properties:
+        functions:
+          type: array
+          items:
+            $ref: "#/components/schemas/FunctionSpec"
+        types:
+          type: array
+          items:
+            type: object
+            required: [kind, name]
+            properties:
+              kind:
+                type: string
+                enum: [struct, enum, union, error_enum]
+              name:
+                type: string
+              fields:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    type:
+                      type: string
+              cases:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: integer
+                    types:
+                      type: array
+                      items:
+                        type: string
+
+    UpgradeRecord:
+      type: object
+      required: [ledger, old_hash, new_hash, tx_hash, timestamp]
+      properties:
+        ledger:
+          type: integer
+        old_hash:
+          type: string
+          nullable: true
+        new_hash:
+          type: string
+          nullable: true
+        tx_hash:
+          type: string
+          nullable: true
+        timestamp:
+          type: string
+          format: date-time
+
+    CallGraph:
+      type: object
+      required: [nodes, edges]
+      properties:
+        nodes:
+          type: array
+          items:
+            type: object
+            required: [id, label, type]
+            properties:
+              id:
+                type: string
+              label:
+                type: string
+              type:
+                type: string
+                example: "contract"
+        edges:
+          type: array
+          items:
+            type: object
+            required: [source, target]
+            properties:
+              source:
+                type: string
+              target:
+                type: string
+              label:
+                type: string
+                nullable: true
+              call_count:
+                type: integer
+
+    ContractTtl:
+      type: object
+      required: [contract_id, current_ledger, instance, code]
+      properties:
+        contract_id:
+          type: string
+        current_ledger:
+          type: integer
+        instance:
+          type: object
+          properties:
+            live_until_ledger:
+              type: integer
+              nullable: true
+        code:
+          type: object
+          properties:
+            live_until_ledger:
+              type: integer
+              nullable: true
+
+    SourceVerification:
+      type: object
+      required: [signer, signature, compiler_hash, wasm_hash, submitted_at]
+      properties:
+        signer:
+          type: string
+        signature:
+          type: string
+        compiler_hash:
+          type: string
+        wasm_hash:
+          type: string
+        submitted_at:
+          type: string
+          format: date-time
+
+    TokenHolder:
+      type: object
+      required: [address, balance_raw, balance]
+      properties:
+        address:
+          type: string
+        balance_raw:
+          type: string
+          description: Raw integer balance as a string (avoids precision loss for i128 values)
+        balance:
+          type: string
+          description: Human-readable balance formatted using the token's decimals
+
+    NftListResponse:
+      type: object
+      required: [contract_id, tokens, pagination]
+      properties:
+        contract_id:
+          type: string
+        tokens:
+          type: array
+          items:
+            type: object
+            required: [token_id, owner, metadata, last_transfer_ledger]
+            properties:
+              token_id:
+                type: string
+              owner:
+                type: string
+              metadata:
+                type: object
+                nullable: true
+                additionalProperties: true
+              last_transfer_ledger:
+                type: integer
+                nullable: true
+        pagination:
+          type: object
+          properties:
+            page:
+              type: integer
+            limit:
+              type: integer
+            total:
+              type: integer
+            total_pages:
+              type: integer
+            has_next:
+              type: boolean
+
+    SandboxRecord:
+      type: object
+      required: [sandboxId, templateId]
+      properties:
+        sandboxId:
+          type: string
+          example: "sandbox-abc123"
+        templateId:
+          type: string
+          example: "soroban-hello-world"
+        files:
+          type: object
+          additionalProperties:
+            type: string
+        metadata:
+          type: object
+          additionalProperties: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    SandboxSummary:
+      type: object
+      required: [sandboxId, templateId, updated_at]
+      properties:
+        sandboxId:
+          type: string
+        templateId:
+          type: string
+        updated_at:
+          type: string
+          format: date-time
+
+    SandboxSimulateResult:
+      type: object
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        returnValue:
+          type: string
+          nullable: true
+        cost:
+          type: object
+          nullable: true
+          properties:
+            cpuInsns:
+              type: string
+            memBytes:
+              type: string
+        minResourceFee:
+          type: string
+          nullable: true
+        latestLedger:
+          type: integer
+          nullable: true
+        error:
+          type: string
+          nullable: true
+
+    SimulateResult:
+      type: object
+      required: [success]
+      properties:
+        success:
+          type: boolean
+        returnValue:
+          type: string
+          nullable: true
+        cost:
+          type: object
+          nullable: true
+          properties:
+            cpuInsns:
+              type: string
+            memBytes:
+              type: string
+        error:
+          type: string
+          nullable: true
+
+    BatchSubRequest:
+      type: object
+      required: [path]
+      properties:
+        path:
+          type: string
+          description: Relative API path to dispatch as a sub-request, including query string.
+          example: "/api/events?limit=2"
+        method:
+          type: string
+          default: GET
+          enum: [GET, POST]
+        body:
+          type: object
+          nullable: true
+          additionalProperties: true
+
+    BatchSubResult:
+      type: object
+      required: [status, body]
+      properties:
+        status:
+          type: integer
+          example: 200
+        body:
+          description: The dispatched sub-request's own response body.
+          additionalProperties: true
+
+    AuditLogEntry:
+      type: object
+      required: [id, timestamp, tier, ip, method, endpoint, status_code]
+      properties:
+        id:
+          type: integer
+        timestamp:
+          type: string
+          format: date-time
+        api_key_id:
+          type: string
+          nullable: true
+        key_name:
+          type: string
+          nullable: true
+        tier:
+          type: string
+          example: "free"
+        ip:
+          type: string
+        method:
+          type: string
+          example: "GET"
+        endpoint:
+          type: string
+          example: "/api/events"
+        status_code:
+          type: integer
+          example: 200
+        response_time_ms:
+          type: integer
+        rate_limit_remaining:
+          type: integer
+          nullable: true
+        user_agent:
+          type: string
+          nullable: true
+        request_body_hash:
+          type: string
+          nullable: true
+          description: SHA-256 hash of the request body for state-changing calls, null otherwise.
 
     WalletBalance:
       type: object

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,6 +34,7 @@
         "@types/react": "18.3.3",
         "@types/react-dom": "18.3.0",
         "@vitejs/plugin-react": "^4.5.0",
+        "@vitest/coverage-v8": "^4.1.11",
         "eslint": "^9.0.0",
         "jsdom": "^29.1.1",
         "prettier": "^3.3.0",
@@ -356,6 +357,15 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -1586,8 +1596,9 @@
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true
     },
     "node_modules/@stellar/freighter-api": {
       "version": "4.1.0",
@@ -1782,8 +1793,9 @@
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
@@ -2049,8 +2061,9 @@
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -2331,15 +2344,46 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
-    "node_modules/@vitest/expect": {
-      "version": "4.1.9",
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.11.tgz",
+      "integrity": "sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==",
       "dev": true,
-      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.11",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.11",
+        "vitest": "4.1.11"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2348,11 +2392,12 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.9",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.9",
+        "@vitest/spy": "4.1.11",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2373,9 +2418,10 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.9",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^3.1.0"
       },
@@ -2384,11 +2430,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.9",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.9",
+        "@vitest/utils": "4.1.11",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2396,12 +2443,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.9",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2410,19 +2458,21 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.9",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.9",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.9",
+        "@vitest/pretty-format": "4.1.11",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2537,11 +2587,29 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -2803,8 +2871,9 @@
     },
     "node_modules/chai": {
       "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -3505,8 +3574,9 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
@@ -3822,6 +3892,12 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "license": "MIT",
@@ -3960,6 +4036,42 @@
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4173,10 +4285,37 @@
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4411,8 +4550,9 @@
     },
     "node_modules/pathe": {
       "version": "2.0.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5270,17 +5410,18 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.9",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.9",
-        "@vitest/mocker": "4.1.9",
-        "@vitest/pretty-format": "4.1.9",
-        "@vitest/runner": "4.1.9",
-        "@vitest/snapshot": "4.1.9",
-        "@vitest/spy": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -5308,12 +5449,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.9",
-        "@vitest/browser-preview": "4.1.9",
-        "@vitest/browser-webdriverio": "4.1.9",
-        "@vitest/coverage-istanbul": "4.1.9",
-        "@vitest/coverage-v8": "4.1.9",
-        "@vitest/ui": "4.1.9",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
     "@vitejs/plugin-react": "^4.5.0",
+    "@vitest/coverage-v8": "^4.1.11",
     "eslint": "^9.0.0",
     "jsdom": "^29.1.1",
     "prettier": "^3.3.0",

--- a/frontend/test/EventTable.test.tsx
+++ b/frontend/test/EventTable.test.tsx
@@ -60,9 +60,13 @@ describe("EventTable — contract badge (Issue #556)", () => {
 
     renderTable([swapEvent]);
 
-    const nameLink = await screen.findByText("StellarSwap");
-    expect(nameLink.tagName).toBe("A");
-    expect(nameLink.getAttribute("href")).toBe(`/contract/${DEX_CONTRACT_ID}`);
+    // CopyableAddress wraps the display text in its own inner <span>, so the
+    // matched node is that span, not the <Link> itself — walk up to the
+    // nearest <a> ancestor to verify the link.
+    const nameText = await screen.findByText("StellarSwap");
+    const nameLink = nameText.closest("a");
+    expect(nameLink).not.toBeNull();
+    expect(nameLink?.getAttribute("href")).toBe(`/contract/${DEX_CONTRACT_ID}`);
     expect(screen.getByTitle("Protocol type: DEX")).toBeDefined();
   });
 

--- a/frontend/test/WalletPage.test.tsx
+++ b/frontend/test/WalletPage.test.tsx
@@ -74,17 +74,30 @@ describe("WalletPage", () => {
     const seqLink = await screen.findByText("#1001");
     expect(seqLink).toBeDefined();
     expect(screen.getByText("#1002")).toBeDefined();
-    expect(screen.getByText("2,500,000")).toBeDefined();
-    expect(screen.getByText("2,500,005")).toBeDefined();
-    expect(screen.getByText("transfer")).toBeDefined();
-    expect(screen.getByText("swap")).toBeDefined();
+    // "2,500,000" is both this event's own ledger AND the wallet summary's
+    // "first seen ledger" (they're the same value here), so it legitimately
+    // renders twice — use getAllByText rather than requiring a single match.
+    expect(screen.getAllByText("2,500,000").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("2,500,005").length).toBeGreaterThanOrEqual(1);
+    // "transfer"/"swap" also appear as <option> values in the function
+    // filter dropdown, so more than one match is expected here too.
+    expect(screen.getAllByText("transfer").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("swap").length).toBeGreaterThanOrEqual(1);
   });
 
   it("shows a friendly error for an invalid address (#525)", async () => {
     renderWalletPage("GFOO");
 
-    // #525: error message must include the bad address
-    const errorEl = await screen.findByText(/GFOO is not a valid Stellar address/i);
+    // #525: error message must include the bad address. "GFOO" and
+    // "is not a valid Stellar address" are in separate DOM nodes (the
+    // address is wrapped in its own <strong>), so match on combined
+    // textContent of the innermost containing element.
+    const hasErrorText = (el: Element | null) =>
+      Boolean(el?.textContent?.includes("GFOO") && el?.textContent?.includes("is not a valid Stellar address"));
+    const errorEl = await screen.findByText(
+      (_, element) =>
+        hasErrorText(element) && Array.from(element?.children ?? []).every((child) => !hasErrorText(child)),
+    );
     expect(errorEl).toBeDefined();
     expect(mockWalletHistory).not.toHaveBeenCalled();
   });
@@ -120,14 +133,25 @@ describe("WalletPage", () => {
         description: "Swap event",
         raw_topics: [],
       },
+      {
+        seq: 3,
+        contract_id: "CDLZFC3SYJYDZT7K67VZ75HRJDTIKI7BF6RQD7MFPK5QERZUTXX7YV7V",
+        function: "mint",
+        ledger: 1002,
+        description: "Mint event",
+        raw_topics: [],
+      },
     ];
     mockWalletHistory.mockResolvedValue({ events: mockEvents, horizon_account: null });
 
     renderWalletPage(VALID_ADDR);
 
-    // Summary: 2 total events, 2 unique contracts
-    expect(await screen.findByText("2")).toBeDefined();
+    // Summary: 3 total events, 2 unique contracts — distinct numbers so the
+    // query below can't ambiguously match both <strong> elements.
+    expect(await screen.findByText("3")).toBeDefined();
+    expect(screen.getByText("2")).toBeDefined();
     expect(screen.getByText(/total event/i)).toBeDefined();
+    expect(screen.getByText(/unique contract/i)).toBeDefined();
   });
 
   it("renders XLM balance when horizon_account is present in the response", async () => {

--- a/frontend/test/api.test.ts
+++ b/frontend/test/api.test.ts
@@ -1,97 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-
-const BASE = "/api";
-
-async function get(path: string) {
-  const res = await fetch(BASE + path);
-  if (!res.ok) throw new Error(`API ${res.status}: ${path}`);
-  return res.json();
-}
-
-const api = {
-  events: (params: { contract?: string; fn?: string; after_seq?: number; limit?: number; type?: string }) => {
-    const q = new URLSearchParams();
-    if (params.contract) q.set("contract", params.contract);
-    if (params.fn) q.set("fn", params.fn);
-    if (params.after_seq) q.set("after_seq", String(params.after_seq));
-    if (params.limit) q.set("limit", String(params.limit));
-    if (params.type) q.set("type", params.type);
-    return get<{ data: Array<{ seq: number }>; next_cursor: number | null }>(`/events?${q}`);
-  },
-  event: (seq: number) => get<{ seq: number }>(`/events/${seq}`),
-  contract: (id: string) => get<{ id: string; name: string }>(`/contracts/${id}`),
-  wallet: (address: string) => get<{ events: Array<{ seq: number }> }>(`/wallet/${address}`),
-  contractStats: (id: string) =>
-    get<{ total_events: number; unique_callers: number; first_seen_ledger: number | null; last_seen_ledger: number | null; events_per_day: Array<{ date: string; count: number }> }>(
-      `/contracts/${id}/stats`,
-    ),
-  search: (q: string, limit = 10) =>
-    get<{ contracts: unknown[]; events: unknown[]; wallets: unknown[]; suggestions: unknown[] }>(
-      `/search?q=${encodeURIComponent(q)}&limit=${limit}`,
-    ),
-  burnAlerts: (contract: string) => get<Array<{ contractId: string }>>(`/burn-alerts?contract=${contract}`),
-  migrationStatus: (id: string) => get<{ pending: boolean }>(`/contracts/${id}/migration-status`),
-  roles: (id: string) => get<Array<{ role: string; address: string }>>(`/contracts/${id}/roles`),
-  contractTTL: (id: string) => get<{ contract_id: string; current_ledger: number }>(`/contracts/${id}/ttl`),
-  stateDiffs: (id: string, key?: string) => {
-    const q = key ? `?key=${encodeURIComponent(key)}` : "";
-    return get<Array<{ ledger: number }>>(`/contracts/${id}/state-diffs${q}`);
-  },
-  contractGraph: (limit = 500) =>
-    get<{ nodes: Array<{ id: string }>; links: Array<{ source: string; target: string }> }>(`/contract-graph?limit=${limit}`),
-  quorumFreeze: (id: string) => get<{ is_frozen: boolean }>(`/contracts/${id}/quorum-freeze`),
-  specFull: (id: string) =>
-    get<{ functions: Array<{ name: string }>; types: Array<{ name: string }> }>(`/contracts/${id}/spec-full`),
-  downloadAbi: async (id: string) => {
-    const res = await fetch(`${BASE}/contracts/${id}/abi`);
-    if (!res.ok) throw new Error(`API ${res.status}: /contracts/${id}/abi`);
-    const blob = await res.blob();
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `${id}.abi.json`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-  },
-  subInvocations: (txHash: string) => get<Array<{ id: number; parent_tx_hash: string }>>(`/transactions/${txHash}/sub-invocations`),
-  circuitBreakerStatus: (id: string) =>
-    get<{ has_circuit_breaker: boolean; is_paused: boolean; status: string }>(`/contracts/${id}/circuit-breaker`),
-  rwaMetadata: (id: string) => get<{ is_rwa: boolean }>(`/contracts/${id}/rwa-metadata`),
-  wasmMetadata: (id: string) => get<{ wasm_hash: string }>(`/contracts/${id}/wasm`),
-  upgradeHistory: (id: string) => get<Array<{ ledger: number; old_hash: string | null; new_hash: string | null }>>(`/contracts/${id}/upgrades`),
-  contractCallGraph: (id: string) =>
-    get<{ nodes: Array<{ id: string }>; edges: Array<{ source: string; target: string }> }>(`/contracts/${id}/call-graph`),
-  sourceVerifications: (id: string, wasmHash?: string) => {
-    const q = wasmHash ? `?wasm_hash=${encodeURIComponent(wasmHash)}` : "";
-    return get<Array<{ signer: string }>>(`/contracts/${id}/source-verifications${q}`);
-  },
-  batchSimulate: (calls: Array<{ id: string; contractId: string; functionName: string; args: unknown[] }>, sourceAccount?: string) =>
-    fetch(`${BASE}/batch/simulate`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ calls, sourceAccount }),
-    }).then((r) => r.json()),
-  batchEstimateGas: (calls: Array<{ id: string; contractId: string; functionName: string; args: unknown[] }>, sourceAccount?: string) =>
-    fetch(`${BASE}/batch/estimate-gas`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ calls, sourceAccount }),
-    }).then((r) => r.json()),
-  batchOptimize: (calls: Array<{ id: string; contractId: string; functionName: string; args: unknown[] }>, sourceAccount?: string) =>
-    fetch(`${BASE}/batch/optimize`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ calls, sourceAccount }),
-    }).then((r) => r.json()),
-  batchValidate: (calls: Array<{ id: string; contractId: string; functionName: string; args: unknown[] }>, sourceAccount?: string) =>
-    fetch(`${BASE}/batch/validate`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ calls, sourceAccount }),
-    }).then((r) => r.json()),
-};
+import { api } from "../src/api";
 
 describe("api utility", () => {
   beforeEach(() => {
@@ -193,7 +101,8 @@ describe("api utility", () => {
     const result = await api.search("USDC transfer", 25);
     expect(result.contracts).toEqual([]);
     const [url] = (fetch as any).mock.calls[0];
-    expect(url).toContain("q=USDC%20transfer");
+    // URLSearchParams encodes spaces as "+", equivalent to %20 in a query string.
+    expect(url).toContain("q=USDC+transfer");
     expect(url).toContain("limit=25");
   });
 

--- a/indexer/jest.config.js
+++ b/indexer/jest.config.js
@@ -3,4 +3,5 @@ export default {
   transform: {},
   testTimeout: 30000,
   setupFiles: ["<rootDir>/test/jest.setup.js"],
+  setupFilesAfterEnv: ["<rootDir>/test/jest.setupAfterEnv.js"],
 };

--- a/indexer/migrations/027_api_key_rotation_columns.sql
+++ b/indexer/migrations/027_api_key_rotation_columns.sql
@@ -1,0 +1,10 @@
+-- API key rotation support (security: rotation grace period).
+--
+-- auth/apiKeyAuth.js selects rotated_at/rotation_grace_until on every
+-- authenticated request, and admin/keyManager.js's rotateKey() writes them,
+-- but no prior migration ever added these columns — every request bearing a
+-- real DB-issued API key 500ed with "column \"rotated_at\" does not exist".
+
+ALTER TABLE api_keys
+  ADD COLUMN IF NOT EXISTS rotated_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS rotation_grace_until TIMESTAMPTZ;

--- a/indexer/src/api.js
+++ b/indexer/src/api.js
@@ -50,22 +50,58 @@ import { getHealthStatus, getLivenessStatus, getReadinessStatus } from "./health
 import { getActiveAlerts } from "./alertManager.js";
 import { randomUUID } from "crypto";
 import { resolveAsset } from "./horizonClient.js";
-import { createRequire } from "module";
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
 
 // ── AJV schema validator for POST /api/contracts ──────────────────────────────
-const _require = createRequire(import.meta.url);
-const _contractRegistrySchema = _require("./contractRegistry.schema.json");
+// This validates the real ContractMeta shape stored via db.upsertContractMeta
+// (id, name, description, functions[].{name,description,args}, registered_by,
+// protocol_type, version, abi_version, min_ledger) — NOT the differently-shaped
+// contractRegistry.schema.json (contractId/template), which is a separate
+// schema for community-submitted custom ABI interpretations.
 const _ajv = new Ajv({ allErrors: true, strict: false });
 addFormats(_ajv);
-// The POST body uses 'id' instead of 'contractId' — patch the schema for validation
 const _postContractSchema = {
-  ..._contractRegistrySchema,
-  required: _contractRegistrySchema.required.map((k) => (k === "contractId" ? "id" : k)),
+  type: "object",
+  required: ["id", "name", "functions"],
   properties: {
-    ..._contractRegistrySchema.properties,
-    id: _contractRegistrySchema.properties.contractId,
+    id: {
+      type: "string",
+      description: "Stellar contract address (C... strkey, 56 chars)",
+      pattern: "^C[A-Z2-7]{55}$",
+    },
+    name: { type: "string", minLength: 1, maxLength: 100 },
+    description: { type: ["string", "null"], maxLength: 500 },
+    registered_by: { type: ["string", "null"] },
+    protocol_type: {
+      type: ["string", "null"],
+      enum: ["token", "dex", "lending", "nft", "bridge", "other", null],
+    },
+    version: { type: ["integer", "null"] },
+    abi_version: { type: ["integer", "null"] },
+    min_ledger: { type: ["integer", "null"] },
+    functions: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["name"],
+        properties: {
+          name: { type: "string", minLength: 1 },
+          description: { type: "string" },
+          args: {
+            type: "array",
+            items: {
+              type: "object",
+              required: ["name", "type"],
+              properties: {
+                name: { type: "string", minLength: 1 },
+                type: { type: "string", minLength: 1 },
+              },
+            },
+          },
+        },
+      },
+    },
   },
 };
 const _validateContractPost = _ajv.compile(_postContractSchema);
@@ -883,9 +919,14 @@ export function createApi({ logDestination, dbOverride } = {}) {
   // PATCH /api/contracts/:id  — update ABI metadata (issue #523: ownership check)
   app.patch("/api/contracts/:id", writeLimiter, async (req, res) => {
     try {
-      // Must be authenticated
+      // Must be authenticated. The static admin key (API_KEY env var) is
+      // recognized by apiKeyAuthenticator with tier "enterprise" but no DB
+      // row, so keyId is null for it too — check tier, not just keyId,
+      // otherwise the admin key would be rejected here before ever reaching
+      // the isAdmin check below.
       const keyId = req.rateContext?.keyId ?? null;
-      if (!keyId) {
+      const isUnauthenticated = !req.rateContext || req.rateContext.tier === "unauthenticated";
+      if (isUnauthenticated) {
         return res.status(401).json({ error: "Authentication required" });
       }
 

--- a/indexer/src/audit/auditLogger.js
+++ b/indexer/src/audit/auditLogger.js
@@ -212,16 +212,33 @@ async function _ensurePartitionFor(date) {
   }
 }
 
+async function _doEnsureAuditPartitions() {
+  const now = new Date();
+  const nextMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
+  await _ensurePartitionFor(now);
+  await _ensurePartitionFor(nextMonth);
+}
+
+// Tracks the most recent ensureAuditPartitions() call so test teardown can
+// await it — callers (api.js, startAuditPartitionCron) invoke this
+// fire-and-forget, and its console.log can otherwise fire after Jest tears
+// a test file's environment down, which silently sets process.exitCode = 1
+// for the whole run. See getPendingAuditPartitionWork().
+let _pendingPartitionWork = Promise.resolve();
+
 /**
  * Eagerly ensures the current and next month's partitions exist. Call once
  * at server startup, before requests start flowing — see module docstring
  * for why the cron alone isn't sufficient.
  */
-async function ensureAuditPartitions() {
-  const now = new Date();
-  const nextMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
-  await _ensurePartitionFor(now);
-  await _ensurePartitionFor(nextMonth);
+function ensureAuditPartitions() {
+  _pendingPartitionWork = _doEnsureAuditPartitions();
+  return _pendingPartitionWork;
+}
+
+/** Exported for test teardown — see _pendingPartitionWork above. */
+function getPendingAuditPartitionWork() {
+  return _pendingPartitionWork;
 }
 
 // ── startAuditPartitionCron ───────────────────────────────────────────────────
@@ -307,4 +324,5 @@ export {
   startAuditPartitionCron,
   startAuditFlush,
   ensureAuditPartitions,
+  getPendingAuditPartitionWork,
 };

--- a/indexer/src/csrf.js
+++ b/indexer/src/csrf.js
@@ -175,6 +175,16 @@ function verifyCsrf(req, res, next) {
     return next();
   }
 
+  // Admin routes — skip. They're gated by a Bearer token (adminAuthMiddleware),
+  // never by a browser session cookie, so they aren't vulnerable to CSRF the
+  // way cookie auth is: a malicious page can't make the browser attach an
+  // Authorization header the way it auto-attaches cookies. The route itself
+  // still requires and validates the token (including the "none provided"
+  // case, which it correctly rejects with 401).
+  if (req.path.startsWith('/api/admin/')) {
+    return next();
+  }
+
   // WebSocket upgrade requests — skip.
   const upgrade = req.headers['upgrade'];
   if (upgrade && upgrade.toLowerCase() === 'websocket') {

--- a/indexer/test/api/api.test.js
+++ b/indexer/test/api/api.test.js
@@ -49,6 +49,15 @@ describe("REST API Integration Tests", () => {
       functions: [],
       registered_by: "test-admin",
     });
+    // Full-length strkey-format ID for the POST /api/contracts 409 test,
+    // since that route validates `id` against the real strkey pattern.
+    await db.upsertContractMeta({
+      id: "CONEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      name: "Contract One (full ID)",
+      description: "Seeded for the POST /api/contracts 409 test",
+      functions: [{ name: "noop" }],
+      registered_by: "test-admin",
+    });
 
     // Seed 50 events
     for (let i = 1; i <= 50; i++) {
@@ -415,12 +424,16 @@ describe("REST API Integration Tests", () => {
   });
 
   describe("POST /api/contracts", () => {
+    // POST /api/contracts validates `id` against the Stellar contract strkey
+    // pattern (C + 55 chars of [A-Z2-7]), so these use full-length fixture
+    // IDs distinct from the short "C1"/"C2"/"C3" seed data used elsewhere in
+    // this file for GET-endpoint tests, where the format doesn't matter.
     it("should register a new contract successfully", async () => {
       const res = await request(app)
         .post("/api/contracts")
         .set("x-api-key", "test-api-key")
         .send({
-          id: "C4",
+          id: "CFOURAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
           name: "Contract Four",
           description: "Fourth contract details",
           functions: [{ name: "burn", args: [] }],
@@ -434,9 +447,9 @@ describe("REST API Integration Tests", () => {
         .post("/api/contracts")
         .set("x-api-key", "test-api-key")
         .send({
-          id: "C1",
+          id: "CONEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
           name: "Contract One Dupe",
-          functions: [],
+          functions: [{ name: "noop" }],
         });
       expect(res.status).toBe(409);
       expect(res.body).toEqual({ error: "Contract already exists" });
@@ -447,11 +460,12 @@ describe("REST API Integration Tests", () => {
         .post("/api/contracts")
         .set("x-api-key", "test-api-key")
         .send({
-          id: "C5",
+          id: "CFIVEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
           // missing functions
         });
       expect(res.status).toBe(400);
-      expect(res.body).toEqual({ error: "Missing id or functions" });
+      expect(res.body).toHaveProperty("errors");
+      expect(Array.isArray(res.body.errors)).toBe(true);
     });
   });
 

--- a/indexer/test/api/batch-order.test.js
+++ b/indexer/test/api/batch-order.test.js
@@ -42,8 +42,12 @@ describe("POST /api/batch (issue #416)", () => {
   });
 
   it("returns results in submission order, with the 404 isolated to its slot", async () => {
+    // /api/batch can dispatch mutating sub-requests, so the outer POST is
+    // correctly CSRF-protected. x-api-key is CSRF-exempt (machine-to-machine)
+    // and this test is only concerned with ordering, not auth.
     const res = await request(server)
       .post("/api/batch")
+      .set("x-api-key", "test-api-key")
       .send({
         requests: [
           { method: "GET", path: "/api/events" }, // valid -> 200
@@ -61,8 +65,10 @@ describe("POST /api/batch (issue #416)", () => {
     expect(res.body[1].status).toBe(404);
     expect(res.body[2].status).toBe(200);
 
-    // Entries 1 and 3 still carry their successful payloads.
-    expect(Array.isArray(res.body[0].body)).toBe(true);
+    // Entries 1 and 3 still carry their successful payloads. GET /api/events
+    // uses keyset pagination (#490): { data: Event[], next_cursor }, not a
+    // bare array.
+    expect(Array.isArray(res.body[0].body.data)).toBe(true);
     expect(res.body[2].body.id).toBe(contractId);
   });
 });

--- a/indexer/test/api/contract.test.js
+++ b/indexer/test/api/contract.test.js
@@ -94,6 +94,15 @@ describe("OpenAPI Contract Validation Tests", () => {
       functions: [{ name: "mint", args: [] }],
       registered_by: "test-admin",
     });
+    // Full-length strkey-format ID for the POST /api/contracts 409 test,
+    // since that route validates `id` against the real strkey pattern.
+    await db.upsertContractMeta({
+      id: "CONEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      name: "Contract One (full ID)",
+      description: "Seeded for the POST /api/contracts 409 test",
+      functions: [{ name: "noop" }],
+      registered_by: "test-admin",
+    });
 
     // Seed events
     for (let i = 1; i <= 30; i++) {
@@ -191,7 +200,7 @@ describe("OpenAPI Contract Validation Tests", () => {
       .post("/api/contracts")
       .set("x-api-key", "test-api-key")
       .send({
-        id: "C3",
+        id: "CTHREEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         name: "Contract Three",
         description: "Third contract",
         functions: [{ name: "burn", description: "burn spec", args: [] }],
@@ -205,9 +214,9 @@ describe("OpenAPI Contract Validation Tests", () => {
       .post("/api/contracts")
       .set("x-api-key", "test-api-key")
       .send({
-        id: "C1",
+        id: "CONEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         name: "Contract One",
-        functions: [],
+        functions: [{ name: "noop" }],
       });
     expect(res.status).toBe(409);
     expect(() => validateResponse("/api/contracts", "POST", 409, res.body)).not.toThrow();
@@ -218,7 +227,7 @@ describe("OpenAPI Contract Validation Tests", () => {
       .post("/api/contracts")
       .set("x-api-key", "test-api-key")
       .send({
-        id: "C4",
+        id: "CFOURAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
       });
     expect(res.status).toBe(400);
     expect(() => validateResponse("/api/contracts", "POST", 400, res.body)).not.toThrow();

--- a/indexer/test/api/contracts-ownership.test.js
+++ b/indexer/test/api/contracts-ownership.test.js
@@ -21,7 +21,7 @@ const { startApi } = await import("../../src/api.js");
 
 describe("PATCH /api/contracts/:id — ownership verification (issue #523)", () => {
   let server;
-  const contractId = "COWNER523ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJK1";
+  const contractId = "COWNER523AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
   const validFunctions = [
     {
       name: "transfer",
@@ -54,8 +54,15 @@ describe("PATCH /api/contracts/:id — ownership verification (issue #523)", () 
         functions: validFunctions,
       });
 
-    const res = await request(server)
+    // No x-api-key means this request isn't CSRF-exempt, so it needs a real
+    // CSRF token/cookie pair to get past verifyCsrf and reach the route's
+    // own auth check (otherwise it fails CSRF with 403 before that runs).
+    const agent = request.agent(server);
+    const { body: csrf } = await agent.get("/api/csrf-token");
+
+    const res = await agent
       .patch(`/api/contracts/${contractId}`)
+      .set("X-CSRF-Token", csrf.csrfToken)
       .send({ name: "Updated Name", functions: validFunctions });
 
     expect(res.status).toBe(401);
@@ -63,7 +70,7 @@ describe("PATCH /api/contracts/:id — ownership verification (issue #523)", () 
 
   it("returns 404 when patching a non-existent contract", async () => {
     const res = await request(server)
-      .patch("/api/contracts/CNONEXISTENT23ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDE")
+      .patch("/api/contracts/CNONEXISTENT23AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
       .set("x-api-key", "admin-static-key")
       .send({ name: "Does not matter", functions: validFunctions });
 

--- a/indexer/test/api/contracts-register.test.js
+++ b/indexer/test/api/contracts-register.test.js
@@ -16,7 +16,7 @@ const { startApi } = await import("../../src/api.js");
 
 describe("POST /api/contracts (issue #414)", () => {
   let server;
-  const contractId = "CABITEST414ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJK";
+  const contractId = "CABITESTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
   beforeAll(async () => {
     await db.init();
@@ -61,6 +61,10 @@ describe("POST /api/contracts (issue #414)", () => {
       .send({ id: "CMISSINGFUNCTIONS414" }); // no functions
 
     expect(res.status).toBe(400);
-    expect(res.body).toHaveProperty("error");
+    // Schema validation failures return { errors: [...] } (AJV-style, plural),
+    // not a single { error: "..." } string.
+    expect(res.body).toHaveProperty("errors");
+    expect(Array.isArray(res.body.errors)).toBe(true);
+    expect(res.body.errors.length).toBeGreaterThan(0);
   });
 });

--- a/indexer/test/api/contracts-schema-validation.test.js
+++ b/indexer/test/api/contracts-schema-validation.test.js
@@ -22,7 +22,7 @@ const { startApi } = await import("../../src/api.js");
 
 describe("POST /api/contracts — ABI schema validation (issue #522)", () => {
   let server;
-  const validId = "CSCHEMA522ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJK";
+  const validId = "CSCHEMA522ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKABC";
 
   beforeAll(async () => {
     await db.init();

--- a/indexer/test/api/wsEvents.test.js
+++ b/indexer/test/api/wsEvents.test.js
@@ -39,34 +39,43 @@ function nextMessage(ws, timeoutMs = 1000) {
 }
 
 // Helper: create an HTTP server on an OS-assigned port, attach the WS server,
-// and return { httpServer, port }.
+// and return { httpServer, wss, port }.
 function createServer() {
   return new Promise((resolve) => {
     const httpServer = http.createServer();
-    attachWebSocketServer(httpServer);
+    const wss = attachWebSocketServer(httpServer);
     httpServer.listen(0, "127.0.0.1", () => {
       const { port } = httpServer.address();
-      resolve({ httpServer, port });
+      resolve({ httpServer, wss, port });
     });
   });
 }
 
 describe("wsEvents — broadcast to connected clients", () => {
   let httpServer;
+  let wss;
   let port;
   let clientA;
   let clientB;
 
   beforeAll(async () => {
-    ({ httpServer, port } = await createServer());
+    ({ httpServer, wss, port } = await createServer());
     // Open both clients and wait for their welcome frames
     [clientA, clientB] = await Promise.all([connectClient(port), connectClient(port)]);
   });
 
-  afterAll(() => {
+  afterAll(async () => {
     clientA?.terminate();
     clientB?.terminate();
-    httpServer?.close();
+    // wss.close()'s callback fires only once every server-side connection has
+    // finished its own "close" handler (see wsEvents.js) — awaiting it here
+    // (instead of firing-and-forgetting like `httpServer.close()` used to)
+    // stops those handlers' console.log calls from landing after Jest tears
+    // this file's environment down, which otherwise silently sets
+    // process.exitCode = 1 for the whole run (issue: CI red on "Cannot log
+    // after tests are done" from a client disconnecting late).
+    await new Promise((resolve) => wss.close(resolve));
+    await new Promise((resolve) => httpServer.close(resolve));
   });
 
   it("both clients receive a published event within 1 second", async () => {

--- a/indexer/test/api/wsEvents.test.js
+++ b/indexer/test/api/wsEvents.test.js
@@ -165,18 +165,25 @@ describe("wsEvents — broadcast to connected clients", () => {
     // Wait a tick for the close event to propagate and the bus listener to be removed
     await new Promise((r) => setTimeout(r, 50));
 
-    // Publishing after D disconnected must not throw
-    expect(() =>
-      publish({
-        seq: 5,
-        contract_id: "CCLEAN",
-        function: "transfer",
-        ledger: 3,
-        description: "post-disconnect publish",
-        raw_topics: [],
-        raw_data: "",
+    // Publishing after D disconnected must not throw. clientA/clientB are
+    // still connected and will also receive this broadcast — drain it from
+    // both so it doesn't leak into the next test's nextMessage() calls.
+    const cleanupEvent = {
+      seq: 5,
+      contract_id: "CCLEAN",
+      function: "transfer",
+      ledger: 3,
+      description: "post-disconnect publish",
+      raw_topics: [],
+      raw_data: "",
+    };
+    await Promise.all([
+      nextMessage(clientA),
+      nextMessage(clientB),
+      Promise.resolve().then(() => {
+        expect(() => publish(cleanupEvent)).not.toThrow();
       }),
-    ).not.toThrow();
+    ]);
   });
 
   it("publishTransactionStatus is broadcast via the transaction_status channel", async () => {

--- a/indexer/test/jest.setupAfterEnv.js
+++ b/indexer/test/jest.setupAfterEnv.js
@@ -1,0 +1,19 @@
+// Registered via jest.config.js's setupFilesAfterEnv, so this runs once per
+// test file, after the test framework globals (describe/afterAll/expect) are
+// installed but before the file's own top-level code runs. Jest runs
+// same-level afterAll hooks in reverse declaration order, so this global
+// afterAll fires after each test file's own afterAll/teardown has already
+// run — right before Jest tears the file's module environment down.
+//
+// createApi() kicks off ensureAuditPartitions() fire-and-forget (see
+// src/api.js and src/audit/auditLogger.js) so server startup doesn't block
+// on it. If that promise is still pending when a test file finishes, its
+// console.log can fire after Jest freezes the file's console, which prints
+// "Cannot log after tests are done" and — more importantly — silently sets
+// process.exitCode = 1 for the *entire* test run, even though every test
+// passed. Waiting for it here (a no-op for files that never touched the
+// audit logger) closes that race.
+afterAll(async () => {
+  const { getPendingAuditPartitionWork } = await import("../src/audit/auditLogger.js");
+  await getPendingAuditPartitionWork();
+});


### PR DESCRIPTION
## Why

#710 fixed the infrastructure that let indexer tests run at all (they were crashing at import time, or hanging forever on a partition bug). Once they could actually run to completion, they caught real bugs — this PR fixes what they found, plus the workflow-level issues causing `CI` and `Docs — Build & Deploy` to fail on `main` right now.

## Critical: previously-undiscovered production bug

**Every real (DB-issued) API key request 500'd.** `auth/apiKeyAuth.js` selects `rotated_at`/`rotation_grace_until` on every authenticated request, and `admin/keyManager.js`'s `rotateKey()` writes them — but no migration ever created these columns on `api_keys`. This has apparently been broken since the key-rotation feature merged; it was invisible in this environment because the tests that exercise DB-backed keys couldn't run at all before #710. Added `indexer/migrations/027_api_key_rotation_columns.sql`.

## CI-blocking bugs

- **`docs.yml`** referenced `indexer/openapi.yaml` (doesn't exist — real spec is `docs/api/openapi.yaml`), breaking the Pages build on every push.
- **`frontend/package.json`** was missing `@vitest/coverage-v8`, which `vitest.config.ts` requires — `npm test -- --coverage` failed outright.
- **`Testnet Smoke Tests`** job curled a real deployed indexer via a secret with no server started in the job and a `localhost` fallback that can never work — unconditional failure on every push to `main`. Now skips cleanly via a step-output gate when the secret isn't configured (confirmed with `actionlint` that job-level `if:` can't reference `secrets` directly).
- **`pr-quality.yml`** interpolated `github.head_ref` directly into a shell script — a branch-name injection risk flagged by `actionlint`. Moved to `env:`.
- **`docs/api/openapi.yaml`**: two duplicate-key YAML errors (one pre-existing on `main` independent of this branch) plus 16 dangling `$ref`s to schemas that were never defined — broke both `swagger-cli validate` and `contract.test.js`'s own schema-conformance suite.
- **`POST`/`PATCH /api/contracts`** validated bodies against `contractRegistry.schema.json` — a *different* feature's schema (`contractId`/`template`, for community-submitted custom ABI interpretations) — via a runtime patch that renamed one field but kept every other mismatched constraint. Real `ContractMeta` payloads always failed. Replaced with a schema matching what the route and `db.upsertContractMeta` actually accept.
- **CSRF** exempted `x-api-key`-authenticated requests but not Bearer-token admin routes, even though a malicious page can't make a browser attach an `Authorization` header the way it auto-attaches cookies — CSRF doesn't apply to Bearer auth the way it does to cookie auth. Every `/api/admin/*` POST failed CSRF before the route's own auth check ran. Exempted `/api/admin/*`.
- **`PATCH /api/contracts/:id`**'s auth gate checked `!keyId`, but the static admin key is recognized with `tier: "enterprise"` and `keyId: null` — it was rejected before ever reaching the `isAdmin` check meant to grant it access.

## Test bugs exposed once the above were fixed (all pre-existing, all real)

- Several fixtures used contract IDs too short and/or containing digits (`0/1/8/9`) outside the strkey base32 alphabet — they slipped past validation before only because validation itself was broken.
- `wsEvents.test.js`: an earlier test published to shared WebSocket clients without draining the message, leaking it into the next test.
- `batch-order.test.js` asserted `GET /api/events` returns a bare array; it's returned `{ data, next_cursor }` since the `#490` keyset-pagination migration.
- `frontend/test/api.test.ts` (470 lines) never imported the real `src/api.ts` — it hand-duplicated the entire API client and tested the copy, which is exactly how the real `walletHistory` regression went uncaught. Rewritten to import and exercise the real module.

## Verified

- `cargo fmt --check && cargo clippy -- -D warnings && cargo test`: clean.
- `cd indexer && npm test`: **123/123** (up from a suite where entire files couldn't run past import time).
- `node --test test/concurrentWrite.test.js`: passes.
- `cd frontend && npm run build && npx vitest run`: build clean, **175/175** tests, zero `tsc` errors.
- `docs/api/openapi.yaml`: passes both `swagger-cli validate` and `redocly lint`.
- Every modified workflow file passes `actionlint` with zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)