### PR TITLE
fix: enforce contract size limits, align dev Node versions, remove any types

### DIFF
--- a/contracts/explorer/src/lib.rs
+++ b/contracts/explorer/src/lib.rs
@@ -1395,6 +1395,38 @@ mod tests {
         client.register_contract(&admin, &cid, &meta);
     }
 
+    // MAX_PARAM_NAME_LEN / MAX_PARAM_KIND_LEN = 32 ────────────────────────────
+    // ParamDef.name/.kind are Soroban `Symbol`s, which the SDK itself refuses
+    // to construct above 32 characters, so the reject path is enforced at
+    // construction time rather than in `validate_meta`. These tests confirm
+    // the accept path holds exactly at the limit.
+
+    #[test]
+    fn test_param_name_and_kind_at_limit_succeeds() {
+        let (env, client) = setup();
+        let admin = Address::generate(&env);
+        client.init(&admin, &0u32);
+
+        let cid: BytesN<32> = BytesN::from_array(&env, &[71u8; 32]);
+        let long_symbol = Symbol::new(&env, "abcdefghijklmnopqrstuvwxyz012345");
+        let mut params: Vec<ParamDef> = Vec::new(&env);
+        params.push_back(ParamDef {
+            name: long_symbol.clone(),
+            kind: long_symbol,
+        });
+        let mut fns: Vec<FunctionAbi> = Vec::new(&env);
+        fns.push_back(FunctionAbi {
+            name: symbol_short!("fn"),
+            description: String::from_str(&env, "d"),
+            params,
+        });
+        let meta = ContractMeta {
+            functions: fns,
+            ..make_meta(&env, "ParamNameKindLimit", &admin)
+        };
+        client.register_contract(&admin, &cid, &meta);
+    }
+
     // Event description limit ─────────────────────────────────────────────────
 
     #[test]

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:20-alpine
 
 WORKDIR /app
 COPY package*.json ./

--- a/frontend/src/components/SubInvocationGraph.tsx
+++ b/frontend/src/components/SubInvocationGraph.tsx
@@ -3,6 +3,7 @@
 // Nodes = contracts (sized by call frequency, coloured by type).
 // Edges = invocations between contracts.
 import { useEffect, useRef } from "react";
+import type { Core } from "cytoscape";
 import type { SubInvocationExtended } from "../api";
 
 interface Props {
@@ -23,7 +24,7 @@ function short(id: string) {
 
 export default function SubInvocationGraph({ invocations }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const cyRef = useRef<any>(null);
+  const cyRef = useRef<Core | null>(null);
 
   useEffect(() => {
     if (!containerRef.current || invocations.length === 0) return;
@@ -89,8 +90,8 @@ export default function SubInvocationGraph({ invocations }: Props) {
               "font-size": 10,
               "text-valign": "bottom",
               "text-margin-y": 4,
-              width: "mapData(count, 1, 20, 28, 72)" as any,
-              height: "mapData(count, 1, 20, 28, 72)" as any,
+              width: "mapData(count, 1, 20, 28, 72)",
+              height: "mapData(count, 1, 20, 28, 72)",
             },
           },
           ...Object.entries(CONTRACT_TYPE_COLORS).map(([type, color]) => ({
@@ -100,7 +101,7 @@ export default function SubInvocationGraph({ invocations }: Props) {
           {
             selector: "edge",
             style: {
-              width: "mapData(weight, 1, 10, 1, 5)" as any,
+              width: "mapData(weight, 1, 10, 1, 5)",
               "line-color": "#4b5563",
               "target-arrow-color": "#4b5563",
               "target-arrow-shape": "triangle",
@@ -108,7 +109,7 @@ export default function SubInvocationGraph({ invocations }: Props) {
             },
           },
         ],
-        layout: { name: "cose", padding: 32, animate: false } as any,
+        layout: { name: "cose", padding: 32, animate: false },
         userZoomingEnabled: true,
         userPanningEnabled: true,
       });

--- a/frontend/src/pages/BatchMultiCall.tsx
+++ b/frontend/src/pages/BatchMultiCall.tsx
@@ -53,8 +53,8 @@ export default function BatchMultiCall() {
         });
         const data = await response.json();
         setSimResult(data);
-      } catch (e: any) {
-        setSimResult({ success: false, error: e.message });
+      } catch (e) {
+        setSimResult({ success: false, error: e instanceof Error ? e.message : String(e) });
       } finally {
         setLoading(false);
       }
@@ -74,8 +74,8 @@ export default function BatchMultiCall() {
       });
       const data = await response.json();
       setSimResult({ success: true, totalGas: data.totalGas, estimates: data.estimates });
-    } catch (e: any) {
-      setSimResult({ success: false, error: e.message });
+    } catch (e) {
+      setSimResult({ success: false, error: e instanceof Error ? e.message : String(e) });
     } finally {
       setLoading(false);
     }
@@ -93,8 +93,8 @@ export default function BatchMultiCall() {
       });
       const data = await response.json();
       setSimResult({ success: data.valid, conflicts: data.conflicts, errors: data.errors });
-    } catch (e: any) {
-      setSimResult({ success: false, error: e.message });
+    } catch (e) {
+      setSimResult({ success: false, error: e instanceof Error ? e.message : String(e) });
     } finally {
       setLoading(false);
     }
