### PR TITLE
security: rolling admin secret rotation, self-service IP allowlist, CodeQL scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'  # Monday 06:00 UTC
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+          - language: rust
+            build-mode: autobuild
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/docs/rate-limit-tuning.md
+++ b/docs/rate-limit-tuning.md
@@ -1,0 +1,45 @@
+# Rate-limit tuning methodology
+
+The per-tier rate limits (`unauthenticated` / `free` / `pro` / `enterprise`),
+defined in `indexer/src/rateLimit/endpointGroups.js`, were set from initial
+design-phase estimates rather than observed production traffic. This
+document defines the methodology for validating and adjusting them once
+production traffic data is available; it does not itself change the
+constants, since that requires real traffic data this repository does not
+have access to.
+
+## Data to collect
+
+- Per-tier request rate distribution (p50/p95/p99 requests-per-minute per
+  client), sourced from the `CL.THROTTLE` Redis counters or, when the
+  in-process fallback is active, the fallback bucket stats logged by
+  `indexer/src/rateLimit/tokenBucket.js`.
+- 429 (rate-limited) response counts per tier and endpoint group, to
+  identify limits that are too tight for legitimate usage.
+- Traffic from known abusive/malicious sources (e.g. clients hitting the
+  limit repeatedly in short bursts), to confirm limits still block that
+  pattern after any increase.
+
+## Review cadence
+
+Review the above metrics monthly for the first quarter after a tier's
+limits change, then quarterly, using at least two weeks of trailing data
+each time so weekday/weekend traffic patterns are represented.
+
+## Adjustment criteria
+
+- Raise a tier's `rpm`/`burst` only when its legitimate p99 traffic sits
+  above ~80% of the current burst, and 429 responses to non-abusive
+  clients are observed.
+- Lower a tier's limits only when observed legitimate traffic sits well
+  below the current sustained rate, and no legitimate use case would be
+  throttled by the reduction.
+- Any change to `indexer/src/rateLimit/endpointGroups.js` must be
+  accompanied by the traffic analysis (metrics above, with source and date
+  range) that justified it, recorded in the PR description.
+
+## Status
+
+No production traffic analysis has been performed yet. The current
+constants remain initial estimates until the first review cycle above is
+completed against real traffic.

--- a/frontend/src/components/dashboard/ApiKeysPanel.tsx
+++ b/frontend/src/components/dashboard/ApiKeysPanel.tsx
@@ -23,6 +23,46 @@ function RevealedKey({ label, value, onDismiss }: { label: string; value: string
   );
 }
 
