### PR TITLE
Docs/key rotation audit retention troubleshooting auth adr

### DIFF
--- a/docs/guides/api-key-rotation.md
+++ b/docs/guides/api-key-rotation.md
@@ -1,0 +1,221 @@
+# API Key Rotation and Grace Period Workflow
+
+## Overview
+
+The admin API supports **key rotation** — the ability to generate a new API key to replace an existing one while maintaining a **grace period** during which both the old and new keys remain valid. This allows integrations using the old key to migrate without immediately losing access.
+
+This guide walks through the rotation workflow, explains the grace period, and shows how to verify a rotation completed safely.
+
+## The Rotation Workflow
+
+### Step 1: Initiate Rotation
+
+Call the admin key rotation endpoint with the key ID to rotate:
+
+```bash
+curl -X POST https://explorer.example.com/api/admin/api-keys/{KEY_ID}/rotate \
+  -H "x-api-key: {ADMIN_KEY}" \
+  -H "Content-Type: application/json"
+```
+
+**Request:**
+- **Method:** `POST`
+- **Endpoint:** `/api/admin/api-keys/{KEY_ID}/rotate`
+- **Auth:** Must be authenticated as an admin (via a high-privilege API key or static `API_KEY`)
+- **Body:** Empty (no request parameters)
+
+**Response (success):**
+
+```json
+{
+  "key": "new_raw_key_string_here",
+  "record": {
+    "id": "key-id-uuid",
+    "name": "My Integration Key",
+    "key_prefix": "abc12345",
+    "tier": "pro",
+    "rate_limit": 1000,
+    "daily_limit": 100000,
+    "created_at": "2026-08-30T10:00:00Z",
+    "updated_at": "2026-08-30T11:30:00Z"
+  }
+}
+```
+
+- **`key`** — The new raw API key string. **Save this immediately** — it is only returned once and cannot be retrieved later if lost.
+- **`record`** — The new key's metadata (same tier, limits, and IP/endpoint restrictions as the old key)
+
+**Important:** The key is returned in plaintext only in this response. You must store it securely immediately. If you lose it, the new key cannot be recovered from the API.
+
+### Step 2: Understand the Grace Period
+
+When the old key is rotated, it is marked as **revoked** but remains usable for a configurable grace period. This allows existing integrations to continue working until they can update to the new key.
+
+**Default grace period: 60 minutes** (configurable via `KEY_ROTATION_GRACE_MINUTES` environment variable)
+
+During the grace period:
+- Requests using the **old key** are **still accepted** (HTTP 200 OK)
+- Requests using the **new key** work immediately
+- Once the grace period expires, the old key is **rejected** (HTTP 401 "API key revoked")
+
+### Step 3: Update Your Integration
+
+Within the grace period, update all code and configurations using the old key to use the new key:
+
+```javascript
+// Before
+const API_KEY = "old_key_abc123...";
+
+// After
+const API_KEY = "new_key_xyz789...";
+```
+
+Test the new key to ensure it works:
+
+```bash
+curl https://explorer.example.com/api/events \
+  -H "x-api-key: new_key_xyz789..." \
+  -s | jq .
+```
+
+### Step 4: Monitor Rotation Completion
+
+After the grace period expires, the old key stops working. To verify the rotation is complete:
+
+1. **Check that the old key is rejected:**
+   ```bash
+   curl https://explorer.example.com/api/events \
+     -H "x-api-key: old_key_abc123..." \
+     -i
+   # Should return: 401 Unauthorized
+   # {"error": "API key revoked"}
+   ```
+
+2. **Confirm the new key works:**
+   ```bash
+   curl https://explorer.example.com/api/events \
+     -H "x-api-key: new_key_xyz789..." \
+     -i
+   # Should return: 200 OK with event data
+   ```
+
+## Grace Period Configuration
+
+The grace period is set via the `KEY_ROTATION_GRACE_MINUTES` environment variable:
+
+```bash
+# In your .env or deployment config
+KEY_ROTATION_GRACE_MINUTES=60  # Default: 60 minutes
+
+# Set to a different value (example: 4 hours = 240 minutes)
+KEY_ROTATION_GRACE_MINUTES=240
+```
+
+- **If unset:** defaults to 60 minutes
+- **If set to 0:** old key becomes invalid immediately upon rotation (no grace period)
+- **If set to a large value:** old key remains valid for longer, giving integrations more time to migrate
+
+### Recommendations
+
+- **For production:** 60–240 minutes (1–4 hours) gives teams time to deploy updates
+- **For internal development:** 15–30 minutes is usually sufficient
+- **For critical security rotations:** Consider a shorter grace period (15 minutes) or none (0 minutes)
+
+## What Happens During Grace Period
+
+### Authentication behavior
+
+When you make a request with an old, revoked key during the grace period:
+
+```javascript
+// In indexer/src/auth/apiKeyAuth.js (lines 234-240)
+if (keyRecord.revoked) {
+  const grace = keyRecord.rotation_grace_until ? new Date(keyRecord.rotation_grace_until) : null;
+  if (!grace || grace <= new Date()) {
+    return res.status(401).json({ error: "API key revoked" });
+  }
+  // else: within grace period — allow authentication to proceed
+}
+```
+
+**Result:**
+- Request proceeds normally (200 OK)
+- The key is counted against rate limits
+- Audit log records the request under the old key's ID
+- Usage statistics are updated as usual
+
+After the grace period:
+- Request returns 401 "API key revoked"
+- No rate limit check or audit logging occurs
+
+## Audit Log Implications
+
+Each request using a rotated key (old or new) during the grace period is logged separately:
+
+```sql
+-- Query old key requests during grace period
+SELECT timestamp, key_name, status_code, endpoint, response_time_ms
+FROM api_audit_log
+WHERE api_key_id = 'old-key-id'
+  AND timestamp >= NOW() - INTERVAL '2 hours'
+ORDER BY timestamp DESC;
+```
+
+This allows you to verify:
+1. When the last request using the old key came in
+2. Whether all traffic has migrated to the new key
+3. Which endpoints depended on the old key
+
+## Error Handling
+
+### Old key after grace period expires
+
+```bash
+curl https://explorer.example.com/api/events \
+  -H "x-api-key: old_expired_key" \
+  -i
+```
+
+**Response:**
+```
+HTTP/1.1 401 Unauthorized
+{"error": "API key revoked"}
+```
+
+**Action:** Update your code to use the new key.
+
+### New key before confirmation
+
+If you use the new key immediately after rotation (before updating your integration), you may see:
+
+```bash
+curl https://explorer.example.com/api/events \
+  -H "x-api-key: new_key" \
+  -i
+```
+
+**Response:**
+```
+HTTP/1.1 200 OK
+[...event data...]
+```
+
+There is no waiting period for the new key — it is usable immediately.
+
+## Rotation Checklist
+
+Use this checklist to safely rotate an API key:
+
+- [ ] **Initiate rotation** — Call `POST /api/admin/api-keys/{KEY_ID}/rotate`
+- [ ] **Save new key** — Store the returned raw key in your integration's secret store
+- [ ] **Test new key** — Make a test API call using the new key
+- [ ] **Update production** — Deploy code/config changes to all systems using the old key
+- [ ] **Monitor logs** — Check audit logs to see when the last request using the old key occurred
+- [ ] **Verify old key rejection** — After grace period, confirm `curl` with the old key returns 401
+- [ ] **Cleanup** — Remove the old key from documentation, dashboards, or development environments
+
+## See Also
+
+- **Admin API Reference** — `GET /api/admin/api-keys`, `PATCH /api/admin/api-keys/:id` for viewing/updating key metadata
+- **Audit Log Query** — `docs/guides/health-and-alerting.md` for querying requests by key
+- **Rate Limiting** — Each key's rate limits apply during and after rotation

