### PR TITLE
feat(explorer): historical analytics — event volume trends per contract (#799)

### DIFF
--- a/docs/api/changelog.md
+++ b/docs/api/changelog.md
@@ -14,8 +14,10 @@ from `indexer/openapi.yaml`). Try endpoints live in the
 ### Added
 
 - This changelog and a generated OpenAPI 3.1 JSON document for tooling.
-- `GET /api/contracts/{id}/stats` — event/caller counts and a 30-day daily
-  activity series for a contract, cached for 5 minutes.
+- `GET /api/contracts/{id}/stats` — event/caller counts and a daily activity
+  series for a contract, cached for 5 minutes. Accepts an optional `range`
+  query parameter (1-365 days, default 30) for the historical 30/90/365-day
+  event-volume trend (#799).
 - `GET /api/contracts/{id}/storage-tiers` — write counts grouped by storage
   durability tier (temporary, persistent, instance).
 - `GET /api/assets/{issuer}/{code}` — classic Stellar asset metadata resolved

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -462,7 +462,8 @@ paths:
       summary: Get contract statistics
       description: >-
         Returns aggregate statistics for a contract: total events, unique
-        callers, first/last seen ledger, and a 30-day events-per-day series.
+        callers, first/last seen ledger, and a daily event-volume series
+        over the trailing `range` days (default 30, max 365).
       parameters:
         - name: id
           in: path
@@ -471,6 +472,18 @@ paths:
             type: string
             example: "CC4VM2DTTR4QO4J4E5K2YUXM"
           description: Contract ID
+        - name: range
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 365
+            default: 30
+            example: 90
+          description: >-
+            Number of trailing days to include in the events_per_day series
+            (1-365, default 30). The UI uses 30, 90, and 365-day presets.
       responses:
         "200":
           description: Contract statistics
@@ -486,7 +499,14 @@ paths:
                     unique_callers: 87
                     first_seen_ledger: 1000001
                     last_seen_ledger: 1050320
+                    range: 90
                     events_per_day: []
+        "422":
+          description: Invalid range query parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "404":
           description: Contract not found
           content:
@@ -4827,7 +4847,7 @@ components:
 
     ContractStats:
       type: object
-      required: [total_events, unique_callers, first_seen_ledger, last_seen_ledger, events_per_day]
+      required: [total_events, unique_callers, first_seen_ledger, last_seen_ledger, events_per_day, range]
       properties:
         total_events:
           type: integer
@@ -4843,6 +4863,10 @@ components:
           type: integer
           nullable: true
           example: 1050320
+        range:
+          type: integer
+          description: The number of trailing days requested via the range query parameter
+          example: 90
         events_per_day:
           type: array
           items:

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -459,12 +459,14 @@ export interface DailyEventCount {
   count: number;
 }
 
-// Contract event/caller statistics — GET /api/contracts/:id/stats
+// Contract event/caller statistics — GET /api/contracts/:id/stats?range=
 export interface ContractStats {
   total_events: number;
   unique_callers: number;
   first_seen_ledger: number | null;
   last_seen_ledger: number | null;
+  /** Trailing days the events_per_day series covers (echo of ?range=). */
+  range?: number;
   events_per_day: DailyEventCount[];
 }
 
@@ -793,8 +795,10 @@ export const api = {
   // live TTL status (instance + code expiration ledgers)
   contractTTL: (id: string) => get<ContractTTL>(`/contracts/${id}/ttl`),
 
-  // event/caller stats + 30-day activity series
-  contractStats: (id: string) => get<ContractStats>(`/contracts/${id}/stats`),
+  // event/caller stats + daily activity series over the trailing `range`
+  // days (30/90/365 presets, defaults to 30 server-side)
+  contractStats: (id: string, range?: number) =>
+    get<ContractStats>(`/contracts/${id}/stats${range ? `?range=${range}` : ""}`),
 
   // storage-tier write breakdown
   contractStorageTiers: (id: string) => get<StorageTierCounts>(`/contracts/${id}/storage-tiers`),

--- a/frontend/src/components/ContractStatsWidget.tsx
+++ b/frontend/src/components/ContractStatsWidget.tsx
@@ -1,8 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../api";
+import type { StatsRange } from "./InvocationFrequencyChart";
 
-/** 30-day daily event-count sparkline — plain SVG, no chart library. */
-function Sparkline({ data }: { data: { date: string; count: number }[] }) {
+/** Daily event-count sparkline for the selected range — plain SVG, no chart library. */
+function Sparkline({ data, range }: { data: { date: string; count: number }[]; range: StatsRange }) {
   const w = 300;
   const h = 40;
   const maxCount = Math.max(...data.map((d) => d.count), 1);
@@ -19,7 +20,7 @@ function Sparkline({ data }: { data: { date: string; count: number }[] }) {
       width="100%"
       viewBox={`0 0 ${w} ${h}`}
       style={{ display: "block", overflow: "visible" }}
-      aria-label="Events per day over the last 30 days"
+      aria-label={`Events per day over the last ${range} days`}
     >
       <polyline points={pts} fill="none" stroke="var(--accent)" strokeWidth={2} strokeLinejoin="round" strokeLinecap="round" />
       {data.map((d, i) => {
@@ -46,10 +47,16 @@ function Stat({ label, value }: { label: string; value: string }) {
   );
 }
 
-export default function ContractStatsWidget({ contractId }: { contractId: string }) {
+export default function ContractStatsWidget({
+  contractId,
+  range = 30,
+}: {
+  contractId: string;
+  range?: StatsRange;
+}) {
   const { data, isLoading } = useQuery({
-    queryKey: ["contract-stats", contractId],
-    queryFn: () => api.contractStats(contractId),
+    queryKey: ["contract-stats", contractId, range],
+    queryFn: () => api.contractStats(contractId, range),
     enabled: !!contractId,
   });
 
@@ -64,8 +71,8 @@ export default function ContractStatsWidget({ contractId }: { contractId: string
         <Stat label="Last Activity" value={data.last_seen_ledger != null ? `Ledger ${data.last_seen_ledger.toLocaleString()}` : "—"} />
       </div>
       <div>
-        <div style={{ fontSize: 12, color: "var(--muted)", marginBottom: 6 }}>Events / day (last 30 days)</div>
-        <Sparkline data={data.events_per_day} />
+        <div style={{ fontSize: 12, color: "var(--muted)", marginBottom: 6 }}>Events / day (last {range} days)</div>
+        <Sparkline data={data.events_per_day} range={range} />
       </div>
     </div>
   );

--- a/frontend/src/components/InvocationFrequencyChart.tsx
+++ b/frontend/src/components/InvocationFrequencyChart.tsx
@@ -1,9 +1,20 @@
 /**
- * InvocationFrequencyChart — SVG bar chart of daily contract invocations
- * over the last 30 days, backed by GET /api/contracts/:id/stats.
+ * InvocationFrequencyChart — SVG bar chart of contract event volume over a
+ * selectable time range (30/90/365-day presets), backed by
+ * GET /api/contracts/:id/stats?range=. Long ranges (> 90 days) are bucketed
+ * into weekly windows so the historical trend stays readable at chart width.
  */
 import { useQuery } from "@tanstack/react-query";
 import { api, type DailyEventCount } from "../api";
+
+/** Selectable trailing-day presets for the event-volume trend (#799). */
+export type StatsRange = 30 | 90 | 365;
+
+export const STATS_RANGE_OPTIONS: { label: string; days: StatsRange }[] = [
+  { label: "30D", days: 30 },
+  { label: "90D", days: 90 },
+  { label: "365D", days: 365 },
+];
 
 const CHART_W = 600;
 const CHART_H = 120;
@@ -14,9 +25,30 @@ function formatDateShort(iso: string): string {
   return d.toLocaleDateString(undefined, { month: "short", day: "numeric", timeZone: "UTC" });
 }
 
-function Bars({ data }: { data: DailyEventCount[] }) {
-  const max = Math.max(...data.map((d) => d.count), 1);
-  const barW = CHART_W / data.length - BAR_GAP;
+/** A display bar: a human label plus the event count it represents. */
+type Bar = { label: string; count: number };
+
+/**
+ * Bucket a zero-filled daily series into consecutive 7-day windows, oldest
+ * first. Each bucket sums its days so the 365-day trend renders as ~53 bars
+ * instead of 365 hairline bars.
+ */
+function bucketWeekly(data: DailyEventCount[]): Bar[] {
+  const bars: Bar[] = [];
+  for (let i = 0; i < data.length; i += 7) {
+    const week = data.slice(i, i + 7);
+    if (!week.length) break;
+    bars.push({
+      label: `${formatDateShort(week[0].date)} – ${formatDateShort(week[week.length - 1].date)}`,
+      count: week.reduce((sum, d) => sum + d.count, 0),
+    });
+  }
+  return bars;
+}
+
+function Bars({ bars, ariaLabel }: { bars: Bar[]; ariaLabel: string }) {
+  const max = Math.max(...bars.map((b) => b.count), 1);
+  const barW = CHART_W / bars.length - BAR_GAP;
 
   return (
     <svg
@@ -24,15 +56,15 @@ function Bars({ data }: { data: DailyEventCount[] }) {
       viewBox={`0 0 ${CHART_W} ${CHART_H}`}
       style={{ display: "block", overflow: "visible" }}
       role="img"
-      aria-label="Invocation frequency for the last 30 days"
+      aria-label={ariaLabel}
     >
-      {data.map((d, i) => {
-        const barH = Math.max(d.count > 0 ? 2 : 0, (d.count / max) * (CHART_H - 4));
+      {bars.map((b, i) => {
+        const barH = Math.max(b.count > 0 ? 2 : 0, (b.count / max) * (CHART_H - 4));
         const x = i * (barW + BAR_GAP);
         const y = CHART_H - barH;
         return (
           <rect
-            key={d.date}
+            key={`${b.label}-${i}`}
             x={x}
             y={y}
             width={Math.max(barW, 1)}
@@ -40,10 +72,10 @@ function Bars({ data }: { data: DailyEventCount[] }) {
             fill="var(--accent, #58a6ff)"
             rx={1}
             role="img"
-            aria-label={`${formatDateShort(d.date)}: ${d.count} event${d.count === 1 ? "" : "s"}`}
+            aria-label={`${b.label}: ${b.count} event${b.count === 1 ? "" : "s"}`}
           >
             <title>
-              {formatDateShort(d.date)}: {d.count} event{d.count === 1 ? "" : "s"}
+              {b.label}: {b.count} event{b.count === 1 ? "" : "s"}
             </title>
           </rect>
         );
@@ -52,10 +84,53 @@ function Bars({ data }: { data: DailyEventCount[] }) {
   );
 }
 
-export default function InvocationFrequencyChart({ contractId }: { contractId: string }) {
+function RangeSelector({
+  range,
+  onRangeChange,
+}: {
+  range: StatsRange;
+  onRangeChange: (range: StatsRange) => void;
+}) {
+  return (
+    <div role="group" aria-label="Event volume time range" style={{ display: "flex", gap: 6 }}>
+      {STATS_RANGE_OPTIONS.map((opt) => {
+        const active = opt.days === range;
+        return (
+          <button
+            key={opt.days}
+            type="button"
+            onClick={() => onRangeChange(opt.days)}
+            aria-pressed={active}
+            style={{
+              padding: "4px 10px",
+              fontSize: 12,
+              borderRadius: 6,
+              border: "1px solid var(--border)",
+              background: active ? "var(--accent, #58a6ff)" : "transparent",
+              color: active ? "#fff" : "var(--muted)",
+              cursor: "pointer",
+            }}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function InvocationFrequencyChart({
+  contractId,
+  range = 30,
+  onRangeChange,
+}: {
+  contractId: string;
+  range?: StatsRange;
+  onRangeChange?: (range: StatsRange) => void;
+}) {
   const { data, isLoading, isError } = useQuery({
-    queryKey: ["contract-stats", contractId],
-    queryFn: () => api.contractStats(contractId),
+    queryKey: ["contract-stats", contractId, range],
+    queryFn: () => api.contractStats(contractId, range),
     enabled: !!contractId,
   });
 
@@ -65,22 +140,40 @@ export default function InvocationFrequencyChart({ contractId }: { contractId: s
   const days = data.events_per_day;
   const hasActivity = days.some((d) => d.count > 0);
 
+  // Daily bars up to 90 days; weekly buckets beyond so the trend stays readable.
+  const bars = range > 90 ? bucketWeekly(days) : days.map((d) => ({ label: formatDateShort(d.date), count: d.count }));
+
   return (
     <div className="card" style={{ padding: "14px 16px" }}>
-      <h3
+      <div
         style={{
-          fontSize: 13,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 12,
           marginBottom: 12,
-          color: "var(--muted)",
-          textTransform: "uppercase",
-          letterSpacing: "0.05em",
+          flexWrap: "wrap",
         }}
       >
-        Invocation Frequency (Last 30 Days)
-      </h3>
+        <h3
+          style={{
+            fontSize: 13,
+            color: "var(--muted)",
+            textTransform: "uppercase",
+            letterSpacing: "0.05em",
+            margin: 0,
+          }}
+        >
+          Event Volume Trend (Last {range} Days)
+        </h3>
+        {onRangeChange && <RangeSelector range={range} onRangeChange={onRangeChange} />}
+      </div>
       {hasActivity ? (
         <>
-          <Bars data={days} />
+          <Bars
+            bars={bars}
+            ariaLabel={`Invocation frequency for the last ${range} days`}
+          />
           <div
             style={{
               display: "flex",
@@ -90,12 +183,12 @@ export default function InvocationFrequencyChart({ contractId }: { contractId: s
               marginTop: 6,
             }}
           >
-            <span>{formatDateShort(days[0].date)}</span>
-            <span>{formatDateShort(days[days.length - 1].date)}</span>
+            <span>{bars[0].label}</span>
+            <span>{bars[bars.length - 1].label}</span>
           </div>
         </>
       ) : (
-        <p style={{ color: "var(--muted)", fontSize: 13, margin: 0 }}>No activity in the last 30 days</p>
+        <p style={{ color: "var(--muted)", fontSize: 13, margin: 0 }}>No activity in the last {range} days</p>
       )}
     </div>
   );

--- a/frontend/src/pages/ContractPage.tsx
+++ b/frontend/src/pages/ContractPage.tsx
@@ -28,7 +28,7 @@ import StateDiffTimeline from "../components/StateDiffTimeline";
 import ExportButton from "../components/ExportButton";
 import AbiHistoryDrawer from "../components/AbiHistoryDrawer";
 import ProtocolBadge from "../components/ProtocolBadge";
-import InvocationFrequencyChart from "../components/InvocationFrequencyChart";
+import InvocationFrequencyChart, { type StatsRange } from "../components/InvocationFrequencyChart";
 import StorageTierStackedBar from "../components/StorageTierStackedBar";
 
 type Tab = "overview" | "source" | "simulate" | "flow" | "roles" | "networks" | "graph" | "call-graph" | "state-diff" | "abi-history";
@@ -100,6 +100,9 @@ export default function ContractPage() {
   const [selectedFn, setSelectedFn] = useState("");
   const [snippetFn, setSnippetFn] = useState<string | null>(null);
   const [historyOpen, setHistoryOpen] = useState(false);
+
+  // Shared event-volume time range for the stats widget + invocation chart (#799)
+  const [statsRange, setStatsRange] = useState<StatsRange>(30);
 
   // ── Local ABI (session-only, never sent to server) ──────────────────────────
   const { localAbi, loadAbi, clearAbi, parseError } = useLocalAbi(id);
@@ -391,8 +394,8 @@ export default function ContractPage() {
       {/* Tab: Overview */}
       {tab === "overview" && (
         <>
-          {/* Contract stats widget — total events, unique callers, last activity, sparkline (#536) */}
-          <ContractStatsWidget contractId={id} />
+          {/* Contract stats widget — total events, unique callers, last activity, sparkline (#536, #799) */}
+          <ContractStatsWidget contractId={id} range={statsRange} />
 
           {/* Local ABI upload zone — shown for unverified contracts or when
               the user wants to override descriptions with a local file */}
@@ -498,8 +501,8 @@ export default function ContractPage() {
           {/* Live TTL expiration progress bars */}
           <TTLProgressBar contractId={id} />
 
-          {/* Invocation frequency (last 30 days) */}
-          <InvocationFrequencyChart contractId={id} />
+          {/* Event volume trend with selectable 30/90/365-day range (#799) */}
+          <InvocationFrequencyChart contractId={id} range={statsRange} onRangeChange={setStatsRange} />
 
           {/* Storage writes by durability tier */}
           <StorageTierStackedBar contractId={id} />

--- a/frontend/test/ContractStatsWidget.test.tsx
+++ b/frontend/test/ContractStatsWidget.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Issue #799 — ContractStatsWidget renders aggregate event/caller stats plus
+ * a daily event-count sparkline for the shared selectable time range, and
+ * passes the range through to GET /api/contracts/:id/stats?range=.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+vi.mock("../src/api", () => ({
+  api: {
+    contractStats: vi.fn(),
+  },
+}));
+
+import { api } from "../src/api";
+import ContractStatsWidget from "../src/components/ContractStatsWidget";
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+/** Sequential ISO dates starting 2026-01-01 with a varied daily count. */
+function makeSeries(days: number) {
+  const start = Date.UTC(2026, 0, 1);
+  return Array.from({ length: days }, (_, i) => ({
+    date: new Date(start + i * 86_400_000).toISOString().slice(0, 10),
+    count: (i % 5) * 2,
+  }));
+}
+
+function mockStats(range: number) {
+  vi.mocked(api.contractStats).mockResolvedValue({
+    total_events: 1234,
+    unique_callers: 87,
+    first_seen_ledger: 1000,
+    last_seen_ledger: 2000,
+    range,
+    events_per_day: makeSeries(range),
+  });
+}
+
+describe("ContractStatsWidget (#799)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders totals and fetches with the default 30-day range", async () => {
+    mockStats(30);
+    render(
+      <Wrapper>
+        <ContractStatsWidget contractId="C1" />
+      </Wrapper>,
+    );
+
+    expect(await screen.findByText("1,234")).toBeDefined();
+    expect(screen.getByText("87")).toBeDefined();
+    expect(screen.getByText("Ledger 2,000")).toBeDefined();
+    expect(screen.getByText("Events / day (last 30 days)")).toBeDefined();
+    expect(screen.getByLabelText("Events per day over the last 30 days")).toBeDefined();
+    expect(api.contractStats).toHaveBeenCalledWith("C1", 30);
+  });
+
+  it("uses the shared range prop and reflects it in the sparkline label", async () => {
+    mockStats(90);
+    render(
+      <Wrapper>
+        <ContractStatsWidget contractId="C1" range={90} />
+      </Wrapper>,
+    );
+
+    await waitFor(() => expect(api.contractStats).toHaveBeenCalledWith("C1", 90));
+    expect(await screen.findByText("Events / day (last 90 days)")).toBeDefined();
+    expect(screen.getByLabelText("Events per day over the last 90 days")).toBeDefined();
+  });
+});

--- a/frontend/test/InvocationFrequencyChart.test.tsx
+++ b/frontend/test/InvocationFrequencyChart.test.tsx
@@ -2,9 +2,12 @@
  * Issue #542 — InvocationFrequencyChart renders a 30-bar SVG bar chart from
  * the events_per_day series, shows an empty-state placeholder when all
  * counts are zero, and labels each bar for accessibility.
+ * Issue #799 — the chart exposes selectable 30/90/365-day ranges; long ranges
+ * are bucketed into weekly bars so the historical trend stays readable.
  */
+import { useState } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 vi.mock("../src/api", () => ({
@@ -21,11 +24,40 @@ function Wrapper({ children }: { children: React.ReactNode }) {
   return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
 }
 
+/** Stateful harness that mirrors ContractPage's lifted range state (#799). */
+function RangeHarness() {
+  const [range, setRange] = useState(30);
+  return <InvocationFrequencyChart contractId="C1" range={range} onRangeChange={setRange} />;
+}
+
 function makeDays(counts: number[]) {
   return counts.map((count, i) => ({
     date: `2026-06-${String(i + 1).padStart(2, "0")}`,
     count,
   }));
+}
+
+/** Sequential ISO dates starting 2025-01-01, with a count per day. */
+function makeSeries(days: number, counts?: number[]) {
+  const start = Date.UTC(2025, 0, 1);
+  return Array.from({ length: days }, (_, i) => {
+    const d = new Date(start + i * 86_400_000);
+    return {
+      date: d.toISOString().slice(0, 10),
+      count: counts ? counts[i] ?? 0 : 0,
+    };
+  });
+}
+
+function mockStats(range: number, counts: number[]) {
+  vi.mocked(api.contractStats).mockResolvedValue({
+    total_events: counts.reduce((a, b) => a + b, 0),
+    unique_callers: 3,
+    first_seen_ledger: 100,
+    last_seen_ledger: 200,
+    range,
+    events_per_day: makeSeries(range, counts),
+  });
 }
 
 describe("InvocationFrequencyChart", () => {
@@ -100,5 +132,57 @@ describe("InvocationFrequencyChart", () => {
       expect(container.textContent).not.toMatch(/loading/i);
     });
     expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("refetches with range=365 and renders weekly buckets when 365D is selected (#799)", async () => {
+    // Varies across the year so the weekly trend is non-flat.
+    const counts = Array.from({ length: 365 }, (_, i) => ((i / 7) | 0) % 10);
+    vi.mocked(api.contractStats).mockImplementation((_id, range) =>
+      Promise.resolve({
+        total_events: counts.reduce((a, b) => a + b, 0),
+        unique_callers: 3,
+        first_seen_ledger: 100,
+        last_seen_ledger: 200,
+        range: range ?? 30,
+        events_per_day: makeSeries(range ?? 30, counts),
+      }),
+    );
+
+    render(
+      <Wrapper>
+        <RangeHarness />
+      </Wrapper>,
+    );
+
+    // Wait for the default (30-day) chart so the selector is present.
+    await screen.findByRole("img", { name: /invocation frequency for the last 30 days/i });
+    fireEvent.click(screen.getByRole("button", { name: "365D" }));
+
+    // 365 days bucketed weekly → 53 bars, and the request carries the range.
+    const svg = await screen.findByRole("img", { name: /invocation frequency for the last 365 days/i });
+    expect(svg.querySelectorAll("rect")).toHaveLength(53);
+    await waitFor(() => {
+      expect(api.contractStats).toHaveBeenCalledWith("C1", 365);
+    });
+  });
+
+  it("renders daily bars for the 90-day range when 90D is selected (#799)", async () => {
+    mockStats(90, Array.from({ length: 90 }, (_, i) => (i % 9) * 2));
+
+    render(
+      <Wrapper>
+        <RangeHarness />
+      </Wrapper>,
+    );
+
+    // Wait for the default (30-day) chart so the selector is present.
+    await screen.findByRole("img", { name: /invocation frequency for the last 30 days/i });
+    fireEvent.click(screen.getByRole("button", { name: "90D" }));
+
+    const svg = await screen.findByRole("img", { name: /invocation frequency for the last 90 days/i });
+    expect(svg.querySelectorAll("rect")).toHaveLength(90);
+    await waitFor(() => {
+      expect(api.contractStats).toHaveBeenCalledWith("C1", 90);
+    });
   });
 });

--- a/frontend/test/api.test.ts
+++ b/frontend/test/api.test.ts
@@ -94,6 +94,16 @@ describe("api utility", () => {
     const result = await api.contractStats("C1");
     expect(result.total_events).toBe(100);
     expect(result.unique_callers).toBe(10);
+    const [url] = (fetch as any).mock.calls[0];
+    expect(url).not.toContain("range=");
+  });
+
+  it("contractStats appends the range query param when provided (#799)", async () => {
+    mockFetch({ total_events: 100, unique_callers: 10, first_seen_ledger: 1, last_seen_ledger: 2, events_per_day: [], range: 365 });
+    const result = await api.contractStats("C1", 365);
+    expect(result.range).toBe(365);
+    const [url] = (fetch as any).mock.calls[0];
+    expect(url).toContain("range=365");
   });
 
   it("search builds encoded query string", async () => {

--- a/indexer/migrations/028_contract_events_daily_index.sql
+++ b/indexer/migrations/028_contract_events_daily_index.sql
@@ -1,0 +1,6 @@
+-- Closes #799 — GET /api/contracts/:id/stats?range=90|365 needs an efficient
+-- (contract_id, created_at) range scan to build the daily event-volume series
+-- for long historical windows. Without it, Postgres re-scans every event for a
+-- contract once per generated day (up to 365 index probes per request).
+CREATE INDEX IF NOT EXISTS idx_events_contract_created
+  ON events (contract_id, created_at);

--- a/indexer/src/api.js
+++ b/indexer/src/api.js
@@ -1792,17 +1792,34 @@ export function createApi({ logDestination, dbOverride } = {}) {
 
   // ── Contract Stats ────────────────────────────────────────────
 
-  // GET /api/contracts/:id/stats — event/caller counts + 30-day activity sparkline
+  // GET /api/contracts/:id/stats?range=30|90|365 — event/caller counts + a
+  // daily event-volume series over the trailing `range` days (default 30,
+  // max 365), oldest first and zero-filled. Backs the contract detail page's
+  // stats widget and the selectable-time-range invocation frequency chart
+  // (#799). The series is computed by db.getContractEventsByDay, which uses
+  // idx_events_contract_created (migration 028) for the long-range scan.
   app.get(
     "/api/contracts/:id/stats",
-    makeCache("stats", (req) => `contracts:stats:${req.params.id}`),
+    // Validate before the cache middleware so malformed params can never be
+    // served a cached 200 (their cache key would normalize to the default).
+    (req, res, next) => {
+      if (req.query.range !== undefined) {
+        const parsedRange = Number(req.query.range);
+        if (!Number.isInteger(parsedRange) || parsedRange < 1 || parsedRange > 365) {
+          return res.status(422).json({ error: "Invalid range" });
+        }
+      }
+      next();
+    },
+    makeCache("stats", (req) => `contracts:stats:${req.params.id}:${req.query.range ?? 30}`),
     async (req, res) => {
       try {
+        const range = req.query.range !== undefined ? Number(req.query.range) : 30;
         const [stats, eventsPerDay] = await Promise.all([
           db.getContractStats(req.params.id),
-          db.getContractEventsByDay(req.params.id, 30),
+          db.getContractEventsByDay(req.params.id, range),
         ]);
-        res.json({ ...stats, events_per_day: eventsPerDay });
+        res.json({ ...stats, events_per_day: eventsPerDay, range });
       } catch (e) {
         res.status(500).json({ error: e.message });
       }

--- a/indexer/test/api/contract-stats.test.js
+++ b/indexer/test/api/contract-stats.test.js
@@ -2,7 +2,9 @@ import request from "supertest";
 
 // Issue #536: GET /api/contracts/:id/stats returns aggregate event stats for
 // a contract's stats widget — total events, unique callers, first/last seen
-// ledger, and a zero-filled 30-day daily trend for the sparkline.
+// ledger, and a zero-filled daily trend for the sparkline.
+// Issue #799: the same endpoint accepts a ?range= query param (1-365, default
+// 30) so the contract detail page can render 30/90/365-day event-volume trends.
 
 const DB_URL = process.env.TEST_DATABASE_URL || process.env.DATABASE_URL || "postgres://postgres:postgres@localhost:5432/soroban_test";
 process.env.DATABASE_URL = DB_URL;
@@ -68,6 +70,31 @@ describe("GET /api/contracts/:id/stats (issue #536)", () => {
     expect(res.body.unique_callers).toBe(0);
     expect(res.body.events_per_day).toHaveLength(30);
     expect(res.body.events_per_day.every((d) => d.count === 0)).toBe(true);
+    expect(res.body.range).toBe(30);
+  });
+
+  it("returns a 90-day zero-filled series when ?range=90 (issue #799)", async () => {
+    const res = await request(server).get("/api/contracts/CNOEVENTS536/stats?range=90");
+    expect(res.status).toBe(200);
+    expect(res.body.events_per_day).toHaveLength(90);
+    expect(res.body.events_per_day.every((d) => d.count === 0)).toBe(true);
+    expect(res.body.range).toBe(90);
+  });
+
+  it("returns a 365-day zero-filled series when ?range=365 (issue #799)", async () => {
+    const res = await request(server).get("/api/contracts/CNOEVENTS536/stats?range=365");
+    expect(res.status).toBe(200);
+    expect(res.body.events_per_day).toHaveLength(365);
+    expect(res.body.events_per_day.every((d) => d.count === 0)).toBe(true);
+    expect(res.body.range).toBe(365);
+  });
+
+  it("rejects invalid range values with 422 (issue #799)", async () => {
+    for (const bad of ["abc", "0", "-5", "366", "30.5"]) {
+      const res = await request(server).get(`/api/contracts/CNOEVENTS536/stats?range=${bad}`);
+      expect(res.status).toBe(422);
+      expect(res.body.error).toBe("Invalid range");
+    }
   });
 
   it("caches the response (X-Cache: MISS then HIT)", async () => {


### PR DESCRIPTION
## Summary

Implements **#799 — historical analytics: event-volume trends per contract**. The contract detail page now shows an event-volume trend chart over a selectable time range (30/90/365-day presets), backed by an extended `GET /api/contracts/{id}/stats` time-series response.

**Acceptance criteria:** _A contract's detail page shows an event-volume trend chart over a selectable time range._ ✅

## Backend (`indexer/`)

- **`GET /api/contracts/{id}/stats`** now accepts an optional `?range=` query param (integer 1–365, default 30):
  - Validated **before** the cache middleware — malformed values return `422 Invalid range` and can never be served from a stale cache entry.
  - `range` is part of the cache key, so 30/90/365-day series are cached independently (5-min TTL as before).
  - The response echoes `range` alongside the zero-filled, oldest-first `events_per_day` daily series.
- **Migration `028_contract_events_daily_index.sql`** — adds `idx_events_contract_created ON events(contract_id, created_at)` so the 90/365-day series uses a range scan instead of re-scanning the contract's full history once per generated day.
- **Tests** (`indexer/test/api/contract-stats.test.js`):
  - `?range=90` → 90-day zero-filled series
  - `?range=365` → 365-day zero-filled series
  - invalid ranges (`abc`, `0`, `-5`, `366`, `30.5`) → `422 Invalid range`
  - `range` echo, plus the existing cache MISS→HIT test now covers the range-scoped key.
- **Docs:** `docs/api/openapi.yaml` documents the `range` query param, the new `422` response, and the `range` field on `ContractStats`; `docs/api/changelog.md` updated.

## Frontend (`frontend/`)

- **`InvocationFrequencyChart`** is now an **"Event Volume Trend"** card with a **30D / 90D / 365D selector**:
  - Refetches the daily series for the selected range via `?range=`.
  - Ranges > 90 days are bucketed into **weekly windows** so the 365-day trend stays readable at chart width (~53 bars instead of 365 hairline bars).
  - Title, empty-state message, date-range labels, and per-bar `aria-label`s are range-aware.
- **`ContractStatsWidget`** — the "Events / day" sparkline and label follow the same selected range.
- **`ContractPage`** — lifts a single `statsRange` state shared by both widgets (one selector controls both).
- **`api.contractStats(id, range?)`** — appends `?range=` only when provided, so existing callers (e.g. `RegistryPage`) are unchanged.
- **Tests:**
  - `InvocationFrequencyChart`: 365D → 53 weekly bars, 90D → 90 daily bars, and the request carries the range; existing 30-day / empty-state / error tests still pass.
  - `ContractStatsWidget.test.tsx` (new): default 30-day fetch + shared-range prop coverage.
  - `api.test.ts`: `?range=` is appended only when a range is supplied.

## Verification

- Frontend: **180 tests pass** (`npx vitest run`); `npm run build` (tsc + vite) passes. Coverage on the touched components: `InvocationFrequencyChart` 97.4%, `ContractStatsWidget` 95%.
- OpenAPI spec validates with `swagger-cli validate` and `redocly lint` (only pre-existing `operationId` warnings).
- `node --check` passes on the modified indexer files and tests.
- ⚠️ DB-backed indexer tests and the Rust contract checks could **not** be executed in this sandbox (no writable Postgres instance / read-only cargo registry) — they run in CI (`services` and `contracts` jobs) and the pre-push hook enforces contract checks on every push.

Closes #799