+function AllowlistEditor({ apiKeyId, allowedIps }: { apiKeyId: string; allowedIps: string[] | null }) {
+  const queryClient = useQueryClient();
+  const [value, setValue] = useState((allowedIps ?? []).join(", "));
+
+  const mutation = useMutation({
+    mutationFn: (ips: string[]) => dashboardApi.updateAllowedIps(apiKeyId, ips),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["dashboard", "api-keys"] }),
+  });
+
+  return (
+    <div style={{ marginTop: 6, display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
+      <label style={{ fontSize: 12, color: "var(--muted)" }}>IP allowlist (CIDR, comma-separated):</label>
+      <input
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="e.g. 203.0.113.0/24, 198.51.100.7"
+        style={{ flex: 1, minWidth: 200, fontSize: 12 }}
+      />
+      <button
+        type="button"
+        disabled={mutation.isPending}
+        onClick={() => {
+          const ips = value
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean);
+          mutation.mutate(ips);
+        }}
+      >
+        {mutation.isPending ? "Saving…" : "Save allowlist"}
+      </button>
+      {mutation.isError && (
+        <span style={{ color: "#e5484d", fontSize: 12 }} role="alert">
+          {(mutation.error as Error).message}
+        </span>
+      )}
+    </div>
+  );
+}
+
 function UsageRow({ apiKeyId }: { apiKeyId: string }) {
   const { data, isLoading } = useQuery({
     queryKey: ["dashboard", "api-key-usage", apiKeyId],
@@ -131,6 +171,7 @@ export default function ApiKeysPanel() {
               <div style={{ marginTop: 4 }}>
                 <UsageRow apiKeyId={key.id} />
               </div>
+              <AllowlistEditor apiKeyId={key.id} allowedIps={key.allowed_ips} />
             </div>
             <div style={{ display: "flex", gap: 6, flexShrink: 0 }}>
               <button type="button" disabled={key.revoked} onClick={() => rotateMutation.mutate(key.id)}>

--- a/frontend/src/services/dashboardApi.ts
+++ b/frontend/src/services/dashboardApi.ts
@@ -72,6 +72,7 @@ export interface ApiKeyRecord {
   rate_limit: number | null;
   daily_limit: number | null;
   expires_at: string | null;
+  allowed_ips: string[] | null;
   revoked: boolean;
   last_used_at: string | null;
   usage_count: number;
@@ -132,6 +133,12 @@ export const dashboardApi = {
   revokeApiKey: (id: string) => request<void>(`/dashboard/api-keys/${id}`, { method: "DELETE" }),
 
   apiKeyUsage: (id: string) => request<UsageStats>(`/dashboard/api-keys/${id}/usage`),
+
+  updateAllowedIps: (id: string, allowed_ips: string[]) =>
+    request<ApiKeyRecord>(`/dashboard/api-keys/${id}/allowed-ips`, {
+      method: "PUT",
+      body: JSON.stringify({ allowed_ips }),
+    }),
 
   listWebhooks: () => request<{ data: WebhookSubscription[] }>("/webhooks").then((r) => r.data),
 

--- a/indexer/src/admin/adminAuth.js
+++ b/indexer/src/admin/adminAuth.js
@@ -2,6 +2,10 @@
  * Admin Authentication Middleware
  *
  * Checks the `Authorization: Bearer <token>` header against `ADMIN_SECRET`.
+ * `ADMIN_SECRET` may hold a comma-separated list of secrets so an operator
+ * can rotate it without downtime: deploy both the old and new secret
+ * together, then remove the old one once the grace window has passed —
+ * mirroring the rotation_grace_until pattern used for API keys.
  * Uses crypto.timingSafeEqual to prevent timing-based secret enumeration.
  *
  * When `ADMIN_TOTP_SECRET` is set (non-empty), also requires a valid TOTP code
@@ -25,12 +29,14 @@ import { verifyTotp } from './totp.js';
  * @type {import('express').RequestHandler}
  */
 function adminAuthMiddleware(req, res, next) {
-  const adminSecret = process.env.ADMIN_SECRET;
+  const adminSecretsRaw = process.env.ADMIN_SECRET;
 
   // If ADMIN_SECRET is not configured, block all admin access.
-  if (!adminSecret) {
+  if (!adminSecretsRaw) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
+
+  const validSecrets = adminSecretsRaw.split(',').map((s) => s.trim()).filter(Boolean);
 
   // Optional IP allowlist: if set, enforce it BEFORE checking the token so
   // that disallowed IPs receive 403 even without a valid auth header.
@@ -51,19 +57,18 @@ function adminAuthMiddleware(req, res, next) {
 
   const token = authHeader.slice('Bearer '.length);
 
-  // Use timingSafeEqual to avoid timing attacks.
-  // Both buffers must be the same byte length for the comparison to work.
+  // Use timingSafeEqual to avoid timing attacks. Check the token against
+  // every currently-valid secret (old + new during a rotation window) —
+  // both buffers must be the same byte length for the comparison to work.
   try {
     const tokenBuf = Buffer.from(token);
-    const secretBuf = Buffer.from(adminSecret);
 
-    // If lengths differ the key is clearly wrong, but we still do the
-    // comparison on equal-length buffers to avoid early exit leaking info.
-    if (tokenBuf.length !== secretBuf.length) {
-      return res.status(401).json({ error: 'Unauthorized' });
-    }
+    const match = validSecrets.some((secret) => {
+      const secretBuf = Buffer.from(secret);
+      if (tokenBuf.length !== secretBuf.length) return false;
+      return crypto.timingSafeEqual(tokenBuf, secretBuf);
+    });
 
-    const match = crypto.timingSafeEqual(tokenBuf, secretBuf);
     if (!match) {
       return res.status(401).json({ error: 'Unauthorized' });
     }

--- a/indexer/src/routes/dashboard.js
+++ b/indexer/src/routes/dashboard.js
@@ -14,15 +14,19 @@
  *   POST   /api/dashboard/api-keys/:id/rotate      — rotate one of my keys
  *   DELETE /api/dashboard/api-keys/:id             — revoke one of my keys
  *   GET    /api/dashboard/api-keys/:id/usage       — requests + events-received for one key
+ *   PUT    /api/dashboard/api-keys/:id/allowed-ips — replace the CIDR allowlist for one of my keys
  */
 
 import { Router } from "express";
 import { db } from "../db.js";
 import { requireAuthenticatedKey } from "../auth/requireAuthenticatedKey.js";
-import { createKey, rotateKey, deleteKey, getKeyUsage, getKeyById, listKeysForOwner, assertOwnsKey } from "../admin/keyManager.js";
+import { createKey, rotateKey, deleteKey, updateKey, getKeyUsage, getKeyById, listKeysForOwner, assertOwnsKey } from "../admin/keyManager.js";
 
 const router = Router();
 router.use(requireAuthenticatedKey);
+
+// IPv4, optionally with a /0-32 prefix (a bare IP is treated as /32).
+const CIDR_RE = /^(\d{1,3}\.){3}\d{1,3}(\/(3[0-2]|[12]?\d))?$/;
 
 function statusForError(message) {
   if (/not found/i.test(message)) return 404;
@@ -89,6 +93,22 @@ router.delete("/api-keys/:id", async (req, res) => {
     await assertOwnsKey(req.rateContext.keyId, req.params.id);
     await deleteKey(req.params.id);
     res.status(204).end();
+  } catch (e) {
+    res.status(statusForError(e.message)).json({ error: e.message });
+  }
+});
+
+router.put("/api-keys/:id/allowed-ips", async (req, res) => {
+  try {
+    await assertOwnsKey(req.rateContext.keyId, req.params.id);
+
+    const { allowed_ips } = req.body ?? {};
+    if (!Array.isArray(allowed_ips) || !allowed_ips.every((ip) => typeof ip === "string" && CIDR_RE.test(ip))) {
+      return res.status(400).json({ error: "allowed_ips must be an array of valid IPv4 CIDR strings" });
+    }
+
+    const record = await updateKey(req.params.id, { allowed_ips });
+    res.json(record);
   } catch (e) {
     res.status(statusForError(e.message)).json({ error: e.message });
   }


### PR DESCRIPTION
## Summary
- `adminAuthMiddleware` now accepts a comma-separated `ADMIN_SECRET` list so an operator can rotate the secret without downtime (deploy old+new, then drop the old one) — mirrors the existing API-key rotation grace pattern.
- Add `PUT /api/dashboard/api-keys/:id/allowed-ips` so an API key owner can manage their own CIDR allowlist without admin involvement, plus a matching dashboard UI control in `ApiKeysPanel.tsx`.
- Add a CodeQL workflow (`javascript-typescript` + `rust`) scheduled weekly and on every PR to `main`, surfacing findings in the Security tab and as PR check annotations.
- Document the rate-limit tuning methodology and data-collection plan (`docs/rate-limit-tuning.md`). Note: actual constant changes are deferred until real production traffic data is available to analyze — that data doesn't exist yet, so this issue's acceptance criterion (constants backed by a documented traffic analysis) can only be partially satisfied by this PR.

## Validation performed
- `node --check` on both edited indexer files
- `eslint` on all edited indexer and frontend files (clean)
- `tsc --noEmit` on the frontend (only pre-existing, unrelated errors in `Nav.tsx`/`useFreighter.ts` remain; files touched here are clean)
- YAML parse-check on the new CodeQL workflow

Closes #741
Closes #739
Closes #736
Closes #740