### PR TITLE
fix: security hardening, TTL keep-alive, and audit-trail UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,22 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  # ── Secret Scanning ──────────────────────────────────────────────────────
+  # Closes #735 — fails the build if a credential-shaped string is committed.
+  secret-scan:
+    name: Secret Scanning (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
+
   # ── Contracts ─────────────────────────────────────────────────────────────
   contracts:
     name: Contracts (build + test)

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,17 @@
+# Secret-scanning configuration for gitleaks (see .github/workflows/ci.yml).
+# Extends gitleaks' default rule set (AWS keys, private keys, generic
+# high-entropy secrets, provider-specific tokens, etc.) with repo-specific
+# allowlisting to avoid false positives on lockfiles and test fixtures.
+title = "soroban-smart-block gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Files that legitimately contain high-entropy, non-secret strings"
+paths = [
+  '''(^|/)package-lock\.json$''',
+  '''(^|/)Cargo\.lock$''',
+  '''(^|/)target/''',
+  '''(^|/)node_modules/''',
+]

--- a/contracts/explorer/src/lib.rs
+++ b/contracts/explorer/src/lib.rs
@@ -461,6 +461,40 @@ impl ExplorerContract {
         );
     }
 
+    /// Permissionlessly extends the TTL of a registered contract's persistent
+    /// storage entry (and its current ABI version entry) so long-lived,
+    /// rarely-updated registry entries can stay alive without an admin or
+    /// registrant write via `update_contract`.
+    ///
+    /// This only *extends* TTLs already funded by `register_contract` /
+    /// `update_contract` — it writes no new data and requires no auth, so it
+    /// cannot be used to grief the registry's storage costs; each caller pays
+    /// their own transaction's resource fee for the extension.
+    pub fn bump_contract_ttl(env: Env, contract_id: BytesN<32>) {
+        Self::bump_instance_ttl(&env);
+        let key = DataKey::Contract(contract_id.clone());
+        let existing: ContractMeta = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| panic_with_error!(&env, Error::NotFound));
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
+
+        let vkey = DataKey::ContractVersion(VersionKey {
+            contract_id,
+            abi_version: existing.abi_version,
+        });
+        env.storage().persistent().extend_ttl(
+            &vkey,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
+    }
+
     pub fn get_contract(env: Env, contract_id: BytesN<32>) -> Result<ContractMeta, Error> {
         env.storage()
             .persistent()
@@ -1055,6 +1089,34 @@ mod tests {
             client.try_get_contract(&cid),
             Err(Ok(crate::Error::NotFound))
         ));
