### PR TITLE
Observability + indexer perf: logging migration, partition alerting, SLO dashboards, parallel RPC recovery

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,5 +91,30 @@ services:
       indexer:
         condition: service_started
 
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: soroban-prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./monitoring/prometheus/alerts.yml:/etc/prometheus/alerts.yml
+    depends_on:
+      indexer:
+        condition: service_healthy
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: soroban-grafana
+    ports:
+      - "3002:3000"
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning
+    depends_on:
+      - prometheus
+
 volumes:
   pgdata:

--- a/indexer/src/abiSeeder.js
+++ b/indexer/src/abiSeeder.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /**
  * abiSeeder.js
  *
@@ -51,9 +52,9 @@ export async function seedBuiltinAbis() {
       });
 
       seeded++;
-      console.log(`[abi-seed] registered ${meta.name} (${contractId})`);
+      logger.info(`[abi-seed] registered ${meta.name} (${contractId})`);
     } catch (err) {
-      console.error(`[abi-seed] failed to seed ${file}:`, err.message);
+      logger.error(`[abi-seed] failed to seed ${file}:`, err.message);
     }
   }
   return { seeded, skipped };

--- a/indexer/src/alertManager.js
+++ b/indexer/src/alertManager.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /* global fetch */
 
 /**
@@ -40,6 +41,7 @@ export const ALERT_CONDITIONS = {
   DLQ_THRESHOLD: "DLQ_THRESHOLD",
   REORG_DETECTED: "REORG_DETECTED",
   DECODE_RATE_LOW: "DECODE_RATE_LOW",
+  AUDIT_PARTITION_FAILURE: "AUDIT_PARTITION_FAILURE",
 };
 
 const SEVERITY = {
@@ -52,6 +54,7 @@ const SEVERITY = {
   [ALERT_CONDITIONS.DLQ_THRESHOLD]: "warning",
   [ALERT_CONDITIONS.REORG_DETECTED]: "critical",
   [ALERT_CONDITIONS.DECODE_RATE_LOW]: "warning",
+  [ALERT_CONDITIONS.AUDIT_PARTITION_FAILURE]: "critical",
 };
 
 // Active alert state — maps condition → timestamp when first fired
@@ -72,7 +75,7 @@ async function sendSlack(condition, message) {
       body: JSON.stringify({ text: `${emoji} *[${condition}]* ${message}` }),
     });
   } catch (err) {
-    console.error(`[alertManager] Slack webhook failed: ${err.message}`);
+    logger.error(`[alertManager] Slack webhook failed: ${err.message}`);
   }
 }
 
@@ -94,7 +97,7 @@ async function sendPagerDuty(condition, message) {
       }),
     });
   } catch (err) {
-    console.error(`[alertManager] PagerDuty API failed: ${err.message}`);
+    logger.error(`[alertManager] PagerDuty API failed: ${err.message}`);
   }
 }
 
@@ -110,7 +113,7 @@ async function sendPagerDuty(condition, message) {
 export async function fireAlert(condition, message) {
   if (_active.has(condition)) return;
   _active.set(condition, Date.now());
-  console.warn(`[alertManager] ALERT ${condition}: ${message}`);
+  logger.warn(`[alertManager] ALERT ${condition}: ${message}`);
   await Promise.all([sendSlack(condition, message), sendPagerDuty(condition, message)]);
 }
 
@@ -122,7 +125,7 @@ export async function fireAlert(condition, message) {
 export function resolveAlert(condition) {
   if (_active.has(condition)) {
     _active.delete(condition);
-    console.log(`[alertManager] RESOLVED ${condition}`);
+    logger.info(`[alertManager] RESOLVED ${condition}`);
   }
 }
 

--- a/indexer/src/api.js
+++ b/indexer/src/api.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 import express from "express";
 import http from "http";
 import path from "path";
@@ -127,10 +128,10 @@ function createHttpLogger(logDestination) {
         if (logDestination && typeof logDestination.write === "function") {
           logDestination.write(line);
         } else {
-          console.log(line.trim());
+          logger.info(line.trim());
         }
       } catch (e) {
-        console.log(line.trim());
+        logger.info(line.trim());
       }
     });
     next();
@@ -325,7 +326,7 @@ export function createApi({ logDestination, dbOverride } = {}) {
   // the 500ms flush loop's first tick, even when createApi() is invoked
   // directly (tests) rather than via index.js's startAuditPartitionCron().
   ensureAuditPartitions().catch((err) =>
-    console.error("[api] Startup audit partition check failed:", err.message),
+    logger.error("[api] Startup audit partition check failed:", err.message),
   );
   app.use(auditLoggerMiddleware);
   app.use(apiKeyAuthenticator);
@@ -925,7 +926,7 @@ export function createApi({ logDestination, dbOverride } = {}) {
           });
         }
 
-        console.log(`ABI verified for contract ${id}:`, {
+        logger.info(`ABI verified for contract ${id}:`, {
           functionsVerified: functions.length,
           missing: verification.missingFunctions.length,
           mismatches: verification.argMismatch.length,
@@ -1657,7 +1658,7 @@ export function createApi({ logDestination, dbOverride } = {}) {
         verified: rows[0].verified
       });
     } catch (e) {
-      console.error('[POST /api/keys] Error:', e);
+      logger.error('[POST /api/keys] Error:', e);
       if (e.message.includes('duplicate key') || e.message.includes('unique constraint')) {
         return res.status(409).json({ error: 'An API key for this email already exists and is pending verification.' });
       }
@@ -1736,7 +1737,7 @@ export function createApi({ logDestination, dbOverride } = {}) {
         tier: keyRecord.tier
       });
     } catch (e) {
-      console.error('[GET /api/keys/verify] Error:', e);
+      logger.error('[GET /api/keys/verify] Error:', e);
       res.status(500).json({ error: e.message });
     }
   });
@@ -2322,7 +2323,7 @@ export function createApi({ logDestination, dbOverride } = {}) {
   const server = http.createServer(app);
   if (!runningUnderTest) attachWebSocketServer(server);
 
-  server.on("close", () => console.log("[api] server closed"));
+  server.on("close", () => logger.info("[api] server closed"));
 
   // During test runs we avoid calling `listen()` to prevent port conflicts
   // and background handles that outlive the Jest environment. Tests will
@@ -2331,7 +2332,7 @@ export function createApi({ logDestination, dbOverride } = {}) {
     return app;
   }
 
-  server.listen(PORT, () => console.log(`API listening on :${PORT}`));
+  server.listen(PORT, () => logger.info(`API listening on :${PORT}`));
   return server;
 }
 

--- a/indexer/src/audit/auditLogger.js
+++ b/indexer/src/audit/auditLogger.js
@@ -26,6 +26,8 @@
 import crypto from 'crypto';
 import cron from 'node-cron';
 import { pool } from '../db.js';
+import { logger } from '../logger.js';
+import { fireAlert, resolveAlert, ALERT_CONDITIONS } from '../alertManager.js';
 
 // ── Configuration ─────────────────────────────────────────────────────────────
 const FLUSH_INTERVAL_MS = 500;
@@ -94,14 +96,14 @@ async function _flushQueue() {
       params,
     );
   } catch (err) {
-    console.error('[auditLogger] Batch INSERT failed:', err.message);
+    logger.error('[auditLogger] Batch INSERT failed:', err.message);
     // Re-queue the batch so it is retried on the next flush cycle, up to
     // MAX_FLUSH_ATTEMPTS. Prepend so ordering is roughly preserved.
     const retryable = [];
     for (const entry of batch) {
       const attempts = (entry._flushAttempts ?? 0) + 1;
       if (attempts > MAX_FLUSH_ATTEMPTS) {
-        console.error('[auditLogger] Dropping entry after', MAX_FLUSH_ATTEMPTS, 'failed attempts:', entry.endpoint);
+        logger.error('[auditLogger] Dropping entry after', MAX_FLUSH_ATTEMPTS, 'failed attempts:', entry.endpoint);
         continue;
       }
       entry._flushAttempts = attempts;
@@ -123,7 +125,7 @@ async function _flushQueue() {
 function startAuditFlush() {
   const interval = setInterval(() => {
     _flushQueue().catch((err) => {
-      console.error('[auditLogger] Flush interval error:', err.message);
+      logger.error('[auditLogger] Flush interval error:', err.message);
     });
   }, FLUSH_INTERVAL_MS);
   interval.unref();
@@ -178,7 +180,7 @@ function auditLoggerMiddleware(req, res, next) {
       });
     } catch (err) {
       // Never let audit logging affect the request lifecycle.
-      console.error('[auditLogger] Failed to enqueue entry:', err.message);
+      logger.error('[auditLogger] Failed to enqueue entry:', err.message);
     }
   });
 
@@ -206,9 +208,14 @@ async function _ensurePartitionFor(date) {
        PARTITION OF api_audit_log
        FOR VALUES FROM ('${fromStr}') TO ('${toStr}')`,
     );
-    console.log(`[auditLogger] Ensured partition ${partitionName} (${fromStr} – ${toStr})`);
+    logger.info(`[auditLogger] Ensured partition ${partitionName} (${fromStr} – ${toStr})`);
+    resolveAlert(ALERT_CONDITIONS.AUDIT_PARTITION_FAILURE);
   } catch (err) {
-    console.error(`[auditLogger] Failed to create partition ${partitionName}:`, err.message);
+    logger.error(`[auditLogger] Failed to create partition ${partitionName}:`, err.message);
+    await fireAlert(
+      ALERT_CONDITIONS.AUDIT_PARTITION_FAILURE,
+      `Failed to create partition ${partitionName}: ${err.message}`,
+    );
   }
 }
 
@@ -256,7 +263,7 @@ function getPendingAuditPartitionWork() {
  */
 function startAuditPartitionCron() {
   ensureAuditPartitions().catch((err) =>
-    console.error('[auditLogger] Startup partition check failed:', err.message),
+    logger.error('[auditLogger] Startup partition check failed:', err.message),
   );
 
   return cron.schedule('0 1 1 * *', async () => {
@@ -281,14 +288,18 @@ function startAuditPartitionCron() {
         if (partDate && partDate < cutoff) {
           try {
             await pool.query(`DROP TABLE IF EXISTS ${partition_name}`);
-            console.log(`[auditLogger] Dropped old partition ${partition_name}`);
+            logger.info(`[auditLogger] Dropped old partition ${partition_name}`);
           } catch (dropErr) {
-            console.error(`[auditLogger] Failed to drop partition ${partition_name}:`, dropErr.message);
+            logger.error(`[auditLogger] Failed to drop partition ${partition_name}:`, dropErr.message);
+            await fireAlert(
+              ALERT_CONDITIONS.AUDIT_PARTITION_FAILURE,
+              `Failed to drop partition ${partition_name}: ${dropErr.message}`,
+            );
           }
         }
       }
     } catch (err) {
-      console.error('[auditLogger] Partition cron error:', err.message);
+      logger.error('[auditLogger] Partition cron error:', err.message);
     }
   });
 }

