### PR TITLE
Search trigram indexes + home page indexer stats bar

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -263,6 +263,20 @@ export interface SearchResponse {
   suggestions: SearchSuggestion[];
 }
 
+// GET /api/health — polled every 10s by the home page's compact stats bar.
+export interface HealthStats {
+  total_events: number | null;
+  events_per_minute: number | null;
+  indexer_lag_ledgers: number | null;
+  decode_success_rate: number | null;
+}
+
+export interface HealthResponse {
+  status: "healthy" | "degraded" | "unhealthy";
+  timestamp: string;
+  stats: HealthStats;
+}
+
 export interface HorizonBalance {
   asset_type: string;
   asset_code?: string;
@@ -666,6 +680,8 @@ export const api = {
     return get<SearchResponse>(`/search?${params}`);
   },
   zkCosts: (seq: number) => get<{ calls: ZkHostCall[]; delta: ZkCostDelta | null }>(`/events/${seq}/zk-costs`),
+  /** Powers the home page's compact stats bar — polled every 10s. */
+  health: () => get<HealthResponse>("/health"),
   contract: (id: string) => get<ContractMeta>(`/contracts/${id}`),
   listContracts: (page = 1, limit = 25, type?: string) => {
     const q = new URLSearchParams();

--- a/frontend/src/components/StatsBar.tsx
+++ b/frontend/src/components/StatsBar.tsx
@@ -1,0 +1,117 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { api } from "../api";
+
+function formatCount(n: number | null): string {
+  if (n === null) return "—";
+  return n.toLocaleString();
+}
+
+function formatRate(n: number | null, digits = 1): string {
+  if (n === null) return "—";
+  return n.toFixed(digits);
+}
+
+interface StatItemProps {
+  to: string;
+  label: string;
+  value: string;
+  title: string;
+  /** true for server-rendered routes (e.g. /api/docs) outside the SPA router — needs a full navigation, not client-side routing. */
+  external?: boolean;
+}
+
+function StatItem({ to, label, value, title, external }: StatItemProps) {
+  const linkStyle: React.CSSProperties = {
+    display: "flex",
+    alignItems: "baseline",
+    gap: 6,
+    color: "inherit",
+    textDecoration: "none",
+    whiteSpace: "nowrap",
+  };
+  const content = (
+    <>
+      <span style={{ fontSize: 13, fontWeight: 700 }}>{value}</span>
+      <span style={{ fontSize: 12, color: "var(--muted)" }}>{label}</span>
+    </>
+  );
+
+  if (external) {
+    return (
+      <a href={to} title={title} style={linkStyle}>
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <Link to={to} title={title} style={linkStyle}>
+      {content}
+    </Link>
+  );
+}
+
+/**
+ * Compact home-page stats bar — polls GET /api/health every 10s and
+ * surfaces indexer health at a glance. Hidden below 768px (see the
+ * .stats-bar media query) since there isn't room for it alongside the
+ * mobile nav and filters.
+ */
+export default function StatsBar() {
+  const { data } = useQuery({
+    queryKey: ["health-stats"],
+    queryFn: () => api.health(),
+    refetchInterval: 10_000,
+    staleTime: 5_000,
+  });
+
+  const stats = data?.stats;
+
+  return (
+    <>
+      <style>{`
+        @media (max-width: 768px) {
+          .stats-bar {
+            display: none;
+          }
+        }
+      `}</style>
+      <div
+        className="stats-bar card"
+        style={{
+          display: "flex",
+          gap: 24,
+          alignItems: "center",
+          flexWrap: "wrap",
+          padding: "8px 16px",
+        }}
+      >
+        <StatItem
+          to="/contracts"
+          label="events indexed"
+          value={formatCount(stats?.total_events ?? null)}
+          title="Total events indexed — browse the contract registry"
+        />
+        <StatItem
+          to="/api/docs"
+          label="events/min"
+          value={formatRate(stats?.events_per_minute ?? null)}
+          title="Events indexed per minute (5-minute rolling average) — API docs"
+        />
+        <StatItem
+          to="/rpc-metrics"
+          label="ledgers behind"
+          value={formatCount(stats?.indexer_lag_ledgers ?? null)}
+          title="Indexer lag in ledgers — RPC metrics dashboard"
+        />
+        <StatItem
+          to="/api/docs"
+          label="decode success"
+          value={stats?.decode_success_rate != null ? `${formatRate(stats.decode_success_rate)}%` : "—"}
+          title="Share of events successfully decoded — API docs"
+        />
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -6,6 +6,7 @@ import type { DecodedEvent } from "../api";
 import EventTable from "../components/EventTable";
 import ExportButton from "../components/ExportButton";
 import SkeletonLoader from "../components/SkeletonLoader";
+import StatsBar from "../components/StatsBar";
 import { useEventStream } from "../hooks/useEventStream";
 import { useMetaTags } from "../hooks/useMetaTags";
 
@@ -105,6 +106,8 @@ export default function Home() {
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+      <StatsBar />
+
       <div>
         <h1 style={{ fontSize: 22, marginBottom: 4 }}>Soroban Smart Block Explorer</h1>
         <p style={{ color: "var(--muted)" }}>Human-readable Soroban contract events on Stellar.</p>

--- a/indexer/migrations/021_search_indexes.sql
+++ b/indexer/migrations/021_search_indexes.sql
@@ -1,0 +1,23 @@
+-- Migration 021: trigram indexes backing GET /api/search
+--
+-- searchContracts/searchEvents/searchWallets (see db.js) ILIKE '%term%'
+-- against contracts.name, events.tx_hash, and events.function. A leading
+-- wildcard defeats a plain btree index, so these need pg_trgm's GIN
+-- (gin_trgm_ops) indexes instead — target: keep the combined search query
+-- under 50ms.
+--
+-- CONCURRENTLY avoids locking these tables for writes while the index
+-- builds (see migrate.js, which runs this file's statements outside a
+-- transaction to support it). IF NOT EXISTS keeps a retry after a partial
+-- failure safe.
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contracts_name_trgm
+  ON contracts USING gin (name gin_trgm_ops);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_events_tx_hash_trgm
+  ON events USING gin (tx_hash gin_trgm_ops);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_events_function_trgm
+  ON events USING gin (function gin_trgm_ops);

--- a/indexer/src/health.js
+++ b/indexer/src/health.js
@@ -15,8 +15,40 @@ import { db, pool } from "./db.js";
 import { getActiveAlerts } from "./alertManager.js";
 
 // ── Health check state ────────────────────────────────────────────────────────
-let _indexerStatus = { healthy: true, lastLedger: 0, lastSync: Date.now(), lagSeconds: 0 };
+let _indexerStatus = { healthy: true, lastLedger: 0, lastSync: Date.now(), lagSeconds: 0, ledgerLag: 0 };
 let _workerStatus = { healthy: true, errors: 0, lastRun: Date.now() };
+
+// ── Indexer stats (for the frontend's home-page stats bar) ────────────────
+// COUNT(*) over `events` and `dead_letter_queue` on every /api/health poll
+// (every 10s per client, and there may be several clients) would add
+// avoidable load, so these are memoized for a few seconds.
+let _statsCache = null;
+let _statsCacheAt = 0;
+const STATS_CACHE_MS = 5000;
+
+async function getIndexerStats() {
+  const now = Date.now();
+  if (_statsCache && now - _statsCacheAt < STATS_CACHE_MS) return _statsCache;
+
+  const [totalRes, recentRes, dlqRes] = await Promise.all([
+    db.query("SELECT COUNT(*)::INT AS total FROM events"),
+    db.query("SELECT COUNT(*)::INT AS recent FROM events WHERE created_at > NOW() - INTERVAL '5 minutes'"),
+    db.query("SELECT COUNT(*)::INT AS failed FROM dead_letter_queue WHERE resolved = FALSE"),
+  ]);
+
+  const totalEvents = totalRes.rows[0]?.total ?? 0;
+  const recentEvents = recentRes.rows[0]?.recent ?? 0;
+  const failedDecodes = dlqRes.rows[0]?.failed ?? 0;
+  const decodeAttempts = totalEvents + failedDecodes;
+
+  _statsCache = {
+    total_events: totalEvents,
+    events_per_minute: Math.round((recentEvents / 5) * 10) / 10,
+    decode_success_rate: decodeAttempts > 0 ? Math.round((totalEvents / decodeAttempts) * 10000) / 100 : 100,
+  };
+  _statsCacheAt = now;
+  return _statsCache;
+}
 
 // Global Redis client reference (set by cacheLayer or health check)
 let _redisClient = null;
@@ -32,12 +64,13 @@ export function setRedisClient(client) {
 /**
  * Update indexer health status (called from main daemon)
  */
-export function updateIndexerStatus(ledger, lagSeconds) {
+export function updateIndexerStatus(ledger, lagSeconds, ledgerLag = 0) {
   _indexerStatus = {
     healthy: lagSeconds < 120, // unhealthy if >2 minutes behind
     lastLedger: ledger,
     lastSync: Date.now(),
     lagSeconds,
+    ledgerLag,
   };
 }
 
@@ -164,6 +197,7 @@ function checkIndexer() {
     status: _indexerStatus.healthy && !stale ? "healthy" : "unhealthy",
     lastLedger: _indexerStatus.lastLedger,
     lagSeconds: _indexerStatus.lagSeconds,
+    ledgerLag: _indexerStatus.ledgerLag,
     lastSyncAgo: Math.floor(timeSinceLastSync / 1000),
   };
 }
@@ -188,9 +222,10 @@ function checkWorkers() {
  * Returns detailed status for all dependencies
  */
 export async function getHealthStatus() {
-  const [database, cache] = await Promise.all([
+  const [database, cache, stats] = await Promise.all([
     checkDatabase(),
     checkCache(),
+    getIndexerStats().catch(() => ({ total_events: null, events_per_minute: null, decode_success_rate: null })),
   ]);
 
   const indexer = checkIndexer();
@@ -200,7 +235,7 @@ export async function getHealthStatus() {
   // Overall status: healthy if all critical dependencies are healthy
   // Cache is optional, workers are degradable
   const criticalHealthy = database.status === "healthy" && indexer.status === "healthy";
-  const allHealthy = criticalHealthy && 
+  const allHealthy = criticalHealthy &&
     (cache.status === "healthy" || cache.status === "disabled") &&
     workers.status === "healthy";
 
@@ -212,6 +247,13 @@ export async function getHealthStatus() {
       cache,
       indexer,
       workers,
+    },
+    // Powers the frontend's compact home-page stats bar (polled every 10s).
+    stats: {
+      total_events: stats.total_events,
+      events_per_minute: stats.events_per_minute,
+      indexer_lag_ledgers: indexer.ledgerLag,
+      decode_success_rate: stats.decode_success_rate,
     },
     alerts: {
       active_count: activeAlerts.length,

--- a/indexer/src/index.js
+++ b/indexer/src/index.js
@@ -397,7 +397,8 @@ async function run() {
       alertManager.recordPoll();
       gapRecordLedger(polledFrom);
       const lagSeconds = Math.floor((Date.now() - (polledFrom * 5000)) / 1000); // approximate lag
-      updateIndexerStatus(polledFrom, lagSeconds);
+      const ledgerLag = Math.max(0, latestLedger - polledFrom);
+      updateIndexerStatus(polledFrom, lagSeconds, ledgerLag);
 
       const immediateForkLedger = await checkForReorg(latestLedger, latestLedgerHash).catch((err) => {
         logger.error({ err: err.message, ledger: latestLedger }, "reorg fast-path check failed");

--- a/indexer/src/migrate.js
+++ b/indexer/src/migrate.js
@@ -14,6 +14,23 @@ const MIGRATIONS_DIR = path.resolve(
   "../migrations",
 );
 
+// `CREATE INDEX CONCURRENTLY` cannot run inside a transaction block (and
+// Postgres rejects it if it isn't the sole statement in its query message —
+// the simple query protocol treats multiple ;-separated statements as one
+// implicit transaction). Migrations that use it are split into individual
+// statements and run outside BEGIN/COMMIT, each as its own query.
+const CONCURRENTLY_RE = /\bCONCURRENTLY\b/i;
+
+function splitStatements(sql) {
+  return sql
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("--"))
+    .join("\n")
+    .split(";")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
 /**
  * Run all pending migrations against the provided pg pool.
  * @param {import('pg').Pool} pool
@@ -41,6 +58,27 @@ export async function runMigrations(pool) {
     if (appliedSet.has(file)) continue;
 
     const sql = await readFile(path.join(MIGRATIONS_DIR, file), "utf8");
+
+    if (CONCURRENTLY_RE.test(sql)) {
+      // No transaction wrapper — each statement commits (or fails) on its
+      // own. Statements use IF NOT EXISTS so a re-run after a partial
+      // failure is safe.
+      try {
+        for (const statement of splitStatements(sql)) {
+          await pool.query(statement);
+        }
+        await pool.query(
+          "INSERT INTO schema_migrations (version) VALUES ($1)",
+          [file],
+        );
+        console.log(`[migrations] applied ${file} (non-transactional)`);
+        ran++;
+      } catch (err) {
+        throw new Error(`Migration ${file} failed: ${err.message}`);
+      }
+      continue;
+    }
+
     const client = await pool.connect();
     try {
       await client.query("BEGIN");


### PR DESCRIPTION
## Summary

**Search — `GET /api/search?q=`**
- The endpoint itself (`Promise.all` over `searchContracts`/`searchEvents`/`searchWallets`/`searchSuggestions`, 10s cache TTL) was already implemented and mounted; the missing piece was the index backing it.
- Added `indexer/migrations/021_search_indexes.sql`: enables `pg_trgm` and creates `CONCURRENTLY` GIN trigram indexes on `contracts.name`, `events.tx_hash`, and `events.function`, so the leading-wildcard `ILIKE '%term%'` queries these functions run can use an index instead of falling back to a sequential scan.
- `CREATE INDEX CONCURRENTLY` can't run inside a transaction block, but `migrate.js` previously wrapped every migration file in `BEGIN`/`COMMIT`. Updated `migrate.js` to detect `CONCURRENTLY` migrations and run their statements individually, outside a transaction — so this migration doesn't block writes to `contracts`/`events` while the index builds, and a retry after a partial failure is safe (statements use `IF NOT EXISTS`).

**Home page stats bar**
- `GET /api/health` didn't expose the stats the bar needs, so `health.js` now returns a `stats` block: `total_events`, `events_per_minute` (5-minute rolling average), `indexer_lag_ledgers`, and `decode_success_rate` (events successfully decoded vs. `dead_letter_queue` failures). These queries are memoized for 5s so multiple clients polling every 10s don't hammer the `events` table.
- Added ledger-based lag tracking (`ledgerLag`) alongside the existing time-based lag, wired from the daemon's poll loop in `index.js`.
- Frontend: added `api.health()` and a new `StatsBar` component that polls `/api/health` every 10s and renders four compact, clickable stats at the top of the home page — each links to a relevant page (contract registry, RPC metrics dashboard, or API docs). Hidden below 768px using the same media-query pattern `Nav.tsx` already uses for its own mobile breakpoint.

## Test plan

- [x] `node src/migrate.js` against a fresh Postgres 16 instance — extension + all three trigram indexes created; a second run is a no-op (idempotent)
- [x] Indexer Jest suite (123 tests) + Node test-runner suite, including `db_schema.test.js`'s migration-idempotency check
- [x] Frontend Vitest suite (175 tests), including `Home.test.tsx`
- [x] `tsc --noEmit` clean; production `vite build` succeeds
- [x] Verified `/api/health` and `/api/search` live against a running Postgres + API instance — real stats and trigram-indexed search results returned end-to-end

this pr closes #627 
this pr closes #625 
this pr closes #626 