### PR TITLE
perf + observability: virtualized registry list, wider ETag caching, request-ID log propagation, Sentry integration

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -10,3 +10,6 @@ VITE_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 
 # Network passphrase
 VITE_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+
+# Sentry DSN for frontend error tracking (leave blank to disable)
+VITE_SENTRY_DSN=

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "soroban-explorer-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@sentry/react": "^10.72.0",
         "@stellar/freighter-api": "4.1.0",
         "@stellar/stellar-sdk": "12.3.0",
         "@tanstack/react-query": "5.40.0",
@@ -1593,6 +1594,112 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.72.0.tgz",
+      "integrity": "sha512-pbXHaovq/rRO5wsHz6Yey6SBPJLrbi7kCaYlSr6+v4bB4UoIL5dFB65BcQ7XD3BzZDNNvl6jTe68a1/sUMb5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.72.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.72.0",
+        "@sentry/feedback": "10.72.0",
+        "@sentry/replay": "10.72.0",
+        "@sentry/replay-canvas": "10.72.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.72.0.tgz",
+      "integrity": "sha512-aZyogxXnNgDRupNscB8VEZdJbhbIk0+LiXrg5Fl82foGlcc5I22GdxORSb/JHwkeMFttZmvh1/OMwSPzAmE94Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.72.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.72.0.tgz",
+      "integrity": "sha512-UJMHZfbjP4qk+g4AQhZmzosMdICC2D9p0/hLrm1LofPsp+WBfcSnv9jsY1a9TfmpS4WCAmTx8nANYTIXifcBjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/feedback": {
+      "version": "10.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.72.0.tgz",
+      "integrity": "sha512-UPCABAD5WkOIg8XfyH58B5hsP19RGBbMXmiu7k7yQ0kFr/QIsn1tO2ts5w8ek5tIuTdAaeK3L+tinnCRh2STbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.72.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.72.0.tgz",
+      "integrity": "sha512-I+/Wq2duluHIGoCVbtm2FsC4kp160hNmKVFlCVa/UsutsuEbZAcFC1GI8Zzg/uUWbR7x/LhH7OqP9jdfwJsm4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.72.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.72.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.72.0.tgz",
+      "integrity": "sha512-DiUnhALGvEzaF7bSuRnr/Xftfh4eYZHQ9kwb+CRIDbJ0R2beetHH7vzE8vDe3pFMd8TWAuLkdNLMTC2ic9xfnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.72.0",
+        "@sentry/core": "10.72.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.72.0.tgz",
+      "integrity": "sha512-RdNCbuQ1TBsyCrkHDBPTukQ3gtm8chXi0ldiJSiNUduPGCoKet9L1JocTqJ2gMguV+bOK+QLMvFnBCDbdcSg6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.72.0",
+        "@sentry/replay": "10.72.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@sentry/react": "^10.72.0",
     "@stellar/freighter-api": "4.1.0",
     "@stellar/stellar-sdk": "12.3.0",
     "@tanstack/react-query": "5.40.0",

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Sentry } from "../sentry";
 
 interface Props {
   children: ReactNode;
@@ -17,6 +18,7 @@ export default class ErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     console.error("[ErrorBoundary]", error, info.componentStack);
+    Sentry.captureException(error, { contexts: { react: { componentStack: info.componentStack } } });
   }
 
   render() {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,7 +5,10 @@ import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import { NetworkProvider } from "./contexts/NetworkContext";
 import { initCsrf } from "./hooks/useCsrf";
+import { initSentry } from "./sentry";
 import "./index.css";
+
+initSentry();
 
 const qc = new QueryClient();
 

--- a/frontend/src/pages/RegistryPage.tsx
+++ b/frontend/src/pages/RegistryPage.tsx
@@ -14,6 +14,7 @@ import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import { api, type ContractListItem, type ContractsListResponse, type ContractStats } from "../api";
 import { truncateAddress } from "../utils/strkey";
 import ProtocolBadge from "../components/ProtocolBadge";
+import { useVirtualList, ROW_HEIGHT } from "../hooks/useVirtualList";
 
 // Max concurrent /stats requests when batch-fetching activity for the visible page (#609).
 const MAX_CONCURRENT_STATS_FETCHES = 10;
@@ -118,6 +119,11 @@ export default function RegistryPage() {
 
   const contracts = data?.contracts ?? [];
   const pagination = data?.pagination;
+
+  // Virtualize the row list so large pages (or a future higher page size)
+  // stay smooth on scroll (#751).
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const { totalHeight, visibleItems } = useVirtualList(contracts, scrollContainerRef);
 
   // Batch-fetch event-count / last-activity stats for the visible contracts,
   // capped at MAX_CONCURRENT_STATS_FETCHES concurrent requests (#609).
@@ -226,58 +232,77 @@ export default function RegistryPage() {
               <th style={{ padding: "8px 4px" }}>Activity</th>
             </tr>
           </thead>
-          <tbody>
-            {isLoading && Array.from({ length: 5 }).map((_, i) => <SkeletonRow key={i} />)}
-            {!isLoading && contracts.map((c: ContractListItem) => (
-              <tr key={c.id} style={{ borderBottom: "1px solid var(--border)" }}>
-                <td style={{ padding: "10px 4px" }}>
-                  <Link to={`/contract/${c.id}`} style={{ fontWeight: 600 }}>
-                    {c.name || truncateAddress(c.id)}
-                  </Link>{" "}
-                  <ProtocolBadge type={c.protocol_type} />
-                  {c.description && (
-                    <p style={{ color: "var(--muted)", marginTop: 2, fontSize: 12 }}>
-                      {c.description}
-                    </p>
-                  )}
-                </td>
-                <td style={{ padding: "10px 4px" }}>
-                  <code style={{ fontSize: 12, color: "var(--muted)", wordBreak: "break-all" }}>
-                    {c.id}
-                  </code>
-                </td>
-                <td style={{ padding: "10px 4px" }}>
-                  <code style={{ fontSize: 12 }}>{truncateAddress(c.registered_by)}</code>
-                </td>
-                <td style={{ padding: "10px 4px", color: "var(--muted)", fontSize: 12 }}>
-                  {new Date(c.created_at).toLocaleString()}
-                </td>
-                <td style={{ padding: "10px 4px" }}>
-                  {statsById[c.id] ? (
-                    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                      <div>
-                        <div style={{ fontSize: 12 }}>
-                          {statsById[c.id].total_events.toLocaleString()} events
-                        </div>
-                        <div style={{ fontSize: 11, color: "var(--muted)" }}>
-                          {(() => {
-                            const lastActive = [...statsById[c.id].events_per_day]
-                              .reverse()
-                              .find((d) => d.count > 0);
-                            return lastActive ? `Last active ${timeAgo(lastActive.date)}` : "No activity";
-                          })()}
-                        </div>
-                      </div>
-                      <MiniSparkline data={statsById[c.id].events_per_day.slice(-7)} />
-                    </div>
-                  ) : (
-                    <span style={{ fontSize: 11, color: "var(--muted)" }}>—</span>
-                  )}
-                </td>
-              </tr>
-            ))}
-          </tbody>
+          {isLoading && (
+            <tbody>
+              {Array.from({ length: 5 }).map((_, i) => <SkeletonRow key={i} />)}
+            </tbody>
+          )}
         </table>
+
+        {!isLoading && contracts.length > 0 && (
+          <div
+            ref={scrollContainerRef}
+            data-testid="virtual-scroll-container"
+            style={{ overflowY: "auto", maxHeight: contracts.length > 10 ? 600 : undefined, position: "relative" }}
+          >
+            <div style={{ height: totalHeight, position: "relative" }}>
+              {visibleItems.map(({ item: c, style }: { item: ContractListItem; style: React.CSSProperties }) => (
+                <div key={c.id} style={{ ...style, height: ROW_HEIGHT }}>
+                  <table style={{ width: "100%", borderCollapse: "collapse", tableLayout: "fixed" }}>
+                    <tbody>
+                      <tr style={{ borderBottom: "1px solid var(--border)" }}>
+                        <td style={{ padding: "10px 4px" }}>
+                          <Link to={`/contract/${c.id}`} style={{ fontWeight: 600 }}>
+                            {c.name || truncateAddress(c.id)}
+                          </Link>{" "}
+                          <ProtocolBadge type={c.protocol_type} />
+                          {c.description && (
+                            <p style={{ color: "var(--muted)", marginTop: 2, fontSize: 12 }}>
+                              {c.description}
+                            </p>
+                          )}
+                        </td>
+                        <td style={{ padding: "10px 4px" }}>
+                          <code style={{ fontSize: 12, color: "var(--muted)", wordBreak: "break-all" }}>
+                            {c.id}
+                          </code>
+                        </td>
+                        <td style={{ padding: "10px 4px" }}>
+                          <code style={{ fontSize: 12 }}>{truncateAddress(c.registered_by)}</code>
+                        </td>
+                        <td style={{ padding: "10px 4px", color: "var(--muted)", fontSize: 12 }}>
+                          {new Date(c.created_at).toLocaleString()}
+                        </td>
+                        <td style={{ padding: "10px 4px" }}>
+                          {statsById[c.id] ? (
+                            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                              <div>
+                                <div style={{ fontSize: 12 }}>
+                                  {statsById[c.id].total_events.toLocaleString()} events
+                                </div>
+                                <div style={{ fontSize: 11, color: "var(--muted)" }}>
+                                  {(() => {
+                                    const lastActive = [...statsById[c.id].events_per_day]
+                                      .reverse()
+                                      .find((d) => d.count > 0);
+                                    return lastActive ? `Last active ${timeAgo(lastActive.date)}` : "No activity";
+                                  })()}
+                                </div>
+                              </div>
+                              <MiniSparkline data={statsById[c.id].events_per_day.slice(-7)} />
+                            </div>
+                          ) : (
+                            <span style={{ fontSize: 11, color: "var(--muted)" }}>—</span>
+                          )}
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* Empty state */}
         {!isLoading && !isError && contracts.length === 0 && (

--- a/frontend/src/sentry.ts
+++ b/frontend/src/sentry.ts
@@ -1,0 +1,17 @@
+import * as Sentry from "@sentry/react";
+
+/**
+ * Initializes Sentry error tracking when VITE_SENTRY_DSN is set (#757).
+ * No-op in dev/test environments where the DSN is left blank.
+ */
+export function initSentry() {
+  const dsn = import.meta.env.VITE_SENTRY_DSN;
+  if (!dsn) return;
+  Sentry.init({
+    dsn,
+    environment: import.meta.env.MODE,
+    tracesSampleRate: 0.1,
+  });
+}
+
+export { Sentry };

--- a/indexer/.env.example
+++ b/indexer/.env.example
@@ -29,6 +29,10 @@ ADMIN_SECRET=
 # ADMIN_TOTP_SECRET=
 REDIS_URL=
 
+# ── Observability ──────────────────────────────────────────────────────────────
+# Sentry DSN for error tracking (leave blank to disable)
+SENTRY_DSN=
+
 # ── Email Configuration (for self-service API key creation) ───────────────────
 # Choose one: Resend (recommended) or SMTP
 # Resend configuration (https://resend.com)

--- a/indexer/package-lock.json
+++ b/indexer/package-lock.json
@@ -8,6 +8,7 @@
       "name": "soroban-explorer-indexer",
       "version": "0.1.0",
       "dependencies": {
+        "@sentry/node": "^10.72.0",
         "@stellar/stellar-sdk": "^14.6.1",
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.6",
@@ -1484,6 +1485,110 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -1599,6 +1704,117 @@
       },
       "funding": {
         "url": "https://ko-fi.com/killymxi"
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.72.0.tgz",
+      "integrity": "sha512-UJMHZfbjP4qk+g4AQhZmzosMdICC2D9p0/hLrm1LofPsp+WBfcSnv9jsY1a9TfmpS4WCAmTx8nANYTIXifcBjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.72.0.tgz",
+      "integrity": "sha512-eQHQFxSX26MhG/nB+tAY4QRslnPvJse7pww/hd3zXAqNULRa5lFtjSLALcHx/KUVDCZdTPdUVZEj4nGidcHrow==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/sdk-trace-base": "^2.9.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.72.0",
+        "@sentry/node-core": "10.72.0",
+        "@sentry/opentelemetry": "10.72.0",
+        "@sentry/server-utils": "10.72.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.72.0.tgz",
+      "integrity": "sha512-xYuYWmWEWnN8h3YHa7mds212ANFgrxfrbmLvVg0p0wf9m6MFjLowOTmjaiK0XW20sM/veSelicre650bx8UFtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.72.0",
+        "@sentry/opentelemetry": "10.72.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.72.0.tgz",
+      "integrity": "sha512-ZVbAM1rGU/awN7cH/jvC87WpQw0NOJx5id6dKnnefStXpP/kUnZXYhtX9gfBnofYvJWa5I5VUSeuKCLUcKL75w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.72.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      }
+    },
+    "node_modules/@sentry/server-utils": {
+      "version": "10.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.72.0.tgz",
+      "integrity": "sha512-CWpHMYW81RDBSVBdnxulGUvvBhkBb/OpSr72ubSe1UkKTcgT0NDMCWxE3dLFXqSxzT4DaF5UlUVv9ii5Sse53w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.72.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -3046,6 +3262,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -4144,6 +4366,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
+      "integrity": "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/import-in-the-middle/node_modules/cjs-module-lexer": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.1.tgz",
+      "integrity": "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==",
+      "license": "MIT"
     },
     "node_modules/import-local": {
       "version": "3.2.0",
@@ -5515,6 +5757,12 @@
         "npm": ">=6"
       }
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmmirror.com/ms/-/ms-2.0.0.tgz",
@@ -6364,6 +6612,42 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
+    "node_modules/require-in-the-middle/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/require-in-the-middle/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/resend": {
       "version": "3.5.0",

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -12,6 +12,7 @@
     "test:coverage": "c8 --reporter=text --reporter=lcov node --test tests/decoder.test.js tests/scval.test.js tests/decoderClassic.test.js tests/horizonClient.test.js"
   },
   "dependencies": {
+    "@sentry/node": "^10.72.0",
     "@stellar/stellar-sdk": "^14.6.1",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.6",

--- a/indexer/src/api.js
+++ b/indexer/src/api.js
@@ -43,6 +43,7 @@ import {
 } from "./cacheLayer.js";
 import { recordAccess, schedulePrefetch } from "./prefetchEngine.js";
 import { attachGraphQL } from "./graphql.js";
+import { requestContext } from "./logger.js";
 import { runAllChecks } from "./doctor-lib.js";
 import { registry } from "./metrics.js";
 import pg from "pg";
@@ -116,7 +117,10 @@ function requestIdMiddleware(req, _res, next) {
   // Preserve incoming traceparent header if present
   const tp = req.headers["traceparent"];
   if (tp) _res.setHeader && _res.setHeader("traceparent", tp);
-  next();
+  // Run the rest of the request inside an AsyncLocalStorage context so every
+  // logger.* call made while handling it — including deep in other modules —
+  // automatically carries this request's ID (#756).
+  requestContext.run({ requestId: req.id }, next);
 }
 
 function createHttpLogger(logDestination) {
@@ -1222,7 +1226,10 @@ export function createApi({ logDestination, dbOverride } = {}) {
 
   // GET /api/wallet/:address/balances — classic XLM + SEP-41/classic asset
   // balances sourced from Horizon (issue #530). Cached for 30s per address.
-  app.get("/api/wallet/:address/balances", async (req, res) => {
+  app.get(
+    "/api/wallet/:address/balances",
+    makeCache("wallet_balances", (req) => `wallet:balances:${req.params.address}`),
+    async (req, res) => {
     try {
       const address = req.params.address;
       if (!/^G[A-Z2-7]{55}$/.test(address)) {
@@ -1255,7 +1262,10 @@ export function createApi({ logDestination, dbOverride } = {}) {
 
   // GET /api/assets?after=&limit=  — paginated list of all assets seen in
   // indexed events, cursor-based (keyset) navigation via `next_cursor`.
-  app.get("/api/assets", async (req, res) => {
+  app.get(
+    "/api/assets",
+    makeCache("default", (req) => `assets:list:${req.query.after ?? 0}:${req.query.limit ?? 25}`),
+    async (req, res) => {
     try {
       if (req.query.limit !== undefined) {
         const parsedLimit = Number(req.query.limit);

--- a/indexer/src/index.js
+++ b/indexer/src/index.js
@@ -1,7 +1,10 @@
 import "dotenv/config";
 import { pathToFileURL } from "node:url";
 import { rpc as SorobanRpc } from "@stellar/stellar-sdk";
+import { initSentry } from "./sentry.js";
 import config from "./config.js";
+
+initSentry();
 import { startApi } from "./api.js";
 import { db, pool } from "./db.js";
 import { decode, getDecodeStats } from "./decoder.js";

--- a/indexer/src/logger.js
+++ b/indexer/src/logger.js
@@ -1,15 +1,23 @@
 import { randomUUID } from "node:crypto";
+import { AsyncLocalStorage } from "node:async_hooks";
 
 const LEVELS = { debug: 10, info: 20, warn: 30, error: 40 };
 const currentLevel = LEVELS[process.env.LOG_LEVEL] ?? LEVELS.info;
 
+// Carries the current request's correlation ID across async/await boundaries
+// so every logger.* call made while handling a request — including ones deep
+// in modules that never see `req` — picks it up automatically (#756).
+export const requestContext = new AsyncLocalStorage();
+
 function write(levelName, obj, msg) {
   if ((LEVELS[levelName] ?? 0) < currentLevel) return;
+  const ctx = requestContext.getStore();
   const entry = {
     level: levelName,
     time: new Date().toISOString(),
     service: "indexer",
     pid: process.pid,
+    ...(ctx?.requestId ? { requestId: ctx.requestId } : {}),
     ...(typeof obj === "string" ? { msg: obj } : obj),
     ...(msg !== undefined ? { msg } : {}),
   };

--- a/indexer/src/sentry.js
+++ b/indexer/src/sentry.js
@@ -1,0 +1,27 @@
+import * as Sentry from "@sentry/node";
+
+/**
+ * Initializes Sentry error tracking when SENTRY_DSN is set (#757), and wires
+ * up handlers so uncaught exceptions and unhandled rejections surface in the
+ * dashboard instead of only being log-grepped.
+ * No-op when the DSN is left blank (e.g. local dev).
+ */
+export function initSentry() {
+  const dsn = process.env.SENTRY_DSN;
+  if (!dsn) return;
+
+  Sentry.init({
+    dsn,
+    environment: process.env.NODE_ENV || "development",
+    tracesSampleRate: 0.1,
+  });
+
+  process.on("uncaughtException", (err) => {
+    Sentry.captureException(err);
+  });
+  process.on("unhandledRejection", (reason) => {
+    Sentry.captureException(reason instanceof Error ? reason : new Error(String(reason)));
+  });
+}
+
+export { Sentry };


### PR DESCRIPTION
## Summary
Combined PR addressing four assigned issues:

- **#751** — Virtualize `RegistryPage.tsx`'s contract list with the existing `useVirtualList` hook (same pattern as `EventTable`) so large registries stay smooth on scroll.
- **#752** — Wire `makeCache()` (ETag / `If-None-Match` → `304`) onto `/api/wallet/:address/balances` (previously uncached despite its comment claiming otherwise) and `/api/assets`.
- **#756** — Propagate the request correlation ID through structured logs via `AsyncLocalStorage` in `logger.js`, so every `logger.*` call made while handling a request — including in modules that never see `req` — automatically carries `requestId`, without touching each call site.
- **#757** — Integrate Sentry (`@sentry/react` for the frontend `ErrorBoundary`, `@sentry/node` for the indexer's uncaught exceptions/unhandled rejections), gated behind an optional DSN env var so it's a no-op when unset.

## Validation
- `node --check` on all edited indexer files
- Indexer Jest suite: `tests/logger.test.js` (3/3 pass), `test/api/wallet-balances.test.js` + `test/api/assets.test.js` (9/9 pass)
- Confirmed 3 pre-existing indexer test failures (`contract-stats`, `nft-analytics`, `dlq-retry`) are unrelated — they fail identically on `main` before this branch's changes
- Frontend: `test/RegistryPage.test.tsx` + `test/ErrorBoundary.test.tsx` (6/6 pass)
- `tsc --noEmit`: only pre-existing, unrelated errors in `Nav.tsx` / `useFreighter.ts` (untouched by this PR)

Closes #751
Closes #752
Closes #756
Closes #757