--- a/indexer/src/auth/apiKeyAuth.js
+++ b/indexer/src/auth/apiKeyAuth.js
@@ -1,3 +1,4 @@
+import { logger } from "../logger.js";
 /**
  * API Key Authenticator Middleware
  *
@@ -282,7 +283,7 @@ async function apiKeyAuthenticator(req, res, next) {
 
     return next();
   } catch (err) {
-    console.error("[apiKeyAuth] Unexpected error:", err);
+    logger.error("[apiKeyAuth] Unexpected error:", err);
     return res.status(500).json({ error: "Internal server error" });
   }
 }

--- a/indexer/src/billing/stripeWebhook.js
+++ b/indexer/src/billing/stripeWebhook.js
@@ -1,3 +1,4 @@
+import { logger } from "../logger.js";
 /**
  * Stripe Webhook Handler
  *
@@ -42,7 +43,7 @@ stripeWebhookRouter.post(
     const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
 
     if (!webhookSecret) {
-      console.error('[stripeWebhook] STRIPE_WEBHOOK_SECRET is not set');
+      logger.error('[stripeWebhook] STRIPE_WEBHOOK_SECRET is not set');
       return res.status(500).json({ error: 'Webhook secret not configured' });
     }
 
@@ -56,7 +57,7 @@ stripeWebhookRouter.post(
     try {
       event = stripe.webhooks.constructEvent(req.body, sig, webhookSecret);
     } catch (err) {
-      console.warn('[stripeWebhook] Signature verification failed:', err.message);
+      logger.warn('[stripeWebhook] Signature verification failed:', err.message);
       return res.status(400).json({ error: 'Invalid signature' });
     }
 
@@ -64,7 +65,7 @@ stripeWebhookRouter.post(
       await _handleEvent(event);
       return res.status(200).json({ received: true });
     } catch (err) {
-      console.error('[stripeWebhook] Event handling error:', err.message);
+      logger.error('[stripeWebhook] Event handling error:', err.message);
       // Return 200 to prevent Stripe retrying an event we cannot process.
       // The error is logged for investigation.
       return res.status(200).json({ received: true, warning: err.message });
@@ -91,7 +92,7 @@ async function _handleEvent(event) {
 
     default:
       // Silently ignore unhandled event types.
-      console.log(`[stripeWebhook] Unhandled event type: ${event.type}`);
+      logger.info(`[stripeWebhook] Unhandled event type: ${event.type}`);
   }
 }
 
@@ -112,7 +113,7 @@ async function _handleSubscriptionUpdated(subscription) {
   const apiKeyId = subscription.metadata?.api_key_id;
 
   if (!apiKeyId) {
-    console.warn('[stripeWebhook] subscription.updated: no api_key_id in metadata, skipping');
+    logger.warn('[stripeWebhook] subscription.updated: no api_key_id in metadata, skipping');
     return;
   }
 
@@ -120,7 +121,7 @@ async function _handleSubscriptionUpdated(subscription) {
   const tier = _extractTierFromSubscription(subscription);
 
   if (!tier) {
-    console.warn('[stripeWebhook] subscription.updated: could not determine tier from product metadata');
+    logger.warn('[stripeWebhook] subscription.updated: could not determine tier from product metadata');
     return;
   }
 
@@ -129,7 +130,7 @@ async function _handleSubscriptionUpdated(subscription) {
     [tier, apiKeyId],
   );
 
-  console.log(`[stripeWebhook] Updated api_keys.tier → ${tier} for key ${apiKeyId}`);
+  logger.info(`[stripeWebhook] Updated api_keys.tier → ${tier} for key ${apiKeyId}`);
 }
 
 // ── customer.subscription.deleted ─────────────────────────────────────────────
@@ -143,7 +144,7 @@ async function _handleSubscriptionDeleted(subscription) {
   const apiKeyId = subscription.metadata?.api_key_id;
 
   if (!apiKeyId) {
-    console.warn('[stripeWebhook] subscription.deleted: no api_key_id in metadata, skipping');
+    logger.warn('[stripeWebhook] subscription.deleted: no api_key_id in metadata, skipping');
     return;
   }
 
@@ -152,7 +153,7 @@ async function _handleSubscriptionDeleted(subscription) {
     [apiKeyId],
   );
 
-  console.log(`[stripeWebhook] Downgraded api_keys.tier → free for key ${apiKeyId}`);
+  logger.info(`[stripeWebhook] Downgraded api_keys.tier → free for key ${apiKeyId}`);
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/indexer/src/burnDetector.js
+++ b/indexer/src/burnDetector.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /**
  * burnDetector.js
  *
@@ -102,7 +103,7 @@ export async function runBurnDetection() {
       if (!newAlerts.has(contractId)) alerts.delete(contractId);
     }
   } catch (err) {
-    console.error("[burnDetector] error:", err.message);
+    logger.error("[burnDetector] error:", err.message);
   }
 }
 
@@ -130,5 +131,5 @@ export function getBurnAlerts(contractId) {
 export function startBurnDetector() {
   runBurnDetection();
   setInterval(runBurnDetection, POLL_INTERVAL_MS);
-  console.log("[burnDetector] started, polling every", POLL_INTERVAL_MS / 1000, "s");
+  logger.info("[burnDetector] started, polling every", POLL_INTERVAL_MS / 1000, "s");
 }

--- a/indexer/src/cacheLayer.js
+++ b/indexer/src/cacheLayer.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /**
  * Multi-Tier Cache Layer
  *
@@ -131,10 +132,10 @@ async function _getRedis() {
   try {
     const { createClient } = await import("redis");
     _redis = createClient({ url });
-    _redis.on("error", (err) => console.warn("[cache:l2] error:", err.message));
+    _redis.on("error", (err) => logger.warn("[cache:l2] error:", err.message));
     await _redis.connect();
-    console.log("[cache:l2] connected:", url);
-    _setupPubSub(url).catch((e) => console.warn("[cache:pubsub] setup failed:", e.message));
+    logger.info("[cache:l2] connected:", url);
+    _setupPubSub(url).catch((e) => logger.warn("[cache:pubsub] setup failed:", e.message));
     
     // Register Redis client for health checks
     try {
@@ -144,7 +145,7 @@ async function _getRedis() {
       // Health module may not be available yet
     }
   } catch (err) {
-    console.warn("[cache:l2] unavailable, using L1 only:", err.message);
+    logger.warn("[cache:l2] unavailable, using L1 only:", err.message);
     _redis = null;
   }
   return _redis;
@@ -153,7 +154,7 @@ async function _getRedis() {
 async function _setupPubSub(url) {
   const { createClient } = await import("redis");
   _redisSub = createClient({ url });
-  _redisSub.on("error", (err) => console.warn("[cache:pubsub] error:", err.message));
+  _redisSub.on("error", (err) => logger.warn("[cache:pubsub] error:", err.message));
   await _redisSub.connect();
   await _redisSub.subscribe(INVALIDATION_CHANNEL, (message) => {
     try {
@@ -173,7 +174,7 @@ async function _setupPubSub(url) {
       /* malformed invalidation message — ignore */
     }
   });
-  console.log("[cache:pubsub] subscribed to", INVALIDATION_CHANNEL);
+  logger.info("[cache:pubsub] subscribed to", INVALIDATION_CHANNEL);
 }
 
 // ── Analytics ─────────────────────────────────────────────────────────────────
@@ -261,7 +262,7 @@ async function _getWithMeta(key, cacheType) {
         return { value, layer: "l2", xfetch: false };
       }
     } catch (err) {
-      console.warn("[cache:l2] get error:", err.message);
+      logger.warn("[cache:l2] get error:", err.message);
     }
   }
   _recordMiss("l2", cacheType);
@@ -311,7 +312,7 @@ export async function cacheSet(key, value, ttlOrType = "default", computeMs = 0)
       const wrapped = { __v: value, __computeMs: computeMs, __type: type };
       await redis.set(key, JSON.stringify(wrapped), { EX: l2Ttl });
     } catch (err) {
-      console.warn("[cache:l2] set error:", err.message);
+      logger.warn("[cache:l2] set error:", err.message);
     }
   }
 }
@@ -370,7 +371,7 @@ export async function cacheInvalidate(keyOrPattern) {
         }),
       );
     } catch (err) {
-      console.warn("[cache:invalidate] error:", err.message);
+      logger.warn("[cache:invalidate] error:", err.message);
     }
   }
 