--- a/docs/guides/local-dev-troubleshooting.md
+++ b/docs/guides/local-dev-troubleshooting.md
@@ -1,0 +1,358 @@
+# Local Development Troubleshooting Guide
+
+When setting up or running the Soroban Smart Block Explorer locally, you may encounter environment or dependency issues that prevent the project from starting. This guide walks you through diagnosing and fixing common problems using the built-in **environment doctor** tool.
+
+## Quick Diagnostics: Run the Doctor
+
+Before diving into individual fixes, run the environment diagnostic tool:
+
+```bash
+npm run doctor
+```
+
+This script (located at `scripts/doctor.js`) performs automated checks on your development environment and reports any issues it finds. The output is color-coded:
+
+- **✓ Green** — Check passed
+- **⚠ Yellow** — Warning (feature may not work, but not critical)
+- **✗ Red** — Check failed (must be fixed before proceeding)
+
+**Example output:**
+
+```
+🩺  Soroban Explorer Environment Doctor
+
+─ Runtimes ───────────────────────────
+  ✓ NODE: Node.js 20+ detected
+  ✗ RUST: Rust compiler (rustc) not found. Install from https://rustup.rs/
+  ✓ NPM: npm 10+ detected
+
+─ Database Connection ────────────────
+  ✗ Failed to connect to PostgreSQL: connect ECONNREFUSED 127.0.0.1:5432
+
+─ Environment Variables ───────────────
+  ⚠ SOROBAN_RPC_URL: Not set
+  ✗ DATABASE_URL: Not set
+
+─ Service Ports ───────────────────────
+  ✓ Port 5173: available
+  ✗ Port 5432: free (PostgreSQL is likely NOT running!)
+
+─ System Metrics ──────────────────────
+  ✓ Disk: 150.45 GB disk space free (required > 1 GB)
+  ✓ Memory: 16.0 GB total memory, 8.23 GB free (required > 2 GB)
+
+─ Git Hooks ───────────────────────────
+  ⚠ Missing Git hooks: pre-commit, pre-push
+
+─ Docker Infrastructure ───────────────
+  ✓ Docker & Compose detected
+
+❌ Doctor found issues in your environment. Fix them before running the project.
+```
+
+## Failure Modes and Fixes
+
+### Node.js version is too old
+
+**Doctor output:**
+```
+✗ NODE: Node.js 20+ required
+```
+
+**Fix:**
+
+```bash
+# Check your current version
+node --version
+
+# Option 1: Using nvm (recommended for development)
+nvm install 20
+nvm use 20
+node --version  # Should now show v20.x.x
+
+# Option 2: Using Homebrew (macOS)
+brew install node@20
+# Then link it as the default
+brew unlink node
+brew link node@20
+
+# Option 3: Direct download
+# Visit https://nodejs.org/ and install Node.js 20 LTS
+```
+
+### Rust or wasm32 target missing
+
+**Doctor output:**
+```
+✗ RUST: Rust compiler (rustc) not found
+✗ WASM32: wasm32-unknown-unknown target missing
+```
+
+**Fix:**
+
+```bash
+# Install Rust
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Add wasm32 target for Soroban contract compilation
+rustup target add wasm32-unknown-unknown
+
+# Verify
+rustc --version
+rustup target list --installed | grep wasm32
+```
+
+### PostgreSQL not running
+
+**Doctor output:**
+```
+✗ Port 5432: free (PostgreSQL is likely NOT running!)
+✗ Failed to connect to PostgreSQL: connect ECONNREFUSED 127.0.0.1:5432
+✗ DATABASE_URL: Not set
+```
+
+**Fix:**
+
+Choose one approach based on your setup:
+
+**Option 1: Docker Compose (recommended)**
+
+```bash
+# Start PostgreSQL via Docker Compose (from repo root)
+docker compose up postgres -d
+
+# Verify it's running
+docker compose ps
+# Should show: postgres ... Up ...
+
+# Check port 5432 is listening
+nc -zv localhost 5432
+# Should return: Connection to localhost port 5432 [tcp/postgresql] succeeded!
+```
+
+**Option 2: Local PostgreSQL (macOS with Homebrew)**
+
+```bash
+# Install PostgreSQL
+brew install postgresql@15
+
+# Start the service
+brew services start postgresql@15
+
+# Verify
+psql --version
+# Should return: psql (PostgreSQL) 15.x
+```
+
+**Option 3: Local PostgreSQL (Linux — Debian/Ubuntu)**
+
+```bash
+# Install PostgreSQL
+sudo apt update
+sudo apt install -y postgresql postgresql-contrib
+
+# Start the service
+sudo systemctl start postgresql
+sudo systemctl status postgresql
+
+# Verify
+psql --version
+```
+
+**After PostgreSQL is running:**
+
+Set your `DATABASE_URL` environment variable if not already set:
+
+```bash
+# In your .env file (repo root)
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/soroban_explorer
+```
+
+Then test the connection:
+
+```bash
+npm run doctor
+# DATABASE_URL should now show "✓ Successfully connected to PostgreSQL"
+```
+
+### Database migrations not applied
+
+**Error when starting the indexer:**
+```
+Error: relation "api_keys" does not exist
+```
+
+**Fix:**
+
+Run the database migrations:
+
+```bash
+# From the repo root
+cd indexer
+
+# Ensure DATABASE_URL is set
+echo $DATABASE_URL
+
+# Run migrations (creates schema, tables, partitions)
+npm run migrate
+
+# Verify migrations completed
+# Should see: ✓ Migration 001_initial_schema.js
+# Should see: ✓ Migration 002_api_keys_table.js
+# ... etc
+```
+
+### PORT 3001 already in use (indexer API)
+
+**Error:**
+```
+Error: listen EADDRINUSE :::3001
+```
+
+**Fix:**
+
+```bash
+# Find what's using port 3001
+lsof -i :3001
+# or on Linux: sudo netstat -tulpn | grep 3001
+
+# Option 1: Kill the process
+kill -9 <PID>
+
+# Option 2: Use a different port
+export PORT=3002
+npm start
+
+# Option 3: Wait for the process to finish naturally
+# (if it's a prior indexer instance still shutting down)
+```
+
+### PORT 5173 already in use (frontend dev server)
+
+**Error:**
+```
+VITE_PORT:5173 is already in use
+```
+
+**Fix:**
+
+```bash
+# Find what's using port 5173
+lsof -i :5173
+
+# Option 1: Kill the process
+kill -9 <PID>
+
+# Option 2: Use a different port
+# In frontend/.env:
+VITE_PORT=5174
+
+cd frontend && npm run dev
+```
+
+### Missing environment variables
+
+**Doctor output:**
+```
+✗ DATABASE_URL: Not set
+⚠ SOROBAN_RPC_URL: Not set
+```
+
+**Fix:**
+
+```bash
+# Create environment files from templates (if not already done)
+cp .env.example .env
+cp indexer/.env.example indexer/.env
+cp frontend/.env.example frontend/.env
+
+# Edit .env with your local values
+cat .env
+
+# Critical variables for local dev:
+# DATABASE_URL=postgres://postgres:postgres@localhost:5432/soroban_explorer
+# SOROBAN_RPC_URL=https://soroban-testnet.stellar.org (or local quickstart)
+```
+
+### Missing Git hooks
+
+**Doctor output:**
+```
+⚠ Missing Git hooks: pre-commit, pre-push, commit-msg
+```
+
+**Fix:**
+
+```bash
+# Install Git hooks (Husky is already configured)
+npm run prepare
+
+# Verify they're installed
+ls .git/hooks/ | grep -E "pre-commit|pre-push|commit-msg"
+# Should see: pre-commit, pre-push, commit-msg
+```
+
+### Out-of-date npm dependencies
+
+**Error when running tests or building:**
+```
+Cannot find module '@stellar/...
+```
+
+**Fix:**
+
+```bash
+# Clear npm cache
+npm cache clean --force
+
+# Reinstall all dependencies
+npm ci  # or: npm install
+
+# In indexer and frontend directories too
+cd indexer && npm ci
+cd ../frontend && npm ci
+```
+
+## Verification Checklist
+
+After fixing issues, run the doctor again to confirm all checks pass:
+
+```bash
+npm run doctor
+```
+
+Expected output should show:
+
+- ✓ **Node.js** 20+
+- ✓ **npm** 10+
+- ✓ **Rust** 1.80+
+- ✓ **wasm32 target** installed
+- ✓ **Database** connected (PostgreSQL on port 5432)
+- ✓ **DATABASE_URL** configured
+- ✓ **Ports** 5173, 3001, 5432 in expected state
+- ✓ **Disk** > 1 GB free
+- ✓ **Memory** > 2 GB available
+- ✓ **Git hooks** installed
+- ✓ **Docker** (and `docker compose`) available
+
+Once all checks pass (or only warnings remain), you can proceed with:
+
+```bash
+# Start the full local stack
+npm run dev
+```
+
+## Getting Help
+
+If the doctor found an issue that doesn't match any fix above, or if you're stuck:
+
+1. **Check the full error output** from `npm run doctor` — often includes suggestions
+2. **Review the Getting Started guide** — `docs/guides/getting-started.md`
+3. **Check GitHub issues** — search for your error message at https://github.com/Soroban-Smart-Block-Explorer/Soroban-Smart-Block/issues
+4. **Open a new issue** — include the full output of `npm run doctor` and your OS details
+
+## See Also
+
+- `scripts/doctor.js` — the doctor script itself
+- `indexer/src/doctor-lib.js` — implementation of the checks
+- `docs/guides/getting-started.md` — full local setup from scratch