@@ -112,8 +112,8 @@ export default function BatchMultiCall() {
       });
       const data = await response.json();
       setSimResult({ success: true, optimizedOrder: data.optimizedOrder });
-    } catch (e: any) {
-      setSimResult({ success: false, error: e.message });
+    } catch (e) {
+      setSimResult({ success: false, error: e instanceof Error ? e.message : String(e) });
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/RateLimitDashboard.tsx
+++ b/frontend/src/pages/RateLimitDashboard.tsx
@@ -115,8 +115,8 @@ export default function RateLimitDashboard() {
       setLastUpdated(new Date());
       setAuthed(true);
       setError(null);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     }
   }, [adminToken, topWindow, buildHeaders]);
 

--- a/frontend/test/ContractDetailWidgets.test.tsx
+++ b/frontend/test/ContractDetailWidgets.test.tsx
@@ -16,11 +16,11 @@ function renderWithProviders(children: React.ReactNode) {
 }
 
 function mockFetchOnce(data: unknown, ok = true, status = 200) {
-  (global as any).fetch = vi.fn().mockResolvedValue({
+  global.fetch = vi.fn().mockResolvedValue({
     ok,
     status,
     json: async () => data,
-  });
+  }) as unknown as typeof fetch;
 }
 
 afterEach(() => {
@@ -31,7 +31,7 @@ describe("CircuitBreakerStatus (#539)", () => {
   it("renders nothing when the contract has no circuit breaker metadata", async () => {
     mockFetchOnce({ has_circuit_breaker: false, is_paused: false, status: "CLOSED" });
     const { container } = renderWithProviders(<CircuitBreakerStatus contractId="C1" />);
-    await waitFor(() => expect(global.fetch as any).toHaveBeenCalled());
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
     await waitFor(() => expect(container.textContent).toBe(""));
   });
 

--- a/frontend/test/RegistryPage.test.tsx
+++ b/frontend/test/RegistryPage.test.tsx
@@ -14,7 +14,7 @@ describe("RegistryPage", () => {
       }),
     });
 
-    (global as any).fetch = fetchMock;
+    global.fetch = fetchMock as unknown as typeof fetch;
 
     const queryClient = new QueryClient({
       defaultOptions: {
@@ -59,7 +59,7 @@ describe("RegistryPage", () => {
       }),
     });
 
-    (global as any).fetch = fetchMock;
+    global.fetch = fetchMock as unknown as typeof fetch;
 
     const queryClient = new QueryClient({
       defaultOptions: {
@@ -107,7 +107,7 @@ describe("RegistryPage", () => {
       }),
     });
 
-    (global as any).fetch = fetchMock;
+    global.fetch = fetchMock as unknown as typeof fetch;
 
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/frontend/test/SearchPage.test.tsx
+++ b/frontend/test/SearchPage.test.tsx
@@ -17,7 +17,7 @@ describe("SearchPage", () => {
       }),
     });
 
-    (global as any).fetch = fetchMock;
+    global.fetch = fetchMock as unknown as typeof fetch;
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     const queryClient = new QueryClient({

--- a/indexer/Dockerfile.dev
+++ b/indexer/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:20-alpine
 
 WORKDIR /app
 COPY package*.json ./


### PR DESCRIPTION
## Summary
- **#732**: Confirmed `register_contract`/`update_contract` already validate `ContractMeta` against all size limits and panic with `InvalidInput`; added a missing boundary test covering `MAX_PARAM_NAME_LEN`/`MAX_PARAM_KIND_LEN` (enforced transitively via the SDK's 32-char `Symbol` cap).
- **#731**: Bumped `indexer/Dockerfile.dev` and `frontend/Dockerfile.dev` from Node 18 to Node 20 to match CI (`node-version: 20`) and the production Dockerfiles.
- **#730**: Replaced all 16 remaining `@typescript-eslint/no-explicit-any` warnings across `SubInvocationGraph.tsx`, `BatchMultiCall.tsx`, `RateLimitDashboard.tsx`, and three test files with proper types.
- **#726**: Verified `frontend/test/api.test.ts` already imports and exercises the real `api` object from `src/api.ts` (including `walletHistory`) — no change needed, issue was already resolved on `main`.

Closes #732
Closes #731
Closes #730
Closes #726

## Validation performed
- `cargo test -p soroban-explorer-contract` — all tests pass, including the new boundary test
- `npx eslint .` in `frontend/` — zero `no-explicit-any` warnings (remaining errors are pre-existing `no-unused-vars` issues, unrelated to this change, confirmed present on `main` before these edits)
- `npx tsc --noEmit` — no new type errors in touched files
- `npx vitest run test/api.test.ts test/ContractDetailWidgets.test.tsx test/RegistryPage.test.tsx test/SearchPage.test.tsx` — all pass
- Full `pre-push` hook (wasm32 release build + explorer contract tests + ticket contract tests) passed