--- a/indexer/src/cacheWarming.js
+++ b/indexer/src/cacheWarming.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /**
  * Cache Warming — pre-populate Redis with hot data on deploy.
  *
@@ -12,7 +13,7 @@ import { cacheSet } from "./cacheLayer.js";
 import { db } from "./db.js";
 
 export async function warmCache() {
-  console.log("[cache:warm] starting...");
+  logger.info("[cache:warm] starting...");
   const results = { warmed: 0, failed: 0 };
 
   // Warm the first 3 keyset pages of the events list (cursor chain, #490).
@@ -27,7 +28,7 @@ export async function warmCache() {
       if (result.next_cursor === null) break;
       after = result.next_cursor;
     } catch (e) {
-      console.warn(`[cache:warm] events page ${page} failed:`, e.message);
+      logger.warn(`[cache:warm] events page ${page} failed:`, e.message);
       results.failed++;
       break;
     }
@@ -48,9 +49,9 @@ export async function warmCache() {
       }
     }
   } catch (e) {
-    console.warn("[cache:warm] top contracts failed:", e.message);
+    logger.warn("[cache:warm] top contracts failed:", e.message);
     results.failed++;
   }
 
-  console.log(`[cache:warm] complete — warmed ${results.warmed}, failed ${results.failed}`);
+  logger.info(`[cache:warm] complete — warmed ${results.warmed}, failed ${results.failed}`);
 }

--- a/indexer/src/circuitBreakerIndexer.js
+++ b/indexer/src/circuitBreakerIndexer.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /**
  * Circuit Breaker Indexer
  * Monitors contract events for pause/unpause operations and updates circuit breaker status.
@@ -27,7 +28,7 @@ export async function processCircuitBreakerEvent(decoded, meta) {
     // Update circuit breaker status in database
     await db
       .updateCircuitBreakerStatus(decoded.contract_id, isPaused, decoded.ledger, decoded.tx_hash ?? null)
-      .catch((err) => console.error("[circuitBreakerIndexer] Failed to update status:", err.message));
+      .catch((err) => logger.error("[circuitBreakerIndexer] Failed to update status:", err.message));
   }
 }
 
@@ -59,6 +60,6 @@ export async function refreshCircuitBreakerStatus(contractId, meta) {
     // Update database
     await db.updateCircuitBreakerStatus(contractId, status.isPaused, status.lastStatusChange, status.txHash ?? null);
   } catch (err) {
-    console.error("[circuitBreakerIndexer] Failed to refresh status:", err.message);
+    logger.error("[circuitBreakerIndexer] Failed to refresh status:", err.message);
   }
 }

--- a/indexer/src/config.js
+++ b/indexer/src/config.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /**
  * Environment Configuration Validation
  *
@@ -306,10 +307,10 @@ let config;
 
 try {
   config = configSchema.parse(process.env);
-  console.log("[config] ✓ Environment variables validated successfully");
+  logger.info("[config] ✓ Environment variables validated successfully");
 } catch (error) {
-  console.error("\n❌ Configuration Validation Error\n");
-  console.error("Invalid environment variables detected. Please fix the following issues:\n");
+  logger.error("\n❌ Configuration Validation Error\n");
+  logger.error("Invalid environment variables detected. Please fix the following issues:\n");
   
   if (error instanceof z.ZodError) {
     error.issues.forEach((err, index) => {
@@ -318,21 +319,21 @@ try {
       const message = err.message;
       const receivedValue = process.env[envVar];
       
-      console.error(`${index + 1}. ${envVar}`);
-      console.error(`   Error: ${message}`);
+      logger.error(`${index + 1}. ${envVar}`);
+      logger.error(`   Error: ${message}`);
       if (receivedValue !== undefined) {
-        console.error(`   Received: "${receivedValue}"`);
+        logger.error(`   Received: "${receivedValue}"`);
       } else {
-        console.error(`   Received: (not set)`);
+        logger.error(`   Received: (not set)`);
       }
-      console.error("");
+      logger.error("");
     });
   } else {
-    console.error(error);
+    logger.error(error);
   }
   
-  console.error("Please check your .env file or environment variables and try again.\n");
-  console.error("See .env.example for reference configuration.\n");
+  logger.error("Please check your .env file or environment variables and try again.\n");
+  logger.error("See .env.example for reference configuration.\n");
   
   process.exit(1);
 }

--- a/indexer/src/contractVerifier.js
+++ b/indexer/src/contractVerifier.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /**
  * contractVerifier.js
  *
@@ -103,7 +104,7 @@ async function runVerificationBatch() {
         await db.setContractVerified(contract.id, isVerified, isVerified ? onChain.ledger : null);
         processed++;
       } catch (err) {
-        console.error(`[verifier] Error verifying ${contract.id}:`, err.message);
+        logger.error(`[verifier] Error verifying ${contract.id}:`, err.message);
       }
     }
 
@@ -112,20 +113,20 @@ async function runVerificationBatch() {
   }
 
   if (processed > 0) {
-    console.log(`[verifier] Verified ${processed} contracts`);
+    logger.info(`[verifier] Verified ${processed} contracts`);
   }
 }
 
 /** Start the background verification cron job. */
 export function startContractVerifier() {
-  console.log(`[verifier] Scheduling ABI verification (${VERIFY_CRON})`);
+  logger.info(`[verifier] Scheduling ABI verification (${VERIFY_CRON})`);
   // Run once on startup
   runVerificationBatch().catch((err) =>
-    console.error('[verifier] Initial verification batch failed:', err.message),
+    logger.error('[verifier] Initial verification batch failed:', err.message),
   );
   cron.schedule(VERIFY_CRON, () => {
     runVerificationBatch().catch((err) =>
-      console.error('[verifier] Verification batch failed:', err.message),
+      logger.error('[verifier] Verification batch failed:', err.message),
     );
   });
 }

--- a/indexer/src/deadLetterQueue.js
+++ b/indexer/src/deadLetterQueue.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /**
  * Issue #209 — Dead Letter Queue (DLQ)
  *
@@ -75,7 +76,7 @@ export async function enqueue(rawEvent, error) {
   );
 
   const id = rows[0].id;
-  console.warn(`[dlq] enqueued entry id=${id} transient=${transient} error="${error.message}"`);
+  logger.warn(`[dlq] enqueued entry id=${id} transient=${transient} error="${error.message}"`);
   return id;
 }
 
@@ -106,7 +107,7 @@ export async function processRetries(handler) {
       await handler(entry.raw_event);
       await db.query(`UPDATE dead_letter_queue SET resolved = TRUE, updated_at = NOW() WHERE id = $1`, [entry.id]);
       resolved++;
-      console.log(`[dlq] entry id=${entry.id} resolved on retry ${entry.retry_count + 1}`);
+      logger.info(`[dlq] entry id=${entry.id} resolved on retry ${entry.retry_count + 1}`);
     } catch (err) {
       const newCount = entry.retry_count + 1;
       const exhausted = newCount >= entry.max_retries;
@@ -118,7 +119,7 @@ export async function processRetries(handler) {
         [newCount, nextRetry, err.message, entry.id],
       );
       failed++;
-      console.warn(
+      logger.warn(
         `[dlq] entry id=${entry.id} retry ${newCount} failed: ${err.message}${exhausted ? " (retries exhausted)" : ""}`,
       );
     }
@@ -168,7 +169,7 @@ export async function getDlqDepth() {
  */
 export async function resolve(id) {
   await db.query(`UPDATE dead_letter_queue SET resolved = TRUE, updated_at = NOW() WHERE id = $1`, [id]);
-  console.log(`[dlq] entry id=${id} manually resolved`);
+  logger.info(`[dlq] entry id=${id} manually resolved`);
 }
 
 /**
@@ -185,7 +186,7 @@ export async function replay(id, handler) {
   try {
     await handler(entry.raw_event);
     await db.query(`UPDATE dead_letter_queue SET resolved = TRUE, updated_at = NOW() WHERE id = $1`, [id]);
-    console.log(`[dlq] entry id=${id} replayed successfully`);
+    logger.info(`[dlq] entry id=${id} replayed successfully`);
   } catch (err) {
     await db.query(
       `UPDATE dead_letter_queue

--- a/indexer/src/decoder.js
+++ b/indexer/src/decoder.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 import { scValToNative } from "@stellar/stellar-sdk";
 import { db } from "./db.js";
 import { detectSac, detectSacAsset, sacLabel } from "./sac.js";
@@ -368,7 +369,7 @@ async function decodeEvent(ev, { currentAbi = false } = {}) {
       contract_id: contractId,
       ledger: ev.ledger,
       ...roleAssignment,
-    }).catch((err) => console.error("[roleTracker] upsertRole failed:", err.message));
+    }).catch((err) => logger.error("[roleTracker] upsertRole failed:", err.message));
   }
 
   return decoded;
@@ -439,7 +440,7 @@ async function classicAssetLabel(code, issuer, assetType) {
       name: resolved.name,
       domain: resolved.domain,
       decimals: resolved.decimals,
-    }).catch((err) => console.error("[assets] upsertAsset failed:", err.message));
+    }).catch((err) => logger.error("[assets] upsertAsset failed:", err.message));
   }
   return resolved?.name ? `${code} (${resolved.name})` : code;
 }

--- a/indexer/src/dependencyScanner.js
+++ b/indexer/src/dependencyScanner.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /* global fetch */
 const CRATES_API_BASE = "https://crates.io/api/v1/crates";
 
@@ -93,7 +94,7 @@ async function fetchLatestCrateVersion(crateName) {
       return latest;
     }
   } catch (err) {
-    console.warn(`Unable to fetch latest version for ${crateName}:`, err?.message ?? err);
+    logger.warn(`Unable to fetch latest version for ${crateName}:`, err?.message ?? err);
   }
 
   return null;