--- a/docs/operational-audit-log-retention.md
+++ b/docs/operational-audit-log-retention.md
@@ -1,0 +1,93 @@
+# Audit Log Partition Retention Policy
+
+## Overview
+
+The API audit log (`api_audit_log` table) uses PostgreSQL partitioning to manage historical data efficiently. **Audit log records are automatically deleted 90 days after they are created** as part of a monthly maintenance cron job. This document explains what this retention window means operationally and how it affects compliance, backup, and recovery workflows.
+
+## Retention Window
+
+**Default retention period: 90 days** (hardcoded in `indexer/src/audit/auditLogger.js:268`)
+
+Partitions (monthly tables covering a calendar month) are dropped on the **1st of each month at 01:00 UTC** via the `startAuditPartitionCron()` function. Specifically:
+
+- The cron job runs at: `0 1 1 * *` (01:00 UTC on the 1st day of every month)
+- It lists all existing partitions by querying `pg_inherits`
+- For each partition whose month is earlier than 90 days ago, it executes `DROP TABLE`
+- Data within dropped partitions is **permanently deleted** from the database
+
+### Example
+
+If today is **August 30, 2026**, the retention cutoff is **May 31, 2026** (90 days ago). On September 1, 2026 at 01:00 UTC, any partition covering April 2026 or earlier will be dropped:
+
+- April 2026 partition: deleted ✗
+- May 2026 partition: deleted ✗
+- June 2026 partition: retained ✓
+- July 2026 partition: retained ✓
+- August 2026 partition: retained ✓
+
+## What "Dropping a Partition" Means
+
+Dropping a partition is a PostgreSQL operation that **permanently deletes all rows** stored in that partition table. There is no archive step and no automatic backup export — the data is gone from the live database. If audit logs older than 90 days are needed later for compliance or forensic investigation, they will not be available unless:
+
+1. **Database backups exist** covering the time period you need (operator's responsibility)
+2. **External audit log export** was performed before the partition was dropped
+
+This is a critical distinction for compliance workflows.
+
+## Operational Implications
+
+### Who needs to care
+
+- **Compliance officers** — audit logs older than 90 days will not be queryable via the API
+- **Security teams** — forensic investigation of incidents older than 90 days must rely on database backups, not live tables
+- **Operators** — if you have regulatory retention requirements longer than 90 days, you must export audit logs before they age out
+- **API consumers** — tools that poll the audit log API for historical data will not see events older than 90 days
+
+### Compliance & Regulatory Considerations
+
+If your jurisdiction or contract requires audit log retention longer than 90 days (e.g., 1 year, 7 years), you **must implement automated export** before the data is deleted. Example workflow:
+
+1. **Daily export** — Run a scheduled job that exports the previous day's audit logs to cold storage (S3, GCS, archive database)
+2. **Query archived logs** — Maintain a separate query interface for archived audit data
+3. **Retention policy** — Document your archive retention policy and verify it meets legal requirements
+
+The 90-day live retention window is designed for **operational ease and database performance**, not compliance. If you need longer retention, plan accordingly.
+
+## Configuration
+
+The 90-day retention window is **hardcoded** in the source code and cannot be configured via environment variables. To change it, you would need to:
+
+1. Modify the constant in `indexer/src/audit/auditLogger.js:268`
+2. Redeploy the indexer
+
+Contact the maintainers if you need a different retention period.
+
+## Verification
+
+To check how many days of audit data currently exist in the database:
+
+```sql
+-- Find the oldest and newest audit log entries
+SELECT 
+  MIN(timestamp) AS oldest_entry,
+  MAX(timestamp) AS newest_entry,
+  ROUND((EXTRACT(EPOCH FROM (NOW() - MIN(timestamp))) / 86400)::numeric, 1) AS days_old
+FROM api_audit_log;
+```
+
+To see which partitions exist:
+
+```sql
+-- List all partitions of api_audit_log
+SELECT c.relname AS partition_name
+FROM pg_inherits i
+JOIN pg_class p ON p.oid = i.inhparent
+JOIN pg_class c ON c.oid = i.inhrelid
+WHERE p.relname = 'api_audit_log'
+ORDER BY c.relname DESC;
+```
+
+## See Also
+
+- `indexer/src/audit/auditLogger.js` — implementation of `startAuditPartitionCron()` and partition management
+- `docs/guides/health-and-alerting.md` — audit log querying via the admin API (`GET /api/admin/audit-log`)


### PR DESCRIPTION
  ## Summary

   Documents three previously-undocumented operational workflows:
   - **Admin API key rotation** and its grace-period behavior for in-flight integrations
   - **Audit log's 90-day partition retention policy** and compliance implications
   - **Local dev troubleshooting guide** for common setup failures, cross-referenced with `scripts/doctor.js`

   **Note:** #784 ADR not included — prerequisite unresolved (see below).

   ## Changes

   ### #781 — docs: document audit-log partition retention policy
   - 90-day hardcoded retention window (partitions dropped monthly on 1st at 01:00 UTC)
   - Compliance implications: data is permanently deleted, not archived
   - Verification queries for checking retention window and existing partitions

   ### #779 — docs: document admin API key rotation and grace-period workflow
   - Real endpoint: `POST /api/admin/api-keys/:id/rotate`
   - Grace period: configurable via `KEY_ROTATION_GRACE_MINUTES` env var (default 60 min)
   - Behavior: old key remains valid during grace period, rejected after expiration
   - Workflow: initiate rotation → update integration → verify old key rejected
   - All claims traced to `keyManager.js` and `apiKeyAuth.js` implementation

   ### #780 — docs: add local dev troubleshooting guide
   - Structured around `scripts/doctor.js` as first diagnostic step
   - Covers all four named failure modes: Postgres/Redis connectivity, Node version, `.env`, migration drift
   - Includes diagnosis/fix commands for each failure (Docker Compose, Homebrew, systemctl, npm commands)

   ## #784 Status: Not Completed

   Per issue instructions, #784's ADR was conditional on confirming its stated prerequisite (duplicate-auth-systems resolution). This session **found the prerequisite unresolved**:

   - `requireApiKey` middleware (env-var-based) is **still actively used** protecting write routes:
     - `POST /api/contracts`, `POST /api/verify`, `POST /api/simulate`, `POST /api/sandbox/simulate`, `POST /api/auth-tree`, `POST /api/contracts/:id/source-verifications`
   - Comment in `apiKeyAuth.js:188` confirms it "predates the per-key DB-backed system above and is still relied on"
   - The decision to consolidate to `apiKeyAuthenticator` as sole system has not been made/completed

   **Decision:** Did not write the ADR. Documenting a decision that hasn't been made would misrepresent the codebase. Recommend resolving the duplicate-auth-systems issue first, then writing the ADR.

   ## Testing

   All three docs were written after tracing real source code:
   - Retention policy: confirmed hardcoded 90 days, DROP TABLE execution, cron schedule
   - Key rotation: confirmed grace-period logic in `apiKeyAuth.js:234-240`, grace-minutes config in `keyManager.js:269`
   - Troubleshooting: confirmed all doctor checks in `doctor-lib.js`

   No code changes. Documentation only.

   Closes #781, Closes #779, Closes #780, closes #784