+    }
+
+    #[test]
+    fn test_bump_contract_ttl_extends_existing_entry() {
+        let (env, client) = setup();
+        let admin = Address::generate(&env);
+        client.init(&admin, &0u32);
+
+        let cid: BytesN<32> = BytesN::from_array(&env, &[40u8; 32]);
+        let meta = make_meta(&env, "Test", &admin);
+        client.register_contract(&admin, &cid, &meta);
+
+        // Permissionless: no auth mock needed beyond the registration above.
+        client.bump_contract_ttl(&cid);
+
+        let fetched = client.get_contract(&cid);
+        assert_eq!(fetched.name, String::from_str(&env, "Test"));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bump_contract_ttl_missing_contract_panics() {
+        let (env, client) = setup();
+        let admin = Address::generate(&env);
+        client.init(&admin, &0u32);
+
+        let cid: BytesN<32> = BytesN::from_array(&env, &[41u8; 32]);
+        client.bump_contract_ttl(&cid);
     }
 
     #[test]

--- a/docs/secret-scanning.md
+++ b/docs/secret-scanning.md
@@ -1,0 +1,33 @@
+# Secret Scanning
+
+CI runs [gitleaks](https://github.com/gitleaks/gitleaks) (see the `secret-scan`
+job in `.github/workflows/ci.yml`) on every push and pull request. It scans
+the diff for credential-shaped strings (API keys, private keys, tokens,
+high-entropy secrets) and fails the build if one is found. Rule
+configuration and path allowlisting live in `.gitleaks.toml` at the repo root.
+
+## Backfill scan
+
+The full git history was scanned once when this job was introduced
+(PR closing #735) to confirm no existing commits contain a leaked credential.
+No true positives were found in history at that time.
+
+## Handling a true positive
+
+If gitleaks flags a real credential (in CI or in a manual history scan):
+
+1. **Rotate the credential immediately** with the issuing provider — treat it
+   as compromised the moment it was committed, regardless of whether the
+   repo is public.
+2. **Do not just delete it in a new commit.** The secret remains in git
+   history and is recoverable from any clone. Purge it from history with
+   `git filter-repo` (preferred) or the BFG Repo-Cleaner, then force-push
+   the rewritten history and have all collaborators re-clone.
+3. **Invalidate cached history** on the hosting side (contact GitHub Support
+   to purge cached views/forks if the repo is public and the exposure
+   window was significant).
+4. **Add a `.gitleaks.toml` allowlist entry only** for confirmed false
+   positives (e.g. a fixture value that merely looks like a secret) —
+   never to silence a real finding.
+5. **File a short incident note** describing what leaked, for how long, and
+   what was rotated, so the team has a record.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ const SetupPage = lazy(() => import("./pages/SetupPage"));
 const BatchMultiCall = lazy(() => import("./pages/BatchMultiCall"));
 const SubInvocationPage = lazy(() => import("./pages/SubInvocationPage"));
 const RateLimitDashboard = lazy(() => import("./pages/RateLimitDashboard"));
+const AuditLogPage = lazy(() => import("./pages/AuditLogPage"));
 const NftGallery = lazy(() => import("./pages/NftGallery"));
 const RegistrationSuccessPage = lazy(() => import("./pages/RegistrationSuccessPage"));
 const AbiDiffPage = lazy(() => import("./pages/AbiDiffPage"));
@@ -57,6 +58,8 @@ export default function App() {
             <Route path="/batch" element={<BatchMultiCall />} />
             <Route path="/sub-invocations" element={<SubInvocationPage />} />
             <Route path="/admin/rate-limits" element={<RateLimitDashboard />} />
+            {/* Issue #737: admin audit-trail UI */}
+            <Route path="/admin/audit-log" element={<AuditLogPage />} />
             <Route path="/nft/:contractId" element={<NftGallery />} />
             <Route path="/dashboard" element={<DashboardPage />} />
           </Routes>

--- a/frontend/src/pages/AuditLogPage.tsx
+++ b/frontend/src/pages/AuditLogPage.tsx
@@ -1,0 +1,398 @@
+/**
+ * Admin Audit Trail
+ * Views and filters `api_audit_log` via GET /api/admin/audit-log, and
+ * exports via GET /api/admin/audit-log/export. Requires admin authentication.
+ */
+import { useEffect, useState, useCallback } from "react";
+
+type AuditLogRow = {
+  id: number | string;
+  timestamp: string;
+  api_key_id: string | null;
+  key_name: string | null;
+  tier: string | null;
+  ip: string | null;
+  method: string;
+  endpoint: string;
+  status_code: number;
+  response_time_ms: number | null;
+  rate_limit_remaining: number | null;
+  user_agent: string | null;
+  request_body_hash: string | null;
+};
+
+type Filters = {
+  api_key_id: string;
+  ip: string;
+  endpoint: string;
+  status_code: string;
+  from: string;
+  to: string;
+};
+
+const EMPTY_FILTERS: Filters = { api_key_id: "", ip: "", endpoint: "", status_code: "", from: "", to: "" };
+
+function buildQuery(filters: Filters, extra: Record<string, string> = {}): string {
+  const params = new URLSearchParams();
+  Object.entries(filters).forEach(([key, value]) => {
+    if (value.trim()) params.set(key, value.trim());
+  });
+  Object.entries(extra).forEach(([key, value]) => params.set(key, value));
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
+}
+
+export default function AuditLogPage() {
+  const [adminToken, setAdminToken] = useState(() => sessionStorage.getItem("admin_token") ?? "");
+  const [adminTotp, setAdminTotp] = useState(() => sessionStorage.getItem("admin_totp") ?? "");
+  const [tokenInput, setTokenInput] = useState(() => sessionStorage.getItem("admin_token") ?? "");
+  const [totpInput, setTotpInput] = useState("");
+  const [authed, setAuthed] = useState(false);
+
+  const [filters, setFilters] = useState<Filters>(EMPTY_FILTERS);
+  const [rows, setRows] = useState<AuditLogRow[]>([]);
+  const [offset, setOffset] = useState(0);
+  const [limit] = useState(100);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const buildHeaders = useCallback((): HeadersInit => {
+    const headers: Record<string, string> = { Authorization: `Bearer ${adminToken}` };
+    if (adminTotp) headers["X-Admin-TOTP"] = adminTotp;
+    return headers;
+  }, [adminToken, adminTotp]);
+
+  const signIn = () => {
+    const token = tokenInput.trim() || adminToken;
+    if (!token) {
+      setError("Admin token is required.");
+      return;
+    }
+    sessionStorage.setItem("admin_token", token);
+    setAdminToken(token);
+    setTokenInput(token);
+    if (totpInput.trim()) {
+      sessionStorage.setItem("admin_totp", totpInput.trim());
+      setAdminTotp(totpInput.trim());
+    } else {
+      sessionStorage.removeItem("admin_totp");
+      setAdminTotp("");
+    }
+  };
+
+  const signOut = () => {
+    sessionStorage.removeItem("admin_token");
+    sessionStorage.removeItem("admin_totp");
+    setAdminToken("");
+    setAdminTotp("");
+    setTotpInput("");
+    setAuthed(false);
+  };
+
+  const fetchLog = useCallback(
+    async (nextOffset = 0) => {
+      if (!adminToken) return;
+      setLoading(true);
+      try {
+        const res = await fetch(
+          `/api/admin/audit-log${buildQuery(filters, { limit: String(limit), offset: String(nextOffset) })}`,
+          { headers: buildHeaders() },
+        );
+        if (res.status === 401) {
+          setAuthed(false);
+          setError("Invalid or expired admin token.");
+          return;
+        }
+        const body = await res.json();
+        setRows(body.data ?? []);
+        setOffset(nextOffset);
+        setAuthed(true);
+        setError(null);
+      } catch (e: any) {
+        setError(e.message);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [adminToken, filters, limit, buildHeaders],
+  );
+
+  useEffect(() => {
+    if (!adminToken) return;
+    fetchLog(0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [adminToken]);
+
+  const exportLog = (format: "csv" | "json") => {
+    const url = `/api/admin/audit-log/export${buildQuery(filters, { format })}`;
+    fetch(url, { headers: buildHeaders() })
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`Export failed (${res.status})`);
+        const blob = await res.blob();
+        const objectUrl = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = objectUrl;
+        a.download = `audit-log.${format}`;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(objectUrl);
+      })
+      .catch((e) => setError(e.message));
+  };
+
+  if (!adminToken || !authed) {
+    return (
+      <div
+        style={{
+          maxWidth: 400,
+          margin: "80px auto",
+          border: "1px solid #e5e7eb",
+          borderRadius: 8,
+          padding: 32,
+          background: "#fff",
+        }}
+      >
+        <h2 style={{ margin: "0 0 8px", fontSize: 18 }}>Admin Login</h2>
+        <p style={{ color: "#6b7280", fontSize: 13, marginBottom: 20 }}>
+          Enter your ADMIN_SECRET to access the Audit Trail. If admin 2FA is enabled, also
+          enter a current authenticator code.
+        </p>
+        {error && (
+          <div
+            style={{
+              padding: "8px 12px",
+              background: "#fee2e2",
+              borderRadius: 4,
+              color: "#991b1b",
+              fontSize: 13,
+              marginBottom: 12,
+            }}
+          >
+            {error}
+          </div>
+        )}
+        <input
+          type="password"
+          placeholder="Admin token"
+          value={tokenInput}
+          onChange={(e) => setTokenInput(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && signIn()}
+          style={{
+            width: "100%",
+            padding: "8px 12px",
+            borderRadius: 4,
+            border: "1px solid #d1d5db",
+            fontSize: 14,
+            boxSizing: "border-box",
+            marginBottom: 12,
+          }}
+          aria-label="Admin token"
+        />
+        <input
+          type="text"
+          inputMode="numeric"
+          autoComplete="one-time-code"
+          placeholder="TOTP code (if 2FA enabled)"
+          value={totpInput}
+          onChange={(e) => setTotpInput(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && signIn()}
+          style={{
+            width: "100%",
+            padding: "8px 12px",
+            borderRadius: 4,
+            border: "1px solid #d1d5db",
+            fontSize: 14,
+            boxSizing: "border-box",
+            marginBottom: 12,
+          }}
+          aria-label="TOTP code"
+        />
+        <button
+          onClick={signIn}
+          style={{
+            width: "100%",
+            padding: "8px 12px",
+            background: "#7c3aed",
+            color: "#fff",
+            border: "none",
+            borderRadius: 4,
+            fontSize: 14,
+            fontWeight: 600,
+            cursor: "pointer",
+          }}
+        >
+          Sign in
+        </button>
+      </div>
+    );
+  }
+
+  const inputStyle: React.CSSProperties = {
+    padding: "6px 10px",
+    borderRadius: 4,
+    border: "1px solid #d1d5db",
+    fontSize: 13,
+  };
+
+  return (
+    <div>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }}>
+        <h2 style={{ margin: 0 }}>Audit Trail</h2>
+        <button
+          onClick={signOut}
+          style={{
+            padding: "4px 12px",
+            fontSize: 12,
+            borderRadius: 4,
+            border: "1px solid #e5e7eb",
+            background: "#f9fafb",
+            cursor: "pointer",
+          }}
+        >
+          Sign out
+        </button>
+      </div>
+
+      {error && (
+        <div
+          style={{
+            padding: 12,
+            background: "#fee2e2",
+            borderRadius: 6,
+            marginBottom: 16,
+            color: "#991b1b",
+            fontSize: 13,
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 8,
+          marginBottom: 16,
+          padding: 16,
+          border: "1px solid #e5e7eb",
+          borderRadius: 8,
+          background: "#fff",
+        }}
+      >
+        <input
+          style={inputStyle}
+          placeholder="API key ID"
+          value={filters.api_key_id}
+          onChange={(e) => setFilters({ ...filters, api_key_id: e.target.value })}
+        />
+        <input
+          style={inputStyle}
+          placeholder="IP"
+          value={filters.ip}
+          onChange={(e) => setFilters({ ...filters, ip: e.target.value })}
+        />
+        <input
+          style={inputStyle}
+          placeholder="Endpoint"
+          value={filters.endpoint}
+          onChange={(e) => setFilters({ ...filters, endpoint: e.target.value })}
+        />
+        <input
+          style={inputStyle}
+          placeholder="Status code"
+          value={filters.status_code}
+          onChange={(e) => setFilters({ ...filters, status_code: e.target.value })}
+        />
+        <input
+          style={inputStyle}
+          type="datetime-local"
+          value={filters.from}
+          onChange={(e) => setFilters({ ...filters, from: e.target.value })}
+        />
+        <input
+          style={inputStyle}
+          type="datetime-local"
+          value={filters.to}
+          onChange={(e) => setFilters({ ...filters, to: e.target.value })}
+        />
+        <button style={inputStyle} onClick={() => fetchLog(0)} disabled={loading}>
+          {loading ? "Loading…" : "Apply filters"}
+        </button>
+        <button
+          style={inputStyle}
+          onClick={() => {
+            setFilters(EMPTY_FILTERS);
+          }}
+        >
+          Reset
+        </button>
+        <span style={{ flex: 1 }} />
+        <button style={inputStyle} onClick={() => exportLog("csv")}>
+          Export CSV
+        </button>
+        <button style={inputStyle} onClick={() => exportLog("json")}>
+          Export JSON
+        </button>
+      </div>
+
+      <div style={{ overflowX: "auto", border: "1px solid #e5e7eb", borderRadius: 8, background: "#fff" }}>
+        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+          <thead>
+            <tr style={{ textAlign: "left", borderBottom: "1px solid #e5e7eb" }}>
+              {["Timestamp", "Key", "Tier", "IP", "Method", "Endpoint", "Status", "Latency", "Body Hash"].map(
+                (h) => (
+                  <th key={h} style={{ padding: "8px 12px", whiteSpace: "nowrap" }}>
+                    {h}
+                  </th>
+                ),
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.id} style={{ borderBottom: "1px solid #f3f4f6" }}>
+                <td style={{ padding: "8px 12px", whiteSpace: "nowrap" }}>
+                  {new Date(row.timestamp).toLocaleString()}
+                </td>
+                <td style={{ padding: "8px 12px" }}>{row.key_name ?? "—"}</td>
+                <td style={{ padding: "8px 12px" }}>{row.tier ?? "—"}</td>
+                <td style={{ padding: "8px 12px" }}>{row.ip ?? "—"}</td>
+                <td style={{ padding: "8px 12px" }}>{row.method}</td>
+                <td style={{ padding: "8px 12px" }}>{row.endpoint}</td>
+                <td style={{ padding: "8px 12px" }}>{row.status_code}</td>
+                <td style={{ padding: "8px 12px" }}>
+                  {row.response_time_ms != null ? `${row.response_time_ms}ms` : "—"}
+                </td>
+                <td style={{ padding: "8px 12px", fontFamily: "monospace", fontSize: 11 }}>
+                  {row.request_body_hash ?? "—"}
+                </td>
+              </tr>
+            ))}
+            {rows.length === 0 && !loading && (
+              <tr>
+                <td colSpan={9} style={{ padding: 16, textAlign: "center", color: "#9ca3af" }}>
+                  No audit log entries match the current filters.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 12 }}>
+        <button style={inputStyle} onClick={() => fetchLog(Math.max(0, offset - limit))} disabled={offset === 0}>
+          Previous
+        </button>
+        <button
+          style={inputStyle}
+          onClick={() => fetchLog(offset + limit)}
+          disabled={rows.length < limit}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/indexer/package-lock.json
+++ b/indexer/package-lock.json
@@ -19,7 +19,7 @@
         "lru-cache": "^10.4.3",
         "maxmind": "^4.3.22",
         "node-cron": "^3.0.3",
-        "nodemailer": "^6.9.13",
+        "nodemailer": "^9.0.6",
         "pg": "8.12.0",
         "prom-client": "15.1.3",
         "redis": "^4.7.0",
@@ -5567,9 +5567,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
-      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.6.tgz",
+      "integrity": "sha512-IQUGFdhdGwI9+AWX+FpUt4DLmvFaOjTMEoneTIWX/RXxuy1TdenPwWrvFMSfLkPKl+HQEXWuSAxEMMbPYXtBmg==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -23,7 +23,7 @@
     "lru-cache": "^10.4.3",
     "maxmind": "^4.3.22",
     "node-cron": "^3.0.3",
-    "nodemailer": "^6.9.13",
+    "nodemailer": "^9.0.6",
     "pg": "8.12.0",
     "prom-client": "15.1.3",
     "redis": "^4.7.0",


### PR DESCRIPTION
## Summary
- Bumps `nodemailer` in `indexer/` to 9.0.6, clearing SMTP command injection, CRLF injection, SSRF, and TLS-validation advisories (`npm audit` now reports zero nodemailer vulnerabilities). The `emailService.js` usage (`createTransport`/`sendMail` with host/port/auth/from/to/subject/html/text) is unchanged and API-compatible.
- Adds a `secret-scan` CI job (gitleaks) that runs on every push and PR, plus a `.gitleaks.toml` config and `docs/secret-scanning.md` documenting the backfill scan and the true-positive remediation process.
- Adds a permissionless `bump_contract_ttl(contract_id)` entry point to the explorer contract so a registry entry that is never updated can still have its persistent-storage TTL extended without an admin/registrant `update_contract` call. It only extends existing TTLs (no new storage, no auth required), so it cannot be used to grief the registry's storage costs — each caller pays their own transaction fee.
- Adds an admin-only Audit Trail page at `/admin/audit-log` that filters (by key, IP, endpoint, status, date range) and exports (CSV/JSON) `api_audit_log` via the existing `GET /api/admin/audit-log` and `/audit-log/export` endpoints, following the same admin-token/TOTP auth pattern as the existing Rate Limit dashboard.

## Validation
- `npm audit` in `indexer/`: 0 vulnerabilities (was flagging nodemailer high-severity issues).
- `cargo fmt --check` / `cargo clippy --all-targets --all-features -- -D warnings` for `soroban-explorer-contract`: clean.
- `cargo test -p soroban-explorer-contract` (unit + auth + integration + gas + proptest fuzz + snapshot + storage bench): 42+15+1+1+3+1+1 tests, all passing.
- `tsc --noEmit` on the frontend: no new errors introduced (pre-existing unrelated errors in `Nav.tsx`/`useFreighter.ts` left untouched, out of scope).
- Repo pre-push hook (rebuilds wasm32 target + runs full contract test suite for both `explorer` and `ticket` contracts): all checks passed.
- YAML-validated the updated `.github/workflows/ci.yml`.

Closes #733
Closes #735
Closes #734
Closes #737