--- a/indexer/src/emailService.js
+++ b/indexer/src/emailService.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /**
  * Email Service
  *
@@ -76,7 +77,7 @@ async function sendEmail({ to, subject, html, text }) {
       });
     }
   } catch (error) {
-    console.error('[EmailService] Failed to send email:', error);
+    logger.error('[EmailService] Failed to send email:', error);
     throw new Error(`Failed to send email: ${error.message}`);
   }
 }

--- a/indexer/src/gasGuzzlers.js
+++ b/indexer/src/gasGuzzlers.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /**
  * Daily Gas Consumption Leaderboard
  *
@@ -51,9 +52,9 @@ async function refresh() {
     );
     _cache = rows;
     _lastUpdated = new Date().toISOString();
-    console.log(`[gasGuzzlers] leaderboard refreshed — ${rows.length} contracts ranked`);
+    logger.info(`[gasGuzzlers] leaderboard refreshed — ${rows.length} contracts ranked`);
   } catch (err) {
-    console.error("[gasGuzzlers] refresh failed:", err.message);
+    logger.error("[gasGuzzlers] refresh failed:", err.message);
   }
 }
 

--- a/indexer/src/githubAbiSync.js
+++ b/indexer/src/githubAbiSync.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /**
  * githubAbiSync.js
  *
@@ -39,7 +40,7 @@ async function ghFetch(url) {
   if (res.status === 403 || res.status === 429) {
     const reset = res.headers.get("x-ratelimit-reset");
     const waitMs = reset ? Number(reset) * 1000 - Date.now() : 60_000;
-    console.warn(`[abi-sync] GitHub rate-limited. Retrying after ${Math.ceil(waitMs / 1000)}s`);
+    logger.warn(`[abi-sync] GitHub rate-limited. Retrying after ${Math.ceil(waitMs / 1000)}s`);
     await new Promise((r) => setTimeout(r, Math.max(waitMs, 0)));
     return ghFetch(url);
   }
@@ -56,7 +57,7 @@ async function syncAbis() {
   try {
     entries = await ghFetch(dirUrl);
   } catch (err) {
-    console.error("[abi-sync] Failed to list ABI directory:", err.message);
+    logger.error("[abi-sync] Failed to list ABI directory:", err.message);
     return;
   }
 
@@ -72,7 +73,7 @@ async function syncAbis() {
       const meta = typeof raw === "string" ? JSON.parse(raw) : raw;
 
       if (!meta.id || !meta.name) {
-        console.warn(`[abi-sync] Skipping ${file.name}: missing id or name`);
+        logger.warn(`[abi-sync] Skipping ${file.name}: missing id or name`);
         continue;
       }
 
@@ -87,16 +88,16 @@ async function syncAbis() {
 
       existing ? updated++ : added++;
     } catch (err) {
-      console.error(`[abi-sync] Error processing ${file.name}:`, err.message);
+      logger.error(`[abi-sync] Error processing ${file.name}:`, err.message);
       errors++;
     }
   }
 
-  console.log(`[abi-sync] Sync complete — added: ${added}, updated: ${updated}, errors: ${errors}`);
+  logger.info(`[abi-sync] Sync complete — added: ${added}, updated: ${updated}, errors: ${errors}`);
 }
 
 export function startAbiSync() {
-  console.log(`[abi-sync] Scheduling ABI sync (${SYNC_CRON}) from ${ABI_REPO}/${ABI_PATH}`);
+  logger.info(`[abi-sync] Scheduling ABI sync (${SYNC_CRON}) from ${ABI_REPO}/${ABI_PATH}`);
   // Run once immediately on startup, then on schedule
   syncAbis();
   cron.schedule(SYNC_CRON, syncAbis);

--- a/indexer/src/graphql.js
+++ b/indexer/src/graphql.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /**
  * GraphQL Interface for Contract Events
  *
@@ -537,10 +538,10 @@ export function attachGraphQL(app) {
     }
   });
 
-  console.log("[graphql] Endpoint mounted at /graphql with security limits:");
-  console.log(`[graphql]   Max depth: ${config.MAX_GRAPHQL_DEPTH}`);
-  console.log(`[graphql]   Max complexity: ${config.MAX_GRAPHQL_COMPLEXITY}`);
-  console.log(`[graphql]   Introspection: ${process.env.NODE_ENV !== 'production' ? 'enabled' : 'auth required'}`);
+  logger.info("[graphql] Endpoint mounted at /graphql with security limits:");
+  logger.info(`[graphql]   Max depth: ${config.MAX_GRAPHQL_DEPTH}`);
+  logger.info(`[graphql]   Max complexity: ${config.MAX_GRAPHQL_COMPLEXITY}`);
+  logger.info(`[graphql]   Introspection: ${process.env.NODE_ENV !== 'production' ? 'enabled' : 'auth required'}`);
 }
 
 // Export helper functions for testing

--- a/indexer/src/index.js
+++ b/indexer/src/index.js
@@ -30,7 +30,14 @@ import { checkForReorg, recordLedgerHash } from "./reorgWorker.js";
 import { startReDecodeWorker } from "./reDecodeWorker.js";
 import { warmCache } from "./cacheWarming.js";
 import { cacheInvalidate } from "./cacheLayer.js";
-import { eventsIngested, decodeLatency, rpcErrors, updateDbPoolMetrics, dlqDepth } from "./metrics.js";
+import {
+  eventsIngested,
+  decodeLatency,
+  rpcErrors,
+  updateDbPoolMetrics,
+  dlqDepth,
+  indexerLagLedgers,
+} from "./metrics.js";
 import { startUsageFlushCron, startRetentionCleanupCron } from "./usage/usageTracker.js";
 import { startAuditPartitionCron, startAuditFlush } from "./audit/auditLogger.js";
 import { updateIndexerStatus, updateWorkerStatus, updateDlqDepth } from "./health.js";
@@ -99,13 +106,13 @@ async function indexWasmUploads(txHashes, ledger) {
         const wasmBytes = hf.wasm();
         const meta = extractBuildMetadata(wasmBytes);
         await db.upsertWasmBuildMetadata({ ...meta, ledger, tx_hash: txHash });
-        console.log(
+        logger.info(
           `[${ledger}] WASM upload indexed: ${meta.wasm_hash.slice(0, 16)}… compiler=${meta.compiler ?? "unknown"}`,
         );
       }
     } catch (err) {
       // Non-fatal: log and continue
-      console.error(`[wasmUpload] tx ${txHash}: ${err.message}`);
+      logger.error(`[wasmUpload] tx ${txHash}: ${err.message}`);
     }
   }
 }
@@ -186,7 +193,7 @@ export async function processSingleEvent(rawSorobanEvent, context = undefined) {
 
   const upgrade = detectUpgrade(rawSorobanEvent);
   if (upgrade) {
-    console.log(
+    logger.info(
       `[${rawSorobanEvent.ledger}] CONTRACT UPGRADE ${rawSorobanEvent.contractId}: ${upgrade.oldHash} → ${upgrade.newHash}`,
     );
     decoded.upgrade = upgrade;
@@ -203,7 +210,7 @@ export async function processSingleEvent(rawSorobanEvent, context = undefined) {
   cacheInvalidate("wallet:events:*").catch(() => {});
   // Notify matching webhook subscriptions (non-blocking; failures retry via the DLQ).
   deliverWebhooksForEvent(decoded).catch((err) =>
-    console.error("[webhookDelivery] dispatch failed:", err.message),
+    logger.error("[webhookDelivery] dispatch failed:", err.message),
   );
 
   // Persist per-key state diffs for the timeline.
@@ -215,8 +222,8 @@ export async function processSingleEvent(rawSorobanEvent, context = undefined) {
   if (evictions.length) {
     await db
       .insertArchivalEvictions(evictions)
-      .catch((err) => console.error("[archivalEviction] insert failed:", err.message));
-    console.log(
+      .catch((err) => logger.error("[archivalEviction] insert failed:", err.message));
+    logger.info(
       `[${rawSorobanEvent.ledger}] EVICTED ${evictions.length} key(s) in tx ${rawSorobanEvent.txHash}`,
     );
   }
@@ -227,11 +234,11 @@ export async function processSingleEvent(rawSorobanEvent, context = undefined) {
   // Process circuit breaker events.
   if (contractMeta) {
     processCircuitBreakerEvent(decoded, contractMeta).catch((err) =>
-      console.error("[circuitBreakerIndexer] Error:", err.message),
+      logger.error("[circuitBreakerIndexer] Error:", err.message),
     );
   }
 
-  console.log(`[${rawSorobanEvent.ledger}] ${decoded.function}: ${decoded.description}`);
+  logger.info(`[${rawSorobanEvent.ledger}] ${decoded.function}: ${decoded.description}`);
   return decoded;
 }
 
@@ -291,7 +298,7 @@ async function indexLedger(ledger) {
     }
 
     // Scan transactions for UploadContractWasm operations (non-blocking)
-    indexWasmUploads(uniqueTxHashes, ledger).catch((err) => console.error("[wasmUpload] batch error:", err.message));
+    indexWasmUploads(uniqueTxHashes, ledger).catch((err) => logger.error("[wasmUpload] batch error:", err.message));
 
     // record the latest ledger hash for re-org detection
     if (res.latestLedger && res.latestLedgerHash) {
@@ -378,7 +385,7 @@ async function run() {
       // ── drain gap queue first ──────────────────────────────────────
       while (_gapQueue.length > 0 && !shutdown) {
         const gap = _gapQueue[0];
-        console.log(`[gap] re-indexing ledgers ${gap.from} → ${gap.to} (attempt ${gap.retries + 1}/${MAX_GAP_RETRIES})`);
+        logger.info(`[gap] re-indexing ledgers ${gap.from} → ${gap.to} (attempt ${gap.retries + 1}/${MAX_GAP_RETRIES})`);
         let gapOk = true;
         for (let ledger = gap.from; ledger <= gap.to; ledger++) {
           if (shutdown) break;
@@ -415,7 +422,7 @@ async function run() {
       }
 
       // ── normal forward indexing ────────────────────────────────────
-      console.log(`[daemon] polling from ledger ${_cursor}`);
+      logger.info(`[daemon] polling from ledger ${_cursor}`);
       const polledFrom = _cursor;
       const latest = await indexLedger(polledFrom);
       const latestLedger = latest.latestLedger ?? polledFrom;
@@ -425,6 +432,7 @@ async function run() {
       const lagSeconds = Math.floor((Date.now() - (polledFrom * 5000)) / 1000); // approximate lag
       const ledgerLag = Math.max(0, latestLedger - polledFrom);
       updateIndexerStatus(polledFrom, lagSeconds, ledgerLag);
+      indexerLagLedgers.set(ledgerLag);
 
       const immediateForkLedger = await checkForReorg(latestLedger, latestLedgerHash).catch((err) => {
         logger.error({ err: err.message, ledger: latestLedger }, "reorg fast-path check failed");

--- a/indexer/src/logger.js
+++ b/indexer/src/logger.js
@@ -21,12 +21,42 @@ function write(levelName, obj, msg) {
   }
 }
 
+function formatArg(a) {
+  if (a instanceof Error) return a.stack || a.message;
+  if (typeof a === "string") return a;
+  try {
+    return JSON.stringify(a);
+  } catch {
+    return String(a);
+  }
+}
+
+// Accepts either the structured form `(obj, msg?)` or a variadic console-like
+// form `(...parts)` so former `console.log/warn/error/debug` call sites can
+// route straight through the structured logger without rewriting their args.
+function makeLevelFn(levelName, ctx) {
+  return (...args) => {
+    let obj;
+    let msg;
+    if (args.length === 1 && typeof args[0] !== "string") {
+      obj = args[0];
+    } else if (typeof args[0] === "object" && args[0] !== null && !(args[0] instanceof Error)) {
+      obj = args[0];
+      msg = args.slice(1).map(formatArg).join(" ");
+    } else {
+      obj = {};
+      msg = args.map(formatArg).join(" ");
+    }
+    write(levelName, { ...ctx, ...obj }, msg);
+  };
+}
+
 function makeLogger(ctx = {}) {
   return {
-    debug: (obj, msg) => write("debug", { ...ctx, ...(typeof obj === "string" ? { msg: obj } : obj) }, msg),
-    info:  (obj, msg) => write("info",  { ...ctx, ...(typeof obj === "string" ? { msg: obj } : obj) }, msg),
-    warn:  (obj, msg) => write("warn",  { ...ctx, ...(typeof obj === "string" ? { msg: obj } : obj) }, msg),
-    error: (obj, msg) => write("error", { ...ctx, ...(typeof obj === "string" ? { msg: obj } : obj) }, msg),
+    debug: makeLevelFn("debug", ctx),
+    info: makeLevelFn("info", ctx),
+    warn: makeLevelFn("warn", ctx),
+    error: makeLevelFn("error", ctx),
     child: (extra) => makeLogger({ ...ctx, ...extra }),
   };
 }

--- a/indexer/src/metrics.js
+++ b/indexer/src/metrics.js
@@ -98,6 +98,13 @@ export const cacheMissTotal = new Counter({
   registers: [registry],
 });
 
+/** Current indexer lag behind chain tip, in ledgers. Backs the indexer-lag SLO. */
+export const indexerLagLedgers = new Gauge({
+  name: "soroban_indexer_lag_ledgers",
+  help: "Number of ledgers the indexer is behind the chain tip",
+  registers: [registry],
+});
+
 /** Histogram of HTTP request durations in seconds with labels. */
 export const apiRequestDuration = new Histogram({
   name: "api_request_duration_seconds",

--- a/indexer/src/migrate.js
+++ b/indexer/src/migrate.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /**
  * Zero-downtime migration runner.
  *
@@ -71,7 +72,7 @@ export async function runMigrations(pool) {
           "INSERT INTO schema_migrations (version) VALUES ($1)",
           [file],
         );
-        console.log(`[migrations] applied ${file} (non-transactional)`);
+        logger.info(`[migrations] applied ${file} (non-transactional)`);
         ran++;
       } catch (err) {
         throw new Error(`Migration ${file} failed: ${err.message}`);
@@ -88,7 +89,7 @@ export async function runMigrations(pool) {
         [file],
       );
       await client.query("COMMIT");
-      console.log(`[migrations] applied ${file}`);
+      logger.info(`[migrations] applied ${file}`);
       ran++;
     } catch (err) {
       await client.query("ROLLBACK");
@@ -98,7 +99,7 @@ export async function runMigrations(pool) {
     }
   }
 
-  if (ran === 0) console.log("[migrations] schema up to date");
+  if (ran === 0) logger.info("[migrations] schema up to date");
   return ran;
 }
 
@@ -112,7 +113,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     await runMigrations(pool);
     process.exitCode = 0;
   } catch (err) {
-    console.error(`[migrations] ${err.message}`);
+    logger.error(`[migrations] ${err.message}`);
     process.exitCode = 1;
   } finally {
     await pool.end();

--- a/indexer/src/optional/kafkaEventBus.js
+++ b/indexer/src/optional/kafkaEventBus.js
@@ -1,3 +1,4 @@
+import { logger } from "../logger.js";
 /**
  * Issue #209 — Kafka-Compatible Event Bus (Redis-backed)
  *
@@ -22,7 +23,7 @@ const DEDUP_TTL_S = config.KAFKA_BUS_DEDUP_TTL_S;
 const EVENT_TTL_S = config.KAFKA_BUS_EVENT_TTL_S;
 
 if (process.env.KAFKA_BROKERS) {
-  console.log(
+  logger.info(
     "[kafkaEventBus] KAFKA_BROKERS detected — configure kafkajs consumer to replace Redis transport for production throughput",
   );
 }
@@ -42,7 +43,7 @@ const _subClients = new Map();
 async function getPubClient() {
   if (!_pubClient) {
     _pubClient = createClient({ url: REDIS_URL });
-    _pubClient.on("error", (err) => console.error("[kafkaEventBus] pub Redis error:", err.message));
+    _pubClient.on("error", (err) => logger.error("[kafkaEventBus] pub Redis error:", err.message));
     await _pubClient.connect();
   }
   return _pubClient;
@@ -51,7 +52,7 @@ async function getPubClient() {
 async function getSubClient(key) {
   if (!_subClients.has(key)) {
     const client = createClient({ url: REDIS_URL });
-    client.on("error", (err) => console.error(`[kafkaEventBus] sub Redis error (${key}):`, err.message));
+    client.on("error", (err) => logger.error(`[kafkaEventBus] sub Redis error (${key}):`, err.message));
     await client.connect();
     _subClients.set(key, client);
   }
@@ -115,7 +116,7 @@ export async function createIdempotentConsumer(topic, groupId, handler) {
       await handler(payload, messageId);
     } catch (err) {
       await pubClient.sRem(dedupKey, messageId).catch(() => {});
-      console.error(`[kafkaEventBus] handler error (${groupId}/${messageId}): ${err.message}`);
+      logger.error(`[kafkaEventBus] handler error (${groupId}/${messageId}): ${err.message}`);
     }
   });
 
@@ -157,7 +158,7 @@ export async function replayStream(topic, groupId, handler) {
       await handler(payload, messageId);
     } catch (err) {
       await client.sRem(dedupKey, messageId).catch(() => {});
-      console.error(`[kafkaEventBus] replay error (${groupId}/${messageId}): ${err.message}`);
+      logger.error(`[kafkaEventBus] replay error (${groupId}/${messageId}): ${err.message}`);
     }
   }
 }

--- a/indexer/src/optional/leaderElection.js
+++ b/indexer/src/optional/leaderElection.js
@@ -1,3 +1,4 @@
+import { logger } from "../logger.js";
 /**
  * Issue #209 — Redis-Based Leader Election
  *
@@ -40,7 +41,7 @@ export function getInstanceId() {
 async function getClient() {
   if (!_client) {
     _client = createClient({ url: REDIS_URL });
-    _client.on("error", (err) => console.error("[leaderElection] Redis error:", err.message));
+    _client.on("error", (err) => logger.error("[leaderElection] Redis error:", err.message));
     await _client.connect();
   }
   return _client;
@@ -57,7 +58,7 @@ export async function tryAcquireLock() {
   const result = await client.set(LEADER_KEY, id, { NX: true, EX: LEASE_TTL_S });
   if (result === "OK") {
     _isLeader = true;
-    console.log(`[leaderElection] instance ${id} acquired leadership`);
+    logger.info(`[leaderElection] instance ${id} acquired leadership`);
     return true;
   }
   return false;
@@ -76,7 +77,7 @@ export async function renewLock() {
   const current = await client.get(LEADER_KEY);
   if (current !== id) {
     _isLeader = false;
-    console.warn(`[leaderElection] lost leadership — current leader is ${current}`);
+    logger.warn(`[leaderElection] lost leadership — current leader is ${current}`);
     return false;
   }
   await client.expire(LEADER_KEY, LEASE_TTL_S);
@@ -93,7 +94,7 @@ export async function releaseLock() {
   const current = await client.get(LEADER_KEY);
   if (current === id) {
     await client.del(LEADER_KEY);
-    console.log(`[leaderElection] instance ${id} released leadership`);
+    logger.info(`[leaderElection] instance ${id} released leadership`);
   }
   _isLeader = false;
 }
@@ -115,7 +116,7 @@ export function start({ onBecomeLeader, onLoseLeadership } = {}) {
   _renewTimer = setInterval(async () => {
     if (!_isLeader) return;
     const renewed = await renewLock().catch((err) => {
-      console.error("[leaderElection] renew error:", err.message);
+      logger.error("[leaderElection] renew error:", err.message);
       return false;
     });
     if (!renewed && _isLeader) {
@@ -127,7 +128,7 @@ export function start({ onBecomeLeader, onLoseLeadership } = {}) {
   _electionTimer = setInterval(async () => {
     if (_isLeader) return;
     const won = await tryAcquireLock().catch((err) => {
-      console.error("[leaderElection] election poll error:", err.message);
+      logger.error("[leaderElection] election poll error:", err.message);
       return false;
     });
     if (won) onBecomeLeader?.();

--- a/indexer/src/optional/rpcProviderPool.js
+++ b/indexer/src/optional/rpcProviderPool.js
@@ -1,3 +1,4 @@
+import { logger } from "../logger.js";
 /**
  * Issue #209 — Weighted RPC Provider Pool
  *
@@ -146,7 +147,7 @@ export async function call(method, ...args) {
       if (ledger) target.latestLedger = ledger;
       if (!target.healthy) {
         target.healthy = true;
-        console.log(`[rpcPool] provider ${target.url} recovered`);
+        logger.info(`[rpcPool] provider ${target.url} recovered`);
       }
       return result;
     } catch (err) {
@@ -154,9 +155,9 @@ export async function call(method, ...args) {
       target.recordOutcome(false, latency);
       if (target.errorRate >= 0.5) {
         target.healthy = false;
-        console.warn(`[rpcPool] provider ${target.url} marked unhealthy (error_rate=${target.errorRate.toFixed(2)})`);
+        logger.warn(`[rpcPool] provider ${target.url} marked unhealthy (error_rate=${target.errorRate.toFixed(2)})`);
       }
-      console.warn(`[rpcPool] provider ${target.url} failed (${err.message}), trying next`);
+      logger.warn(`[rpcPool] provider ${target.url} failed (${err.message}), trying next`);
     }
   }
 
@@ -189,7 +190,7 @@ setInterval(async () => {
         provider.latestLedger = res.sequence;
         provider.recordOutcome(true, Date.now() - start);
         provider.healthy = true;
-        console.log(`[rpcPool] provider ${provider.url} recovered`);
+        logger.info(`[rpcPool] provider ${provider.url} recovered`);
       } catch {
         provider.recordOutcome(false, Date.now() - start);
       }

--- a/indexer/src/pruner.js
+++ b/indexer/src/pruner.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /**
  * Automated Data Pruning Task for Temporary Storage Logs
  *
@@ -33,13 +34,13 @@ async function getCurrentLedger() {
 }
 
 async function pruneExpiredTemporaryData() {
-  console.log("[pruner] starting pruning run…");
+  logger.info("[pruner] starting pruning run…");
 
   const currentLedger = await getCurrentLedger();
   const expiryLedger = currentLedger - MAX_TEMP_TTL_LEDGERS - PRUNE_LEDGER_BUFFER;
 
   if (expiryLedger <= 0) {
-    console.log("[pruner] not enough ledger history yet, skipping");
+    logger.info("[pruner] not enough ledger history yet, skipping");
     return;
   }
 
@@ -64,19 +65,19 @@ async function pruneExpiredTemporaryData() {
   );
 
   const deleted = result.rowCount ?? 0;
-  console.log(`[pruner] deleted ${deleted} expired temporary-storage events (ledger < ${expiryLedger})`);
+  logger.info(`[pruner] deleted ${deleted} expired temporary-storage events (ledger < ${expiryLedger})`);
 
   // Also vacuum the table to reclaim space (non-blocking)
   await db.query("VACUUM ANALYZE events").catch(() => {});
-  console.log("[pruner] VACUUM ANALYZE complete");
+  logger.info("[pruner] VACUUM ANALYZE complete");
 
   return deleted;
 }
 
 export function startPruner() {
-  console.log(`[pruner] scheduled — cron: "${PRUNE_CRON}"`);
+  logger.info(`[pruner] scheduled — cron: "${PRUNE_CRON}"`);
   cron.schedule(PRUNE_CRON, () => {
-    pruneExpiredTemporaryData().catch((err) => console.error("[pruner] error:", err.message));
+    pruneExpiredTemporaryData().catch((err) => logger.error("[pruner] error:", err.message));
   });
 }
 
@@ -87,7 +88,7 @@ if (process.argv.includes("--run-now")) {
     await pruneExpiredTemporaryData();
     process.exit(0);
   })().catch((err) => {
-    console.error("[pruner] fatal:", err);
+    logger.error("[pruner] fatal:", err);
     process.exit(1);
   });
 }

--- a/indexer/src/rateLimit/abuseDetector.js
+++ b/indexer/src/rateLimit/abuseDetector.js
@@ -1,3 +1,4 @@
+import { logger } from "../logger.js";
 /**
  * Abuse Detector Middleware
  *
@@ -147,11 +148,11 @@ async function recordAuthFailure(ip, redis) {
     if (count > AUTH_FAIL_THRESHOLD) {
       const blockKey = `${ABUSE_BLOCK_PREFIX}:${ip}`;
       await redis.set(blockKey, '1', { EX: IP_BLOCK_TTL });
-      console.warn('[abuseDetector] IP blocked for auth brute-force:', ip);
+      logger.warn('[abuseDetector] IP blocked for auth brute-force:', ip);
     }
   } catch (err) {
     // Redis unavailable — log and continue.
-    console.warn('[abuseDetector] recordAuthFailure Redis error:', err.message);
+    logger.warn('[abuseDetector] recordAuthFailure Redis error:', err.message);
   }
 }
 
@@ -173,7 +174,7 @@ async function recordRateLimitBreach(clientId, redis) {
     }
 
     if (count > BREACH_THRESHOLD) {
-      console.warn(
+      logger.warn(
         JSON.stringify({
           level: 'warn',
           event: 'repeat_offender',
@@ -185,7 +186,7 @@ async function recordRateLimitBreach(clientId, redis) {
       );
     }
   } catch (err) {
-    console.warn('[abuseDetector] recordRateLimitBreach Redis error:', err.message);
+    logger.warn('[abuseDetector] recordRateLimitBreach Redis error:', err.message);
   }
 }
 
@@ -270,7 +271,7 @@ async function checkScrapingPattern(clientId, path, originalLimit, redis) {
       const penaltyKey = `${ABUSE_PENALTY_PREFIX}:${clientId}:*`;
       await redis.set(penaltyKey, '1', { EX: SCRAPE_PENALTY_TTL });
 
-      console.warn(
+      logger.warn(
         JSON.stringify({
           level: 'warn',
           event: 'scraping_detected',
@@ -374,7 +375,7 @@ function notifyCloudflare(endpoint, distinctIps) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
   }).catch((err) => {
-    console.warn('[abuseDetector] Cloudflare webhook notification failed:', err.message);
+    logger.warn('[abuseDetector] Cloudflare webhook notification failed:', err.message);
   });
 }
 
@@ -481,7 +482,7 @@ async function abuseDetector(req, res, next) {
           const ddosKey = `${ABUSE_DDOS_PREFIX}:${endpoint}:${window}`;
           const distinctIps = await r.pfCount(ddosKey).catch(() => 0);
 
-          console.warn(
+          logger.warn(
             JSON.stringify({
               level: 'warn',
               event: 'ddos_detected',

--- a/indexer/src/rateLimit/geoIpLimiter.js
+++ b/indexer/src/rateLimit/geoIpLimiter.js
@@ -1,3 +1,4 @@
+import { logger } from "../logger.js";
 /**
  * GeoIP Rate Limiter Middleware
  *
@@ -41,7 +42,7 @@ async function getMaxmindReader() {
   if (!dbPath) return null;
 
   if (!existsSync(dbPath)) {
-    console.warn('[geoIpLimiter] GeoLite2 database file not found at:', dbPath);
+    logger.warn('[geoIpLimiter] GeoLite2 database file not found at:', dbPath);
     return null;
   }
 
@@ -50,9 +51,9 @@ async function getMaxmindReader() {
     const maxmind = await import('maxmind');
     const open = maxmind.default?.open ?? maxmind.open;
     _maxmindReader = await open(dbPath);
-    console.log('[geoIpLimiter] MaxMind GeoLite2-Country database loaded from:', dbPath);
+    logger.info('[geoIpLimiter] MaxMind GeoLite2-Country database loaded from:', dbPath);
   } catch (err) {
-    console.warn('[geoIpLimiter] Failed to load MaxMind database:', err.message);
+    logger.warn('[geoIpLimiter] Failed to load MaxMind database:', err.message);
     _maxmindReader = null;
   }
 
@@ -95,7 +96,7 @@ function getRateMultipliers() {
     }
     return result;
   } catch {
-    console.warn('[geoIpLimiter] Failed to parse GEO_RATE_MULTIPLIERS — using empty map');
+    logger.warn('[geoIpLimiter] Failed to parse GEO_RATE_MULTIPLIERS — using empty map');
     return {};
   }
 }
@@ -183,7 +184,7 @@ async function geoIpRateLimiter(req, res, next) {
 
     return next();
   } catch (err) {
-    console.error('[geoIpLimiter] Unexpected error:', err.message);
+    logger.error('[geoIpLimiter] Unexpected error:', err.message);
     // Fail open — do not block requests on unexpected errors.
     return next();
   }

--- a/indexer/src/rateLimit/tokenBucket.js
+++ b/indexer/src/rateLimit/tokenBucket.js
@@ -1,3 +1,4 @@
+import { logger } from "../logger.js";
 /**
  * Token Bucket Rate Limiter Middleware
  *
@@ -58,15 +59,15 @@ async function getRedisClient() {
   try {
     const client = createClient({ url });
     client.on('error', (err) => {
-      console.warn('[tokenBucket] Redis error:', err.message);
+      logger.warn('[tokenBucket] Redis error:', err.message);
       _redis = null;
       _redisConnecting = false;
     });
     await client.connect();
     _redis = client;
-    console.log('[tokenBucket] Redis connected:', url);
+    logger.info('[tokenBucket] Redis connected:', url);
   } catch (err) {
-    console.warn('[tokenBucket] Redis unavailable, using in-process fallback:', err.message);
+    logger.warn('[tokenBucket] Redis unavailable, using in-process fallback:', err.message);
     _redis = null;
   } finally {
     _redisConnecting = false;
@@ -212,7 +213,7 @@ async function tokenBucketMiddleware(req, res, next) {
         usedFallback = true;
       }
     } catch (redisErr) {
-      console.warn('[tokenBucket] Redis CL.THROTTLE failed, using in-process fallback:', redisErr.message);
+      logger.warn('[tokenBucket] Redis CL.THROTTLE failed, using in-process fallback:', redisErr.message);
       usedFallback = true;
     }
 
@@ -243,7 +244,7 @@ async function tokenBucketMiddleware(req, res, next) {
 
     return next();
   } catch (err) {
-    console.error('[tokenBucket] Unexpected error:', err);
+    logger.error('[tokenBucket] Unexpected error:', err);
     // Fail open — do not block the request on an unexpected internal error.
     return next();
   }

--- a/indexer/src/reDecodeWorker.js
+++ b/indexer/src/reDecodeWorker.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 import { db } from "./db.js";
 import { decode } from "./decoder.js";
 
@@ -49,7 +50,7 @@ export async function runReDecodeBatch({ dbModule = db, decodeFn = decode, batch
       await dbModule.updateRedecodedEvent(row.seq, decoded, Number(meta.abi_version));
       processed++;
     } catch (error) {
-      console.error(`[redecode] event ${row.seq} failed: ${error.message}`);
+      logger.error(`[redecode] event ${row.seq} failed: ${error.message}`);
     }
   }
   return processed;
@@ -76,8 +77,8 @@ export function startReDecodeWorker({
     }
   };
 
-  const timer = setInterval(() => tick().catch((error) => console.error("[redecode] worker failed:", error.message)), intervalMs);
+  const timer = setInterval(() => tick().catch((error) => logger.error("[redecode] worker failed:", error.message)), intervalMs);
   timer.unref?.();
-  tick().catch((error) => console.error("[redecode] initial run failed:", error.message));
+  tick().catch((error) => logger.error("[redecode] initial run failed:", error.message));
   return () => clearInterval(timer);
 }

--- a/indexer/src/reorgWorker.js
+++ b/indexer/src/reorgWorker.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /**
  * Ledger Re-org Detection & Rollback Worker 
  *
@@ -26,7 +27,7 @@ async function getRecentLedgerHashes(limit = config.REORG_CHECK_INTERVAL + confi
 /** Delete orphaned rows and atomically persist the rewind cursor. */
 export async function rollback(forkLedger) {
   await db.rollbackFromLedger(forkLedger);
-  console.warn(`[reorg] Rolled back ledger ${forkLedger}+`);
+  logger.warn(`[reorg] Rolled back ledger ${forkLedger}+`);
 }
 
 // ── Core check ────────────────────────────────────────────────────────────────
@@ -90,12 +91,12 @@ export async function checkForReorg(latestLedgerOrRpc, latestLedgerHashOrDepende
     const latestEntry = stored.find((row) => Number(row.ledger) === latestLedger);
     if (!latestEntry) return null;
     if (latestEntry.hash !== latestLedgerHash) {
-      console.warn(`[reorg] Mismatch at ledger ${latestLedger}: stored=${latestEntry.hash} network=${latestLedgerHash}`);
+      logger.warn(`[reorg] Mismatch at ledger ${latestLedger}: stored=${latestEntry.hash} network=${latestLedgerHash}`);
       await rollbackFork(latestLedger);
       try {
         await alertReorg(latestLedger);
       } catch (err) {
-        console.error(`[reorg] Alert failed at ledger ${latestLedger}: ${err.message}`);
+        logger.error(`[reorg] Alert failed at ledger ${latestLedger}: ${err.message}`);
       }
       return latestLedger;
     }
@@ -115,7 +116,7 @@ export async function checkForReorg(latestLedgerOrRpc, latestLedgerHashOrDepende
     }
 
     if (networkHash && networkHash !== hash) {
-      console.warn(`[reorg] Mismatch at ledger ${ledgerNumber}: stored=${hash} network=${networkHash}`);
+      logger.warn(`[reorg] Mismatch at ledger ${ledgerNumber}: stored=${hash} network=${networkHash}`);
       earliestFork = earliestFork === null ? ledgerNumber : Math.min(earliestFork, ledgerNumber);
     }
   }
@@ -126,7 +127,7 @@ export async function checkForReorg(latestLedgerOrRpc, latestLedgerHashOrDepende
   try {
     await alertReorg(earliestFork);
   } catch (err) {
-    console.error(`[reorg] Alert failed at ledger ${earliestFork}: ${err.message}`);
+    logger.error(`[reorg] Alert failed at ledger ${earliestFork}: ${err.message}`);
   }
   return earliestFork;
 }
@@ -149,7 +150,7 @@ export function startReorgWorker(rpc, cursorRef, intervalMs = 30_000) {
   let running = true;
 
   (async () => {
-    console.log("[reorg] Worker started");
+    logger.info("[reorg] Worker started");
 
     while (running) {
       await new Promise((r) => setTimeout(r, intervalMs));
@@ -159,10 +160,10 @@ export function startReorgWorker(rpc, cursorRef, intervalMs = 30_000) {
         const forkLedger = await checkForReorg(rpc);
         if (forkLedger !== null) {
           cursorRef.setCursor(forkLedger); // rewind main loop
-          console.log(`[reorg] Cursor rewound to ${forkLedger}`);
+          logger.info(`[reorg] Cursor rewound to ${forkLedger}`);
         }
       } catch (err) {
-        console.error("[reorg] Check failed:", err.message);
+        logger.error("[reorg] Check failed:", err.message);
       }
     }
   })();

--- a/indexer/src/rpcMetrics.js
+++ b/indexer/src/rpcMetrics.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /**
  * RPC Node Performance Metrics
  *
@@ -64,7 +65,7 @@ export function startMetricsCollector() {
   RPC_URLS.forEach(probe);
 
   setInterval(() => RPC_URLS.forEach(probe), PROBE_INTERVAL_MS);
-  console.log(`[rpc-metrics] probing ${RPC_URLS.length} node(s) every ${PROBE_INTERVAL_MS}ms`);
+  logger.info(`[rpc-metrics] probing ${RPC_URLS.length} node(s) every ${PROBE_INTERVAL_MS}ms`);
 }
 
 export function getMetrics() {

--- a/indexer/src/rpcMultiNode.js
+++ b/indexer/src/rpcMultiNode.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /**
  * Multi-Node RPC Validation Client
  *
@@ -85,7 +86,7 @@ async function callWithFailover(method, ...args) {
       // Check if this node is lagging behind the best known ledger
       const bestLedger = Math.max(...nodes.map((n) => n.latestLedger));
       if (bestLedger - node.latestLedger > LAG_THRESHOLD) {
-        console.warn(`[rpc-multi] node ${node.url} is ${bestLedger - node.latestLedger} ledgers behind, switching`);
+        logger.warn(`[rpc-multi] node ${node.url} is ${bestLedger - node.latestLedger} ledgers behind, switching`);
         node.healthy = false;
         primaryIndex = nextHealthy(idx);
         idx = primaryIndex;
@@ -94,14 +95,14 @@ async function callWithFailover(method, ...args) {
 
       // Promote to primary if we had to fail over
       if (idx !== primaryIndex) {
-        console.log(`[rpc-multi] promoting ${node.url} to primary`);
+        logger.info(`[rpc-multi] promoting ${node.url} to primary`);
         primaryIndex = idx;
       }
 
       return result;
     } catch (err) {
       recordOutcome(node, false, Date.now() - start);
-      console.warn(`[rpc-multi] node ${node.url} failed (${err.message}), trying next`);
+      logger.warn(`[rpc-multi] node ${node.url} failed (${err.message}), trying next`);
       node.healthy = false;
       idx = nextHealthy(idx);
     }
@@ -115,23 +116,23 @@ async function callWithFailover(method, ...args) {
 // (e.g. in tests) must not have the side effect of scheduling network calls.
 // unref() defensively, so even a direct call from a test can't keep the
 // process alive on its own.
+async function checkNodeRecovery(node) {
+  const start = Date.now();
+  try {
+    const res = await withTimeout(node.server.getLatestLedger(), CALL_TIMEOUT_MS);
+    recordOutcome(node, true, Date.now() - start);
+    node.latestLedger = res.sequence;
+    node.healthy = true;
+    logger.info(`[rpc-multi] node ${node.url} recovered`);
+  } catch {
+    recordOutcome(node, false, Date.now() - start);
+    // still down
+  }
+}
+
 export function startNodeRecoveryPoll() {
   const interval = setInterval(async () => {
-    for (const node of nodes) {
-      if (!node.healthy) {
-        const start = Date.now();
-        try {
-          const res = await withTimeout(node.server.getLatestLedger(), CALL_TIMEOUT_MS);
-          recordOutcome(node, true, Date.now() - start);
-          node.latestLedger = res.sequence;
-          node.healthy = true;
-          console.log(`[rpc-multi] node ${node.url} recovered`);
-        } catch {
-          recordOutcome(node, false, Date.now() - start);
-          // still down
-        }
-      }
-    }
+    await Promise.all(nodes.filter((node) => !node.healthy).map(checkNodeRecovery));
   }, config.RPC_RECOVERY_INTERVAL_MS);
   interval.unref();
 }

--- a/indexer/src/rpcRetry.js
+++ b/indexer/src/rpcRetry.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 export async function withRetry(fn, { maxAttempts = 5, baseDelayMs = 100 } = {}) {
   let lastError;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
@@ -8,7 +9,7 @@ export async function withRetry(fn, { maxAttempts = 5, baseDelayMs = 100 } = {})
       const isRetryable = isRetryableError(err);
       if (!isRetryable || attempt === maxAttempts) throw err;
       const delay = Math.pow(2, attempt) * baseDelayMs;
-      console.warn(`[rpc-retry] attempt ${attempt}/${maxAttempts} failed (${err.message}), retrying in ${delay}ms`);
+      logger.warn(`[rpc-retry] attempt ${attempt}/${maxAttempts} failed (${err.message}), retrying in ${delay}ms`);
       await new Promise((r) => setTimeout(r, delay));
     }
   }

--- a/indexer/src/rwaDecoder.js
+++ b/indexer/src/rwaDecoder.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /**
  * RWA Token Activity Decoder
  * Decodes Franklin Templeton Benji and other RWA token actions.
@@ -352,7 +353,7 @@ export function decodeRwaEvent(event, meta) {
 
     return decoder(event.function, args, _data);
   } catch (err) {
-    console.error("[RWA Decoder] Error decoding event:", err);
+    logger.error("[RWA Decoder] Error decoding event:", err);
     return null;
   }
 }

--- a/indexer/src/usage/usageTracker.js
+++ b/indexer/src/usage/usageTracker.js
@@ -1,3 +1,4 @@
+import { logger } from "../logger.js";
 /**
  * Usage Tracker
  *
@@ -68,7 +69,7 @@ async function recordRequest(keyId, endpoint, responseBytes, isRateLimited) {
     pipeline.incr(`${base}:endpoint:${endpointGroup}`);
     await pipeline.exec();
   } catch (err) {
-    console.warn('[usageTracker] Failed to record request in Redis:', err.message);
+    logger.warn('[usageTracker] Failed to record request in Redis:', err.message);
   }
 }
 
@@ -162,12 +163,12 @@ function startUsageFlushCron() {
             await redis.del(keys);
           }
         } catch (dbErr) {
-          console.error(`[usageTracker] DB upsert failed for key ${keyId}/${date}:`, dbErr.message);
+          logger.error(`[usageTracker] DB upsert failed for key ${keyId}/${date}:`, dbErr.message);
           // Leave Redis keys intact so the next run can retry.
         }
       }
     } catch (err) {
-      console.error('[usageTracker] Flush cron error:', err.message);
+      logger.error('[usageTracker] Flush cron error:', err.message);
     }
   });
 }
@@ -208,14 +209,14 @@ function startRetentionCleanupCron() {
             [tier, days],
           );
           if (rowCount > 0) {
-            console.log(`[usageTracker] Retention cleanup: deleted ${rowCount} rows for tier=${tier} (>${days}d)`);
+            logger.info(`[usageTracker] Retention cleanup: deleted ${rowCount} rows for tier=${tier} (>${days}d)`);
           }
         } catch (tierErr) {
-          console.error(`[usageTracker] Retention cleanup failed for tier ${tier}:`, tierErr.message);
+          logger.error(`[usageTracker] Retention cleanup failed for tier ${tier}:`, tierErr.message);
         }
       }
     } catch (err) {
-      console.error('[usageTracker] Retention cron error:', err.message);
+      logger.error('[usageTracker] Retention cron error:', err.message);
     }
   });
 }

--- a/indexer/src/vaultIndexer.js
+++ b/indexer/src/vaultIndexer.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /**
  * Vault / Treasury Indexer
  *
@@ -175,12 +176,12 @@ export async function refreshVaultRatio(contractId, ledger) {
     await db.upsertVaultSnapshot(snapshot);
     publishVaultRatio(snapshot);
 
-    console.log(
+    logger.info(
       `[vault] ${contractId.slice(0, 8)}… ratio=${ratio != null ? ratio.toFixed(6) : "N/A"} ` +
         `assets=${totalAssets} supply=${totalSupply} @ ledger=${ledger}`,
     );
   } catch (err) {
-    console.error(`[vault] Failed to refresh ratio for ${contractId}: ${err.message}`);
+    logger.error(`[vault] Failed to refresh ratio for ${contractId}: ${err.message}`);
   }
 }
 
@@ -204,7 +205,7 @@ export async function bootstrapVault(contractId) {
 
     await refreshVaultRatio(contractId, seq);
   } catch (err) {
-    console.error(`[vault] Failed to bootstrap ${contractId}: ${err.message}`);
+    logger.error(`[vault] Failed to bootstrap ${contractId}: ${err.message}`);
   }
 }
 
@@ -221,6 +222,6 @@ export async function refreshAllVaults() {
 
     await Promise.allSettled(ids.map((id) => refreshVaultRatio(id, seq)));
   } catch (err) {
-    console.error(`[vault] refreshAllVaults error: ${err.message}`);
+    logger.error(`[vault] refreshAllVaults error: ${err.message}`);
   }
 }

--- a/indexer/src/verify_abi.js
+++ b/indexer/src/verify_abi.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 import { rpc as SorobanRpc, xdr, StrKey } from "@stellar/stellar-sdk";
 import { withRetry } from "./rpcRetry.js";
 import { parseContractSpec } from "./wasmContractSpec.js";
@@ -67,7 +68,7 @@ export async function fetchContractSpecFull(contractId) {
     if (!wasm) return null;
     return parseContractSpec(wasm);
   } catch (err) {
-    console.error("Failed to fetch full contract spec:", err.message);
+    logger.error("Failed to fetch full contract spec:", err.message);
     return null;
   }
 }
@@ -91,7 +92,7 @@ export async function fetchContractSpec(contractId) {
       args: (fn.inputs ?? []).map((i) => ({ name: i.name, type: i.type })),
     }));
   } catch (err) {
-    console.error("Failed to fetch contract spec:", err.message);
+    logger.error("Failed to fetch contract spec:", err.message);
     return null;
   }
 }

--- a/indexer/src/webhookDelivery.js
+++ b/indexer/src/webhookDelivery.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /**
  * Webhook delivery — outbound POSTs to user-registered subscription URLs.
  *
@@ -225,7 +226,7 @@ export async function deliverWebhooksForEvent(decoded) {
   await Promise.all(
     subs.map((sub) =>
       deliverToSubscription(sub, decoded).catch((err) =>
-        console.error(`[webhookDelivery] subscription ${sub.id} failed:`, err.message),
+        logger.error(`[webhookDelivery] subscription ${sub.id} failed:`, err.message),
       ),
     ),
   );

--- a/indexer/src/wsEvents.js
+++ b/indexer/src/wsEvents.js
@@ -1,3 +1,4 @@
+import { logger } from "./logger.js";
 /**
  * Live Event Streaming via WebSockets 
  *
@@ -71,7 +72,7 @@ export function attachWebSocketServer(httpServer) {
   });
 
   wss.on("connection", (ws, _req) => {
-    console.log("[ws] Client connected");
+    logger.info("[ws] Client connected");
 
     const handler = (event) => {
       if (ws.readyState === ws.OPEN) {
@@ -99,11 +100,11 @@ export function attachWebSocketServer(httpServer) {
       bus.off("event", handler);
       bus.off("vault_ratio", vaultHandler);
       bus.off("contract_link", linkHandler);
-      console.log("[ws] Client disconnected");
+      logger.info("[ws] Client disconnected");
     });
 
     ws.on("error", (err) => {
-      console.error("[ws] Socket error:", err.message);
+      logger.error("[ws] Socket error:", err.message);
       bus.off("event", handler);
       bus.off("vault_ratio", vaultHandler);
       bus.off("contract_link", linkHandler);
@@ -117,6 +118,6 @@ export function attachWebSocketServer(httpServer) {
     );
   });
 
-  console.log("[ws] WebSocket server attached");
+  logger.info("[ws] WebSocket server attached");
   return wss;
 }

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: soroban-indexer
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/provisioning/dashboards/files

--- a/monitoring/grafana/provisioning/dashboards/files/slo-dashboard.json
+++ b/monitoring/grafana/provisioning/dashboards/files/slo-dashboard.json
@@ -1,0 +1,59 @@
+{
+  "title": "Soroban Indexer SLOs",
+  "uid": "soroban-indexer-slo",
+  "timezone": "utc",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "API p99 Latency (SLO: < 500ms)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(api_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99 latency"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.5 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Indexer Lag Behind Chain Tip (SLO: < 20 ledgers)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "expr": "soroban_indexer_lag_ledgers",
+          "legendFormat": "ledger lag"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 20 }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/datasources/datasources.yml
+++ b/monitoring/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/monitoring/prometheus/alerts.yml
+++ b/monitoring/prometheus/alerts.yml
@@ -1,0 +1,22 @@
+groups:
+  - name: soroban-indexer-slo
+    rules:
+      # SLO: p99 API latency < 500ms
+      - alert: ApiLatencyP99SLOBreach
+        expr: histogram_quantile(0.99, sum(rate(api_request_duration_seconds_bucket[5m])) by (le)) > 0.5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "API p99 latency SLO breach"
+          description: "p99 API request latency has exceeded 500ms for 5 minutes (current: {{ $value }}s)."
+
+      # SLO: indexer lag behind chain tip < 20 ledgers
+      - alert: IndexerLagSLOBreach
+        expr: soroban_indexer_lag_ledgers > 20
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Indexer lag SLO breach"
+          description: "Indexer is {{ $value }} ledgers behind the chain tip for 5 minutes (threshold: 20)."

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  - /etc/prometheus/alerts.yml
+
+scrape_configs:
+  - job_name: soroban-indexer
+    static_configs:
+      - targets: ["indexer:3001"]
+    metrics_path: /metrics


### PR DESCRIPTION
## Summary
- Migrate the remaining `console.*` call sites in `indexer/src` to the structured `logger` (37 files); `logger`'s level methods now also accept variadic console-style args so call sites didn't need reshaping.
- `ensureAuditPartitions()` / the partition-drop cron path now fire a real `alertManager` alert (`AUDIT_PARTITION_FAILURE`) on partition create/drop failure instead of only logging, and resolve it on success.
- Add a `soroban_indexer_lag_ledgers` Prometheus gauge, plus a `monitoring/` directory with Prometheus scrape + alerting rules and a provisioned Grafana dashboard covering the two defined SLOs (p99 API latency < 500ms, indexer lag < 20 ledgers); wired `prometheus`/`grafana` services into `docker-compose.yml`.
- Parallelize `rpcMultiNode.js`'s unhealthy-node recovery checks (`startNodeRecoveryPoll`) with `Promise.all` instead of a sequential `for` loop, reducing recovery/cold-start time when multiple nodes need re-checking.

Closes #761
Closes #760
Closes #759
Closes #753

## Validation performed
- `node --check` on every modified/added JS file (all pass).
- Verified every inserted `logger.js` relative import path resolves to an existing file.
- Verified `grep -rn "console\." indexer/src` returns no live call sites (only comments referencing the old behavior).
- Validated the new dashboard JSON parses.
- No lint script is configured in `indexer/package.json`; `node_modules` isn't installed in this environment so the Jest suite wasn't run — flagging for CI.